### PR TITLE
feat: Implement `paths` and `ext` options for `include`

### DIFF
--- a/packages/bundler-plugin-core/package.json
+++ b/packages/bundler-plugin-core/package.json
@@ -38,6 +38,7 @@
     "@sentry/tracing": "^7.11.1",
     "axios": "^0.27.2",
     "form-data": "^4.0.0",
+    "glob": "8.0.3",
     "magic-string": "0.26.2",
     "unplugin": "0.10.1"
   },
@@ -54,6 +55,7 @@
     "@sentry-internal/sentry-bundler-plugin-tsconfig": "0.0.1-alpha.0",
     "@swc/core": "^1.2.205",
     "@swc/jest": "^0.2.21",
+    "@types/glob": "8.0.0",
     "@types/jest": "^28.1.3",
     "@types/node": "^18.6.3",
     "eslint": "^8.18.0",

--- a/packages/bundler-plugin-core/src/options-mapping.ts
+++ b/packages/bundler-plugin-core/src/options-mapping.ts
@@ -42,7 +42,7 @@ type OptionalInternalIncludeEntry = Partial<
   Pick<UserIncludeEntry, "ignoreFile" | "urlPrefix" | "urlSuffix" | "stripPrefix">
 >;
 
-type InternalIncludeEntry = RequiredInternalIncludeEntry &
+export type InternalIncludeEntry = RequiredInternalIncludeEntry &
   OptionalInternalIncludeEntry & {
     ignore: string[];
   };

--- a/packages/bundler-plugin-core/src/sentry/api.ts
+++ b/packages/bundler-plugin-core/src/sentry/api.ts
@@ -4,7 +4,7 @@ import FormData from "form-data";
 import { Options } from "../types";
 import { captureMinimalError } from "./telemetry";
 
-const API_PATH = "/api/0";
+const API_PATH = "api/0";
 const USER_AGENT = `sentry-bundler-plugin/${__PACKAGE_VERSION__}`;
 
 const sentryApiAxiosInstance = ({

--- a/yarn.lock
+++ b/yarn.lock
@@ -2897,6 +2897,14 @@
     "@types/qs" "*"
     "@types/serve-static" "*"
 
+"@types/glob@^8.0.0":
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/@types/glob/-/glob-8.0.0.tgz#321607e9cbaec54f687a0792b2d1d370739455d2"
+  integrity sha512-l6NQsDDyQUVeoTynNpC9uRvCUint/gSUXQA2euwmTuWGvPY5LSDUu6tkCtJB2SvGQlJQzLaKqcGZP4//7EDveA==
+  dependencies:
+    "@types/minimatch" "*"
+    "@types/node" "*"
+
 "@types/graceful-fs@^4.1.2", "@types/graceful-fs@^4.1.3":
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/@types/graceful-fs/-/graceful-fs-4.1.5.tgz#21ffba0d98da4350db64891f92a9e5db3cdb4e15"
@@ -2952,6 +2960,11 @@
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-3.0.1.tgz#5f8f2bca0a5863cb69bc0b0acd88c96cb1d4ae10"
   integrity sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA==
+
+"@types/minimatch@*":
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-5.1.2.tgz#07508b45797cb81ec3f273011b054cd0755eddca"
+  integrity sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==
 
 "@types/minimatch@^3.0.3":
   version "3.0.5"
@@ -6440,6 +6453,17 @@ glob@7.1.4:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+glob@8.0.3, glob@^8.0.1:
+  version "8.0.3"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-8.0.3.tgz#415c6eb2deed9e502c68fa44a272e6da6eeca42e"
+  integrity sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^5.0.1"
+    once "^1.3.0"
+
 glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
   version "7.2.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.3.tgz#b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b"
@@ -6451,17 +6475,6 @@ glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
     minimatch "^3.1.1"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
-
-glob@^8.0.1:
-  version "8.0.3"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-8.0.3.tgz#415c6eb2deed9e502c68fa44a272e6da6eeca42e"
-  integrity sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==
-  dependencies:
-    fs.realpath "^1.0.0"
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "^5.0.1"
-    once "^1.3.0"
 
 globals@^11.1.0:
   version "11.12.0"


### PR DESCRIPTION
Ref: https://github.com/getsentry/sentry-javascript-bundler-plugins/issues/62

This PR adds the logic to grab files the user configured via `include` and `paths` and applies logic for the correct release artifact prefixes:

- If the user points `paths` to a file, it's artifact path will be its basename prefixed with the `urlPrefix` (eg. `/foo/bar/baz.js` -> `~/baz.js`)
- If the user points `paths` to a directory, the plugin will include all the files recursively included in that directory. The file's artifact paths will be the file path, but the part that the user provided via `paths` is replaced with the `urlPrefix`.

We also filter based on file extensions with the `ext` option.