### PR TITLE
fix(publish): Rename repo in craft config

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -1,6 +1,6 @@
 github:
   owner: getsentry
-  repo: bundler-plugins
+  repo: sentry-javascript-bundler-plugins
 changelogPolicy: simple
 preReleaseCommand: bash scripts/craft-pre-release.sh
 requireNames:


### PR DESCRIPTION
This adjusts the repo name in `.craft.yml` to the current (and hopefully final) repo name. Hopefully fixes the GH [asset uploading issue](https://github.com/getsentry/publish/actions/runs/3295724144/jobs/5434563208)  from the last craft run.