### PR TITLE
Add all options including JSDoc to `Options` type

### DIFF
--- a/packages/bundler-plugin-core/src/index.ts
+++ b/packages/bundler-plugin-core/src/index.ts
@@ -15,7 +15,7 @@ import { addSpanToTransaction, captureMinimalError, makeSentryClient } from "./s
 import { Span, Transaction } from "@sentry/types";
 import { createLogger } from "./sentry/logger";
 
-const defaultOptions: Omit<Options, "include"> = {
+const defaultOptions: Omit<Options, "include" | "org" | "authToken" | "project"> = {
   //TODO: add default options here as we port over options from the webpack plugin
   // validate: false
   debug: false,

--- a/packages/bundler-plugin-core/src/sentry/releasePipeline.ts
+++ b/packages/bundler-plugin-core/src/sentry/releasePipeline.ts
@@ -107,7 +107,8 @@ export async function uploadSourceMaps(
 
   //TODO: Remove this once we have internal options. this property must always be present
   const fileExtensions = ext || [];
-  const files = getFiles(include, fileExtensions);
+  //TODO: handle include property properly and remove this def. wrong type cast
+  const files = getFiles(include as string, fileExtensions);
 
   ctx.logger.info(`Found ${files.length} files to upload.`);
 

--- a/packages/bundler-plugin-core/src/types.ts
+++ b/packages/bundler-plugin-core/src/types.ts
@@ -7,9 +7,35 @@ import { createLogger } from "./sentry/logger";
 //TODO: compare types w/ webpack plugin (and sentry-cli?)
 export type Options = {
   /* --- authentication/identification: */
+  /**
+   * The slug of the Sentry organization associated with the app.
+   *
+   * This value can also be specified via `process.env.SENTRY_ORG` (TODO, can it?)
+   */
   org?: string;
+
+  /**
+   * The slug of the Sentry project associated with the app.
+   *
+   * This value can also be specified via `process.env.SENTRY_ORG` (TODO, can it?)
+   */
   project?: string;
+
+  /**
+   * The authentication token to use for all communication with Sentry.
+   * Can be obtained from https://sentry.io/settings/account/api/auth-tokens/.
+   * Required scopes: project:releases (and org:read if setCommits option is used).
+   *
+   * This value an also be specified via `process.env.SENTRY_AUTH_TOKEN` (TODO, can it?).
+   */
   authToken?: string;
+
+  /**
+   * The base URL of your Sentry instance.
+   * Defaults to https://sentry.io/, which is the correct value for SAAS customers.
+   *
+   * This value an also be specified via `process.env.SENTRY_URL` (TODO, can it?).
+   */
   url?: string;
 
   /* --- release properties: */
@@ -30,7 +56,12 @@ export type Options = {
   finalize?: boolean;
 
   /* --- source maps properties: */
-  include: string; // | Array<string | IncludeEntry>;
+  /**
+   * One or more paths that Sentry CLI should scan recursively for sources.
+   * It will upload all .map files and match associated .js files.
+   * Each path can be given as a string or an object with path-specific options
+   */
+  include: string | IncludeEntry | Array<string | IncludeEntry>;
   // ignoreFile: string
   // ignore: string | string[]
   ext?: string[];
@@ -44,6 +75,9 @@ export type Options = {
 
   /* --- other unimportant (for now) stuff- properties: */
   // vcsRemote: string,
+  /**
+   * A header added to all outgoing requests. A string in the format header-key: header-value
+   */
   customHeaders?: Record<string, string>;
 
   // dryRun?: boolean,
@@ -94,12 +128,10 @@ export type Options = {
   telemetry?: boolean;
 };
 
-/*
 type IncludeEntry = {
   paths: string[];
   //TODO: what about the other entries??
 };
-*/
 
 /**
  * Holds data for internal purposes

--- a/packages/bundler-plugin-core/src/types.ts
+++ b/packages/bundler-plugin-core/src/types.ts
@@ -32,6 +32,14 @@ export type Options = {
   authToken?: string;
 
   /**
+   * Authentication token for API, interchangeable with `authToken`.
+   * This value will update `SENTRY_API_KEY` env variable.
+   * TODO: This is not mentioned in the readme, only in the webpack plugin code
+   *       Is this a deprecated field? If yes, then let's get rid of it
+   */
+  apiKey?: string;
+
+  /**
    * The base URL of your Sentry instance.
    * Defaults to https://sentry.io/, which is the correct value for SAAS customers.
    *
@@ -86,16 +94,6 @@ export type Options = {
    * Each path can be given as a string or an object with path-specific options
    */
   include: string | IncludeEntry | Array<string | IncludeEntry>;
-
-  // ignoreFile: string
-  // ignore: string | string[]
-  ext?: string[];
-  // urlPrefix: string,
-  // urlSuffix: string,
-  // stripPrefix?: boolean,
-  // stripCommonPrefix?: boolean,
-  // sourceMapReference?: boolean,
-  // rewrite?: boolean,
 
   /**
    * When `true`, attempts source map validation before upload if rewriting is not enabled.
@@ -167,7 +165,9 @@ export type Options = {
   /**
    * When an error occurs during rlease creation or sourcemaps upload, the plugin will call this function.
    *
-   * By default, the plugin will simply throw an error, thereby stopping the bundling process. If an `errorHandler` callback is provided, compilation will continue, unless an error is thrown in the provided callback.
+   * By default, the plugin will simply throw an error, thereby stopping the bundling process.
+   * If an `errorHandler` callback is provided, compilation will continue, unless an error is
+   * thrown in the provided callback.
    *
    * To allow compilation to continue but still emit a warning, set this option to the following:
    *
@@ -203,8 +203,77 @@ export type Options = {
 };
 
 type IncludeEntry = {
+  /**
+   * One or more paths to scan for files to upload.
+   */
   paths: string[];
-  //TODO: what about the other entries??
+
+  /**
+   * One or more paths to ignore during upload.
+   * Overrides entries in ignoreFile file.
+   *
+   * Defaults to `['node_modules']` if neither `ignoreFile` nor `ignore` is set.
+   */
+  ignore?: string | string[];
+
+  /**
+   * Path to a file containing list of files/directories to ignore.
+   *
+   * Can point to `.gitignore` or anything with the same format.
+   */
+  ignoreFile?: string;
+
+  /**
+   * Array of file extensions of files to be collected for the file upload.
+   *
+   * By default the following file extensions are processed: js, map, jsbundle and bundle.
+   */
+  ext?: string[];
+
+  /**
+   * URL prefix to add to the beginning of all filenames.
+   * Defaults to '~/' but you might want to set this to the full URL.
+   *
+   * This is also useful if your files are stored in a sub folder. eg: url-prefix '~/static/js'.
+   */
+  urlPrefix?: string;
+
+  /**
+   * URL suffix to add to the end of all filenames.
+   * Useful for appending query parameters.
+   */
+  urlSuffix: string;
+
+  /**
+   * When paired with the `rewrite`, this will remove a prefix from filename references inside of
+   * sourcemaps. For instance you can use this to remove a path that is build machine specific.
+   * Note that this will NOT change the names of uploaded files.
+   */
+  stripPrefix?: string[];
+
+  /**
+   * When paired with rewrite, this will add `~` to the stripPrefix array.
+   *
+   * Defaults to false.
+   */
+  stripCommonPrefix?: boolean;
+
+  /**
+   * Determines whether sentry-cli should attempt to link minified files with their corresponding maps.
+   * By default, it will match files and maps based on name, and add a Sourcemap header to each minified file
+   * for which it finds a map. Can be disabled if all minified files contain sourceMappingURL.
+   *
+   * Defaults to true.
+   */
+  sourceMapReference?: boolean;
+
+  /**
+   * Enables rewriting of matching source maps so that indexed maps are flattened and missing sources
+   * are inlined if possible.
+   *
+   * Defaults to true
+   */
+  rewrite?: boolean;
 };
 
 type SetCommitsOptions = {

--- a/packages/bundler-plugin-core/src/types.ts
+++ b/packages/bundler-plugin-core/src/types.ts
@@ -1,11 +1,11 @@
-//TODO: JsDoc for all properties
-
 import { Hub } from "@sentry/hub";
 import { Span } from "@sentry/tracing";
 import { createLogger } from "./sentry/logger";
 
-//TODO: compare types w/ webpack plugin (and sentry-cli?)
-export type Options = {
+/**
+ * The main options object holding all plugin options available to users
+ */
+export type Options = Omit<IncludeEntry, "paths"> & {
   /* --- authentication/identification: */
 
   /**
@@ -119,8 +119,12 @@ export type Options = {
    * The format should be `header-key: header-value`.
    *
    * This value an also be specified via `process.env.CUSTOM_HEADER` (TODO, can it?).
+   *
+   * TODO: This is currently different from the webpack plugin. There, this property is
+   *       called `customHeader` and it only accepts one header as a string.
+   *       Change in follow-up PR.
    */
-  customHeaders?: string;
+  customHeaders?: Record<string, string>;
 
   /**
    * Attempts a dry run (useful for dev environments).
@@ -242,7 +246,7 @@ type IncludeEntry = {
    * URL suffix to add to the end of all filenames.
    * Useful for appending query parameters.
    */
-  urlSuffix: string;
+  urlSuffix?: string;
 
   /**
    * When paired with the `rewrite`, this will remove a prefix from filename references inside of

--- a/packages/bundler-plugin-core/src/types.ts
+++ b/packages/bundler-plugin-core/src/types.ts
@@ -7,6 +7,7 @@ import { createLogger } from "./sentry/logger";
 //TODO: compare types w/ webpack plugin (and sentry-cli?)
 export type Options = {
   /* --- authentication/identification: */
+
   /**
    * The slug of the Sentry organization associated with the app.
    *
@@ -39,8 +40,24 @@ export type Options = {
   url?: string;
 
   /* --- release properties: */
+
+  /**
+   * Unique identifier for the release.
+   *
+   * Defaults to the output of the sentry-cli releases propose-version command,
+   * which automatically detects values for Cordova, Heroku, AWS CodeBuild, CircleCI,
+   * Xcode, and Gradle, and otherwise uses HEAD's commit SHA. (For HEAD option,
+   * requires access to git CLI and for the root directory to be a valid repository).
+   *
+   * This value can also be specified via process.env.SENTRY_RELEASE.
+   */
   release?: string;
-  // dist: string,
+
+  /**
+   * 	Unique identifier for the distribution, used to further segment your release.
+   *  Usually your build number.
+   */
+  dist?: string;
 
   /**
    * Filter for bundle entry points that should contain the provided release. By default, the release will be injected
@@ -53,37 +70,99 @@ export type Options = {
    */
   entries?: (string | RegExp)[] | RegExp | string | ((filePath: string) => boolean);
 
+  /**
+   * Determines if the Sentry release record should be automatically finalized
+   * (meaning a date_released timestamp is added) after artifact upload.
+   *
+   * Defaults to `true`.
+   */
   finalize?: boolean;
 
   /* --- source maps properties: */
+
   /**
    * One or more paths that Sentry CLI should scan recursively for sources.
    * It will upload all .map files and match associated .js files.
    * Each path can be given as a string or an object with path-specific options
    */
   include: string | IncludeEntry | Array<string | IncludeEntry>;
+
   // ignoreFile: string
   // ignore: string | string[]
   ext?: string[];
   // urlPrefix: string,
   // urlSuffix: string,
-  // validate: boolean
   // stripPrefix?: boolean,
   // stripCommonPrefix?: boolean,
   // sourceMapReference?: boolean,
   // rewrite?: boolean,
 
-  /* --- other unimportant (for now) stuff- properties: */
-  // vcsRemote: string,
   /**
-   * A header added to all outgoing requests. A string in the format header-key: header-value
+   * When `true`, attempts source map validation before upload if rewriting is not enabled.
+   * It will spot a variety of issues with source maps and cancel the upload if any are found.
+   *
+   * Defaults to `false` as this can cause false positives.
    */
-  customHeaders?: Record<string, string>;
+  validate?: boolean;
 
-  // dryRun?: boolean,
+  /* --- other unimportant (for now) stuff- properties: */
+
+  /**
+   * Version control system remote name.
+   *
+   * Defaults to 'origin'.
+   *
+   * This value an also be specified via `process.env.SENTRY_VCS_REMOTE` (TODO, can it?).
+   */
+  vcsRemote?: string;
+
+  /**
+   * A header added to every outgoing network request.
+   * The format should be `header-key: header-value`.
+   *
+   * This value an also be specified via `process.env.CUSTOM_HEADER` (TODO, can it?).
+   */
+  customHeaders?: string;
+
+  /**
+   * Attempts a dry run (useful for dev environments).
+   *
+   * Defaults to `false`, but may be automatically set to `true` in development environments
+   * by some framework integrations (Next.JS, possibly others).
+   */
+  dryRun?: boolean;
+
+  /**
+   * Print useful debug information.
+   *
+   * Defaults to `false`.
+   */
   debug?: boolean;
+
+  /**
+   * Suppresses all logs.
+   *
+   * Defaults to `false`.
+   */
   silent?: boolean;
+
+  /**
+   * Remove all the artifacts in the release before the upload.
+   *
+   * Defaults to `false`.
+   */
   cleanArtifacts?: boolean;
+
+  /**
+   * TODO: Can we get rid of this?
+   *
+   * Path to Sentry CLI config properties, as described in
+   * https://docs.sentry.io/product/cli/configuration/#configuration-file.
+   *
+   * By default, the config file is looked for upwards from the current path,
+   * and defaults from ~/.sentryclirc are always loaded
+   */
+  configFile?: string;
 
   /**
    * When an error occurs during rlease creation or sourcemaps upload, the plugin will call this function.
@@ -99,21 +178,16 @@ export type Options = {
    * ```
    */
   errorHandler?: (err: Error) => void;
-  // setCommits?: {
-  //   repo?: string,
-  //   commit?: string,
-  //   previousCommit?: string,
-  //   auto?: boolean,
-  //   ignoreMissing?: boolean
-  // },
-  // deploy?: {
-  //   env: string,
-  //   started?: number,
-  //   finished?: number,
-  //   time?: number,
-  //   name?: string,
-  //   url?: string,
-  // }
+
+  /**
+   * Adds commits to Sentry.
+   */
+  setCommits?: SetCommitsOptions;
+
+  /**
+   * Creates a new release deployment in Sentry.
+   */
+  deploy?: DeployOptions;
 
   /**
    * If set to true, internal plugin errors and performance data will be sent to Sentry.
@@ -131,6 +205,84 @@ export type Options = {
 type IncludeEntry = {
   paths: string[];
   //TODO: what about the other entries??
+};
+
+type SetCommitsOptions = {
+  /**
+   * Automatically sets `commit` and `previousCommit`. Sets `commit` to `HEAD`
+   * and `previousCommit` as described in the option's documentation.
+   *
+   * If you set this to `true`, manually specified `commit` and `previousCommit`
+   * options will be overridden. It is best to not specify them at all if you
+   * set this option to `true`.
+   */
+  auto?: boolean;
+
+  /**
+   * The full repo name as defined in Sentry.
+   *
+   * Required if `auto` option is not `true`.
+   */
+  repo?: string;
+
+  /**
+   * The current (last) commit in the release.
+   *
+   * Required if `auto` option is not `true`.
+   */
+  commit?: string;
+
+  /**
+   * The commit before the beginning of this release (in other words,
+   * the last commit of the previous release).
+   *
+   * Defaults to the last commit of the previous release in Sentry.
+   *
+   * If there was no previous release, the last 10 commits will be used.
+   */
+  previousCommit?: string;
+
+  /**
+   * If the flag is to `true` and the previous release commit was not found
+   * in the repository, we create a release with the default commits count
+   * instead of failing the command.
+   *
+   * Defaults to `false`.
+   */
+  ignoreMissing?: boolean;
+};
+
+type DeployOptions = {
+  /**
+   * Environment for this release. Values that make sense here would
+   * be `production` or `staging`.
+   */
+  env: string;
+
+  /**
+   * Deployment start time in Unix timestamp (in seconds) or ISO 8601 format.
+   */
+  started?: number;
+
+  /**
+   * Deployment finish time in Unix timestamp (in seconds) or ISO 8601 format.
+   */
+  finished?: number;
+
+  /**
+   * Deployment duration (in seconds). Can be used instead of started and finished.
+   */
+  time?: number;
+
+  /**
+   * Human readable name for the deployment.
+   */
+  name?: string;
+
+  /**
+   * URL that points to the deployment.
+   */
+  url?: string;
 };
 
 /**

--- a/packages/bundler-plugin-core/src/types.ts
+++ b/packages/bundler-plugin-core/src/types.ts
@@ -11,39 +11,31 @@ export type Options = Omit<IncludeEntry, "paths"> & {
   /**
    * The slug of the Sentry organization associated with the app.
    *
-   * This value can also be specified via `process.env.SENTRY_ORG` (TODO, can it?)
+   * This is a required field.
    */
-  org?: string;
+  org: string;
 
   /**
    * The slug of the Sentry project associated with the app.
    *
-   * This value can also be specified via `process.env.SENTRY_ORG` (TODO, can it?)
+   * This is a required field.
    */
-  project?: string;
+  project: string;
 
   /**
    * The authentication token to use for all communication with Sentry.
    * Can be obtained from https://sentry.io/settings/account/api/auth-tokens/.
    * Required scopes: project:releases (and org:read if setCommits option is used).
    *
-   * This value an also be specified via `process.env.SENTRY_AUTH_TOKEN` (TODO, can it?).
+   * This is a required field.
    */
-  authToken?: string;
+  authToken: string;
 
   /**
-   * Authentication token for API, interchangeable with `authToken`.
-   * This value will update `SENTRY_API_KEY` env variable.
-   * TODO: This is not mentioned in the readme, only in the webpack plugin code
-   *       Is this a deprecated field? If yes, then let's get rid of it
-   */
-  apiKey?: string;
-
-  /**
-   * The base URL of your Sentry instance.
-   * Defaults to https://sentry.io/, which is the correct value for SAAS customers.
+   * The base URL of your Sentry instance. Use this if you are using a self-hosted
+   * or Sentry instance other than sentry.io.
    *
-   * This value an also be specified via `process.env.SENTRY_URL` (TODO, can it?).
+   * Defaults to https://sentry.io/, which is the correct value for SAAS customers.
    */
   url?: string;
 
@@ -56,8 +48,6 @@ export type Options = Omit<IncludeEntry, "paths"> & {
    * which automatically detects values for Cordova, Heroku, AWS CodeBuild, CircleCI,
    * Xcode, and Gradle, and otherwise uses HEAD's commit SHA. (For HEAD option,
    * requires access to git CLI and for the root directory to be a valid repository).
-   *
-   * This value can also be specified via process.env.SENTRY_RELEASE.
    */
   release?: string;
 
@@ -92,6 +82,8 @@ export type Options = Omit<IncludeEntry, "paths"> & {
    * One or more paths that Sentry CLI should scan recursively for sources.
    * It will upload all .map files and match associated .js files.
    * Each path can be given as a string or an object with path-specific options
+   *
+   * This is a required field.
    */
   include: string | IncludeEntry | Array<string | IncludeEntry>;
 
@@ -109,16 +101,12 @@ export type Options = Omit<IncludeEntry, "paths"> & {
    * Version control system remote name.
    *
    * Defaults to 'origin'.
-   *
-   * This value an also be specified via `process.env.SENTRY_VCS_REMOTE` (TODO, can it?).
    */
   vcsRemote?: string;
 
   /**
    * A header added to every outgoing network request.
    * The format should be `header-key: header-value`.
-   *
-   * This value an also be specified via `process.env.CUSTOM_HEADER` (TODO, can it?).
    *
    * TODO: This is currently different from the webpack plugin. There, this property is
    *       called `customHeader` and it only accepts one header as a string.

--- a/packages/bundler-plugin-core/src/types.ts
+++ b/packages/bundler-plugin-core/src/types.ts
@@ -52,8 +52,8 @@ export type Options = Omit<IncludeEntry, "paths"> & {
   release?: string;
 
   /**
-   * 	Unique identifier for the distribution, used to further segment your release.
-   *  Usually your build number.
+   * Unique identifier for the distribution, used to further segment your release.
+   * Usually your build number.
    */
   dist?: string;
 

--- a/packages/bundler-plugin-core/src/types.ts
+++ b/packages/bundler-plugin-core/src/types.ts
@@ -144,17 +144,6 @@ export type Options = Omit<IncludeEntry, "paths"> & {
   cleanArtifacts?: boolean;
 
   /**
-   * TODO: Can we get rid of this?
-   *
-   * Path to Sentry CLI config properties, as described in
-   * https://docs.sentry.io/product/cli/configuration/#configuration-file.
-   *
-   * By default, the config file is looked for upwards from the current path,
-   * and defaults from ~/.sentryclirc are always loaded
-   */
-  configFile?: string;
-
-  /**
    * When an error occurs during rlease creation or sourcemaps upload, the plugin will call this function.
    *
    * By default, the plugin will simply throw an error, thereby stopping the bundling process.

--- a/packages/integration-tests/fixtures/array-entries-option/setup.ts
+++ b/packages/integration-tests/fixtures/array-entries-option/setup.ts
@@ -1,3 +1,4 @@
+import { Options } from "@sentry/bundler-plugin-core";
 import * as path from "path";
 import { createCjsBundles } from "../../utils/create-cjs-bundles";
 
@@ -9,5 +10,9 @@ const outputDir = path.resolve(__dirname, "./out");
 createCjsBundles(
   { entrypoint1: entryPoint1Path, entrypoint2: entryPoint2Path, entrypoint3: entryPoint3Path },
   outputDir,
-  { release: "I AM A RELEASE!", include: outputDir, entries: [/entrypoint1\.js/, entryPoint3Path] }
+  {
+    release: "I AM A RELEASE!",
+    include: outputDir,
+    entries: [/entrypoint1\.js/, entryPoint3Path],
+  } as Options
 );

--- a/packages/integration-tests/fixtures/basic-release-injection/setup.ts
+++ b/packages/integration-tests/fixtures/basic-release-injection/setup.ts
@@ -1,3 +1,4 @@
+import { Options } from "@sentry/bundler-plugin-core";
 import * as path from "path";
 import { createCjsBundles } from "../../utils/create-cjs-bundles";
 
@@ -7,4 +8,4 @@ const outputDir = path.resolve(__dirname, "./out");
 createCjsBundles({ index: entryPointPath }, outputDir, {
   release: "I AM A RELEASE!",
   include: outputDir,
-});
+} as Options);

--- a/packages/integration-tests/fixtures/function-entries-option/setup.ts
+++ b/packages/integration-tests/fixtures/function-entries-option/setup.ts
@@ -1,3 +1,4 @@
+import { Options } from "@sentry/bundler-plugin-core";
 import * as path from "path";
 import { createCjsBundles } from "../../utils/create-cjs-bundles";
 
@@ -14,5 +15,5 @@ createCjsBundles(
     include: outputDir,
     entries: (entrypointPath) =>
       entrypointPath === entryPoint1Path || entrypointPath === entryPoint3Path,
-  }
+  } as Options
 );

--- a/packages/integration-tests/fixtures/regex-entries-option/setup.ts
+++ b/packages/integration-tests/fixtures/regex-entries-option/setup.ts
@@ -1,3 +1,4 @@
+import { Options } from "@sentry/bundler-plugin-core";
 import * as path from "path";
 import { createCjsBundles } from "../../utils/create-cjs-bundles";
 
@@ -9,4 +10,4 @@ createCjsBundles({ entrypoint1: entryPoint1Path, entrypoint2: entryPoint2Path },
   release: "I AM A RELEASE!",
   include: outputDir,
   entries: /entrypoint1\.js/,
-});
+} as Options);

--- a/packages/integration-tests/fixtures/string-entries-option/setup.ts
+++ b/packages/integration-tests/fixtures/string-entries-option/setup.ts
@@ -1,3 +1,4 @@
+import { Options } from "@sentry/bundler-plugin-core";
 import * as path from "path";
 import { createCjsBundles } from "../../utils/create-cjs-bundles";
 
@@ -9,4 +10,4 @@ createCjsBundles({ entrypoint1: entryPoint1Path, entrypoint2: entryPoint2Path },
   release: "I AM A RELEASE!",
   include: outputDir,
   entries: entryPoint1Path,
-});
+} as Options);

--- a/packages/integration-tests/utils/create-cjs-bundles.ts
+++ b/packages/integration-tests/utils/create-cjs-bundles.ts
@@ -15,7 +15,7 @@ import {
 export function createCjsBundles(
   entrypoints: { [name: string]: string },
   outFolder: string,
-  sentryUnpluginOptions: Options
+  sentryUnpluginOptions: Partial<Options>
 ): void {
   void vite.build({
     clearScreen: false,
@@ -29,13 +29,13 @@ export function createCjsBundles(
         },
       },
     },
-    plugins: [sentryVitePlugin(sentryUnpluginOptions)],
+    plugins: [sentryVitePlugin(sentryUnpluginOptions as Options)],
   });
 
   void rollup
     .rollup({
       input: entrypoints,
-      plugins: [sentryRollupPlugin(sentryUnpluginOptions)],
+      plugins: [sentryRollupPlugin(sentryUnpluginOptions as Options)],
     })
     .then((bundle) =>
       bundle.write({
@@ -48,7 +48,7 @@ export function createCjsBundles(
   void esbuild.build({
     entryPoints: entrypoints,
     outdir: path.join(outFolder, "esbuild"),
-    plugins: [sentryEsbuildPlugin(sentryUnpluginOptions)],
+    plugins: [sentryEsbuildPlugin(sentryUnpluginOptions as Options)],
     minify: true,
     bundle: true,
     format: "cjs",
@@ -64,7 +64,7 @@ export function createCjsBundles(
         libraryTarget: "commonjs",
       },
       target: "node", // needed for webpack 4 so we can access node api
-      plugins: [sentryWebpackPlugin(sentryUnpluginOptions)],
+      plugins: [sentryWebpackPlugin(sentryUnpluginOptions as Options)],
     },
     (err) => {
       if (err) {
@@ -84,7 +84,7 @@ export function createCjsBundles(
         },
       },
       mode: "production",
-      plugins: [sentryWebpackPlugin(sentryUnpluginOptions)],
+      plugins: [sentryWebpackPlugin(sentryUnpluginOptions as Options)],
     },
     (err) => {
       if (err) {

--- a/packages/integration-tests/utils/create-cjs-bundles.ts
+++ b/packages/integration-tests/utils/create-cjs-bundles.ts
@@ -15,7 +15,7 @@ import {
 export function createCjsBundles(
   entrypoints: { [name: string]: string },
   outFolder: string,
-  sentryUnpluginOptions: Partial<Options>
+  sentryUnpluginOptions: Options
 ): void {
   void vite.build({
     clearScreen: false,
@@ -29,13 +29,13 @@ export function createCjsBundles(
         },
       },
     },
-    plugins: [sentryVitePlugin(sentryUnpluginOptions as Options)],
+    plugins: [sentryVitePlugin(sentryUnpluginOptions)],
   });
 
   void rollup
     .rollup({
       input: entrypoints,
-      plugins: [sentryRollupPlugin(sentryUnpluginOptions as Options)],
+      plugins: [sentryRollupPlugin(sentryUnpluginOptions)],
     })
     .then((bundle) =>
       bundle.write({
@@ -48,7 +48,7 @@ export function createCjsBundles(
   void esbuild.build({
     entryPoints: entrypoints,
     outdir: path.join(outFolder, "esbuild"),
-    plugins: [sentryEsbuildPlugin(sentryUnpluginOptions as Options)],
+    plugins: [sentryEsbuildPlugin(sentryUnpluginOptions)],
     minify: true,
     bundle: true,
     format: "cjs",
@@ -64,7 +64,7 @@ export function createCjsBundles(
         libraryTarget: "commonjs",
       },
       target: "node", // needed for webpack 4 so we can access node api
-      plugins: [sentryWebpackPlugin(sentryUnpluginOptions as Options)],
+      plugins: [sentryWebpackPlugin(sentryUnpluginOptions)],
     },
     (err) => {
       if (err) {
@@ -84,7 +84,7 @@ export function createCjsBundles(
         },
       },
       mode: "production",
-      plugins: [sentryWebpackPlugin(sentryUnpluginOptions as Options)],
+      plugins: [sentryWebpackPlugin(sentryUnpluginOptions)],
     },
     (err) => {
       if (err) {


### PR DESCRIPTION
This adds all options + JSDoc from the webpack plugin to our `Options` type. 

Some things in this PR we can discuss before merging, e.g. what to do with the `process.env` thing or if we can get rid of the `configFile` option (which I'd vote yes on). 

Others (e.g. `customHeaders` vs `customHeader`), I'd like to tackle in a follow-up PR as it involves modifying more code than just changing the type. 

ref: #62 