### PR TITLE
fix(publish): Correct craft requireNames config

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -3,11 +3,11 @@ github:
   repo: bundler-plugins
 changelogPolicy: simple
 preReleaseCommand: bash scripts/craft-pre-release.sh
-# requireNames:
-# - /^sentry-bundler-plugin-core--*.tgz$/
-# - /^sentry-esbuild-plugin-*.tgz$/
-# - /^sentry-rollup-plugin-*.tgz$/
-# - /^sentry-vite-plugin-*.tgz$/
+requireNames:
+  - /^sentry-bundler-plugin-core-*.tgz$/
+  - /^sentry-esbuild-plugin-*.tgz$/
+  - /^sentry-rollup-plugin-*.tgz$/
+  - /^sentry-vite-plugin-*.tgz$/
 # TODO: Comment in when we replace the webpack plugin
 # - /^sentry-webpack-plugin-*.tgz$/
 targets:

--- a/.craft.yml
+++ b/.craft.yml
@@ -3,13 +3,13 @@ github:
   repo: bundler-plugins
 changelogPolicy: simple
 preReleaseCommand: bash scripts/craft-pre-release.sh
-requireNames:
-  - /^sentry-bundler-plugin-core--*.tgz$/
-  - /^sentry-esbuild-plugin-*.tgz$/
-  - /^sentry-rollup-plugin-*.tgz$/
-  - /^sentry-vite-plugin-*.tgz$/
-  # TODO: Comment in when we replace the webpack plugin
-  # - /^sentry-webpack-plugin-*.tgz$/
+# requireNames:
+# - /^sentry-bundler-plugin-core--*.tgz$/
+# - /^sentry-esbuild-plugin-*.tgz$/
+# - /^sentry-rollup-plugin-*.tgz$/
+# - /^sentry-vite-plugin-*.tgz$/
+# TODO: Comment in when we replace the webpack plugin
+# - /^sentry-webpack-plugin-*.tgz$/
 targets:
   - name: github
     includeNames: /^sentry-.*.tgz$/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - "You know what they say ‘Fool me once, strike one, but fool me twice… strike three.’" — Michael Scott
 
-## 0.0.0-alpha.0
+## 0.0.1-alpha.0
 
 This release marks the first release of the Sentry bundler blugins. This is still a heavy work in progress and a lot of things are still missing and subject to change
 


### PR DESCRIPTION
Fixes a regex typo in the `requireNames` attribute. Updates Changelog version (0.0.0 is the base tag now)