### PR TITLE
fix: Use `writeBundle` hook instead of `buildEnd`

### DIFF
--- a/packages/bundler-plugin-core/package.json
+++ b/packages/bundler-plugin-core/package.json
@@ -39,7 +39,7 @@
     "axios": "^0.27.2",
     "form-data": "^4.0.0",
     "magic-string": "0.26.2",
-    "unplugin": "0.9.4"
+    "unplugin": "0.10.1"
   },
   "devDependencies": {
     "@babel/core": "7.18.5",

--- a/packages/bundler-plugin-core/src/index.ts
+++ b/packages/bundler-plugin-core/src/index.ts
@@ -80,7 +80,7 @@ const RELEASE_INJECTOR_ID = "\0sentry-release-injector";
  *
  * Source maps upload:
  *
- * The sentry-unplugin will also take care of uploading source maps to Sentry. This is all done in the `buildEnd` hook.
+ * The sentry-unplugin will also take care of uploading source maps to Sentry. This is all done in the `writeBundle` hook.
  * TODO: elaborate a bit on how sourcemaps upload works
  */
 const unplugin = createUnplugin<Options>((originalOptions, unpluginMetaContext) => {
@@ -285,7 +285,7 @@ const unplugin = createUnplugin<Options>((originalOptions, unpluginMetaContext) 
       const release = getReleaseName(options.release);
 
       sentryHub.addBreadcrumb({
-        category: "buildEnd:start",
+        category: "writeBundle:start",
         level: "info",
       });
 
@@ -320,7 +320,7 @@ const unplugin = createUnplugin<Options>((originalOptions, unpluginMetaContext) 
         })
         .finally(() => {
           sentryHub.addBreadcrumb({
-            category: "buildEnd:finish",
+            category: "writeBundle:finish",
             level: "info",
           });
           releasePipelineSpan?.finish();

--- a/packages/bundler-plugin-core/src/index.ts
+++ b/packages/bundler-plugin-core/src/index.ts
@@ -272,7 +272,7 @@ const unplugin = createUnplugin<Options>((originalOptions, unpluginMetaContext) 
      * Responsible for executing the sentry release creation pipeline (i.e. creating a release on
      * Sentry.io, uploading sourcemaps, associating commits and deploys and finalizing the release)
      */
-    buildEnd() {
+    writeBundle() {
       releaseInjectionSpan?.finish();
       const releasePipelineSpan =
         transaction &&

--- a/yarn.lock
+++ b/yarn.lock
@@ -11451,15 +11451,15 @@ unpipe@1.0.0, unpipe@~1.0.0:
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
   integrity sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==
 
-unplugin@0.9.4:
-  version "0.9.4"
-  resolved "https://registry.yarnpkg.com/unplugin/-/unplugin-0.9.4.tgz#53e6f4fc92905122219af0e3f40af753563d38b6"
-  integrity sha512-lUe769wSsZiltVA1Ns9ZRx3K1ri/4yzOrLLI/ebSAj2f0PsXqIJeHIXhkhiayEe1pv+mHuZYyBS3B2RXG2Q2EQ==
+unplugin@0.10.1:
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/unplugin/-/unplugin-0.10.1.tgz#e00dc951c1901aef4124121057102a8c290e28b3"
+  integrity sha512-y1hdBitiLOJvCmer0/IGrMGmHplsm2oFRGWleoAJTRQ8aMHxHOe9gLntYlh1WNLKufBuQ2sOTrHF+KWH4xE8Ag==
   dependencies:
     acorn "^8.8.0"
     chokidar "^3.5.3"
     webpack-sources "^3.2.3"
-    webpack-virtual-modules "^0.4.4"
+    webpack-virtual-modules "^0.4.5"
 
 unset-value@^1.0.0:
   version "1.0.0"
@@ -11708,10 +11708,10 @@ webpack-sources@^3.2.3:
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-3.2.3.tgz#2d4daab8451fd4b240cc27055ff6a0c2ccea0cde"
   integrity sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==
 
-webpack-virtual-modules@^0.4.4:
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/webpack-virtual-modules/-/webpack-virtual-modules-0.4.4.tgz#a19fcf371923c59c4712d63d7d194b1e4d8262cc"
-  integrity sha512-h9atBP/bsZohWpHnr+2sic8Iecb60GxftXsWNLLLSqewgIsGzByd2gcIID4nXcG+3tNe4GQG3dLcff3kXupdRA==
+webpack-virtual-modules@^0.4.5:
+  version "0.4.5"
+  resolved "https://registry.yarnpkg.com/webpack-virtual-modules/-/webpack-virtual-modules-0.4.5.tgz#e476842dab5eafb7beb844aa2f747fc12ebbf6ec"
+  integrity sha512-8bWq0Iluiv9lVf9YaqWQ9+liNgXSHICm+rg544yRgGYaR8yXZTVBaHZkINZSB2yZSWo4b0F6MIxqJezVfOEAlg==
 
 "webpack4@npm:webpack@4.46.0":
   version "4.46.0"


### PR DESCRIPTION
Replaces usage of the `buildEnd` hook with usage of the `writeBundle` hook. The `buildEnd` hook only runs before bundles have been written to disk and that is too early for sourcemaps upload - the `writeBundle` hook runs late enough.