### PR TITLE
feat(core): Add `ignore` option

### DIFF
--- a/packages/bundler-plugin-core/src/options-mapping.ts
+++ b/packages/bundler-plugin-core/src/options-mapping.ts
@@ -114,7 +114,7 @@ function normalizeIncludeEntry(
   userOptions: UserOptions,
   includeEntry: UserIncludeEntry
 ): InternalIncludeEntry {
-  const ignoreOption = includeEntry.ignore ?? userOptions.ignore ?? [];
+  const ignoreOption = includeEntry.ignore ?? userOptions.ignore ?? ["node_modules"];
   const ignore = Array.isArray(ignoreOption) ? ignoreOption : [ignoreOption];
 
   // We're prefixing all entries in the `ext` option with a `.` (if it isn't already) to align with Node.js' `path.extname()`

--- a/packages/bundler-plugin-core/src/sentry/api.ts
+++ b/packages/bundler-plugin-core/src/sentry/api.ts
@@ -32,7 +32,7 @@ export async function createRelease({
   sentryHub: Hub;
   customHeaders?: Record<string, string>;
 }): Promise<void> {
-  const requestUrl = `${sentryUrl}${API_PATH}/organizations/${org}/releases/`;
+  const requestUrl = `${sentryUrl}/${API_PATH}/organizations/${org}/releases/`;
 
   const releasePayload = {
     version: release,
@@ -68,7 +68,7 @@ export async function deleteAllReleaseArtifacts({
   sentryHub: Hub;
   customHeaders?: Record<string, string>;
 }): Promise<void> {
-  const requestUrl = `${sentryUrl}${API_PATH}/projects/${org}/${project}/files/source-maps/?name=${release}`;
+  const requestUrl = `${sentryUrl}/${API_PATH}/projects/${org}/${project}/files/source-maps/?name=${release}`;
 
   try {
     await sentryApiAxiosInstance({ authToken, customHeaders }).delete(requestUrl, {
@@ -99,7 +99,7 @@ export async function updateRelease({
   sentryHub: Hub;
   customHeaders?: Record<string, string>;
 }): Promise<void> {
-  const requestUrl = `${sentryUrl}${API_PATH}/projects/${org}/${project}/releases/${release}/`;
+  const requestUrl = `${sentryUrl}/${API_PATH}/projects/${org}/${project}/releases/${release}/`;
 
   const releasePayload = {
     dateReleased: new Date().toISOString(),
@@ -136,7 +136,7 @@ export async function uploadReleaseFile({
   sentryHub: Hub;
   customHeaders?: Record<string, string>;
 }) {
-  const requestUrl = `${sentryUrl}${API_PATH}/projects/${org}/${project}/releases/${release}/files/`;
+  const requestUrl = `${sentryUrl}/${API_PATH}/projects/${org}/${project}/releases/${release}/files/`;
 
   const form = new FormData();
   form.append("name", filename);

--- a/packages/bundler-plugin-core/src/sentry/api.ts
+++ b/packages/bundler-plugin-core/src/sentry/api.ts
@@ -32,7 +32,7 @@ export async function createRelease({
   sentryHub: Hub;
   customHeaders?: Record<string, string>;
 }): Promise<void> {
-  const requestUrl = `${sentryUrl}/${API_PATH}/organizations/${org}/releases/`;
+  const requestUrl = `${sentryUrl}${API_PATH}/organizations/${org}/releases/`;
 
   const releasePayload = {
     version: release,
@@ -68,7 +68,7 @@ export async function deleteAllReleaseArtifacts({
   sentryHub: Hub;
   customHeaders?: Record<string, string>;
 }): Promise<void> {
-  const requestUrl = `${sentryUrl}/${API_PATH}/projects/${org}/${project}/files/source-maps/?name=${release}`;
+  const requestUrl = `${sentryUrl}${API_PATH}/projects/${org}/${project}/files/source-maps/?name=${release}`;
 
   try {
     await sentryApiAxiosInstance({ authToken, customHeaders }).delete(requestUrl, {
@@ -99,7 +99,7 @@ export async function updateRelease({
   sentryHub: Hub;
   customHeaders?: Record<string, string>;
 }): Promise<void> {
-  const requestUrl = `${sentryUrl}/${API_PATH}/projects/${org}/${project}/releases/${release}/`;
+  const requestUrl = `${sentryUrl}${API_PATH}/projects/${org}/${project}/releases/${release}/`;
 
   const releasePayload = {
     dateReleased: new Date().toISOString(),
@@ -136,7 +136,7 @@ export async function uploadReleaseFile({
   sentryHub: Hub;
   customHeaders?: Record<string, string>;
 }) {
-  const requestUrl = `${sentryUrl}/${API_PATH}/projects/${org}/${project}/releases/${release}/files/`;
+  const requestUrl = `${sentryUrl}${API_PATH}/projects/${org}/${project}/releases/${release}/files/`;
 
   const form = new FormData();
   form.append("name", filename);

--- a/packages/bundler-plugin-core/src/sentry/sourcemaps.ts
+++ b/packages/bundler-plugin-core/src/sentry/sourcemaps.ts
@@ -28,7 +28,9 @@ export function getFiles(includePath: string, includeEntry: InternalIncludeEntry
   if (fileStat.isFile()) {
     files = [{ absolutePath, relativePath: path.basename(absolutePath) }];
   } else if (fileStat.isDirectory()) {
-    const absoluteIgnores = includeEntry.ignore.map((e) => path.join(absolutePath, e));
+    const absoluteIgnores = includeEntry.ignore.map((ignoreEntry) =>
+      path.join(process.cwd(), ignoreEntry)
+    );
 
     files = glob
       .sync(path.join(absolutePath, "**"), {

--- a/packages/bundler-plugin-core/src/sentry/sourcemaps.ts
+++ b/packages/bundler-plugin-core/src/sentry/sourcemaps.ts
@@ -28,10 +28,13 @@ export function getFiles(includePath: string, includeEntry: InternalIncludeEntry
   if (fileStat.isFile()) {
     files = [{ absolutePath, relativePath: path.basename(absolutePath) }];
   } else if (fileStat.isDirectory()) {
+    const absoluteIgnores = includeEntry.ignore.map((e) => path.join(absolutePath, e));
+
     files = glob
       .sync(path.join(absolutePath, "**"), {
         nodir: true,
         absolute: true,
+        ignore: absoluteIgnores,
       })
       .map((globPath) => ({
         absolutePath: globPath,

--- a/packages/bundler-plugin-core/test/option-mappings.test.ts
+++ b/packages/bundler-plugin-core/test/option-mappings.test.ts
@@ -21,7 +21,7 @@ describe("normalizeUserOptions()", () => {
       include: [
         {
           ext: [".js", ".map", ".jsbundle", ".bundle"],
-          ignore: [],
+          ignore: ["node_modules"],
           paths: ["./out"],
           rewrite: true,
           sourceMapReference: true,


### PR DESCRIPTION
This PR adds the `ignore` option implementation to the plugin core. We're using `glob` for recursively searching for files which, as luck would have it, also supports an `ignore` option (h/t @lforst for finding this out). 

We don't have to do a lot to get it working properly other than converting the ignore entries from our users to absolute paths. I tried passing on relative paths but it wouldn't work as expected when trying to replicate how users (and our [documentation](https://github.com/getsentry/sentry-webpack-plugin#optionsinclude)) [use the `ignore` option](https://cs.github.com/?scopeName=All+repos&scope=&q=%22new+sentrycliplugin%28%22+ignore). 

Side note: I decided to split this and the `ignoreFile` options up into separate PRs as the latter one requires some additional work and probably another dependency. Currently figuring that out.

ref: #62 