### PR TITLE
fix(publish): Fix repository and homepage values in root package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "@sentry/sentry-javascript-bundler-plugins",
   "version": "0.0.0",
   "description": "Sentry Bundler Plugins Monorepo.",
-  "repository": "git@github.com:getsentry/sentry-javascript-bundler-plugins.git",
+  "repository": "git://github.com/getsentry/sentry-javascript-bundler-plugins.git",
+  "homepage": "https://github.com/getsentry/sentry-javascript-bundler-plugins",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/packages/bundler-plugin-core/package.json
+++ b/packages/bundler-plugin-core/package.json
@@ -2,8 +2,8 @@
   "name": "@sentry/bundler-plugin-core",
   "version": "0.0.1-alpha.0",
   "description": "Sentry Bundler Plugin Core",
-  "repository": "git://github.com/getsentry/sentry-unplugin.git",
-  "homepage": "https://github.com/getsentry/sentry-unplugin",
+  "repository": "git://github.com/getsentry/sentry-javascript-bundler-plugins.git",
+  "homepage": "https://github.com/getsentry/sentry-javascript-bundler-plugins/tree/main/packages/bundler-plugin-core",
   "author": "Sentry",
   "license": "MIT",
   "publishConfig": {


### PR DESCRIPTION
After our initial package release I noticed that the NPM page of the `@sentry/bundler-plugin-core` package still pointed to the old `getsentry/sentry-unplugin` repo. This PR updates two `package.json`s that still had outdated `repository` and `homepage` values. 