### PR TITLE
feat(core): Add `ignoreFile` option

### DIFF
--- a/packages/bundler-plugin-core/package.json
+++ b/packages/bundler-plugin-core/package.json
@@ -40,6 +40,7 @@
     "form-data": "^4.0.0",
     "glob": "8.0.3",
     "magic-string": "0.26.2",
+    "parse-gitignore": "^2.0.0",
     "unplugin": "0.10.1"
   },
   "devDependencies": {
@@ -58,6 +59,7 @@
     "@types/glob": "8.0.0",
     "@types/jest": "^28.1.3",
     "@types/node": "^18.6.3",
+    "@types/parse-gitignore": "^1.0.0",
     "eslint": "^8.18.0",
     "jest": "^28.1.1",
     "rimraf": "^3.0.2",

--- a/packages/bundler-plugin-core/package.json
+++ b/packages/bundler-plugin-core/package.json
@@ -39,8 +39,8 @@
     "axios": "^0.27.2",
     "form-data": "^4.0.0",
     "glob": "8.0.3",
+    "ignore": "^5.2.0",
     "magic-string": "0.26.2",
-    "parse-gitignore": "^2.0.0",
     "unplugin": "0.10.1"
   },
   "devDependencies": {
@@ -59,7 +59,6 @@
     "@types/glob": "8.0.0",
     "@types/jest": "^28.1.3",
     "@types/node": "^18.6.3",
-    "@types/parse-gitignore": "^1.0.0",
     "eslint": "^8.18.0",
     "jest": "^28.1.1",
     "rimraf": "^3.0.2",

--- a/packages/bundler-plugin-core/src/sentry/sourcemaps.ts
+++ b/packages/bundler-plugin-core/src/sentry/sourcemaps.ts
@@ -19,7 +19,7 @@ type FileNameRecord = {
 };
 
 export function getFiles(includePath: string, includeEntry: InternalIncludeEntry): FileRecord[] {
-  // Start with getting all files for the given includePath. If there are non, we can bail at this point.
+  // Start with getting all (unfiltered) files for the given includePath.
   const files = collectAllFiles(includePath);
   if (!files.length) {
     return [];
@@ -89,14 +89,18 @@ function collectAllFiles(includePath: string): FileNameRecord[] {
   return files;
 }
 
+/**
+ * Adds rules specified in `ignore` and `ignoreFile` to the ignore rule
+ * checker and returns the checker for further use.
+ */
 function getIgnoreRules(includeEntry: InternalIncludeEntry): Ignore {
-  const ig = ignore();
+  const ignoreChecker = ignore();
   if (includeEntry.ignoreFile) {
     const ignoreFileContent = fs.readFileSync(includeEntry.ignoreFile).toString();
-    ig.add(ignoreFileContent);
+    ignoreChecker.add(ignoreFileContent);
   }
-  ig.add(includeEntry.ignore);
-  return ig;
+  ignoreChecker.add(includeEntry.ignore);
+  return ignoreChecker;
 }
 
 function convertWindowsPathToPosix(windowsPath: string): string {

--- a/packages/bundler-plugin-core/src/sentry/sourcemaps.ts
+++ b/packages/bundler-plugin-core/src/sentry/sourcemaps.ts
@@ -61,10 +61,8 @@ function collectAllFiles(includePath: string): FileNameRecord[] {
     return [];
   }
 
-  let files: FileNameRecord[];
-
   if (fileStat.isFile()) {
-    files = [
+    return [
       {
         absolutePath,
         relativePath: path.basename(absolutePath),
@@ -72,7 +70,7 @@ function collectAllFiles(includePath: string): FileNameRecord[] {
       },
     ];
   } else if (fileStat.isDirectory()) {
-    files = glob
+    return glob
       .sync(path.join(absolutePath, "**"), {
         nodir: true,
         absolute: true,
@@ -85,8 +83,6 @@ function collectAllFiles(includePath: string): FileNameRecord[] {
   } else {
     return [];
   }
-
-  return files;
 }
 
 /**

--- a/packages/bundler-plugin-core/src/sentry/sourcemaps.ts
+++ b/packages/bundler-plugin-core/src/sentry/sourcemaps.ts
@@ -3,6 +3,8 @@ import fs, { Stats } from "fs";
 import glob from "glob";
 import { InternalIncludeEntry } from "../options-mapping";
 
+import parseIgnoreFile from "parse-gitignore";
+
 export type FileRecord = {
   name: string;
   content: string;
@@ -28,9 +30,7 @@ export function getFiles(includePath: string, includeEntry: InternalIncludeEntry
   if (fileStat.isFile()) {
     files = [{ absolutePath, relativePath: path.basename(absolutePath) }];
   } else if (fileStat.isDirectory()) {
-    const absoluteIgnores = includeEntry.ignore.map((ignoreEntry) =>
-      path.join(process.cwd(), ignoreEntry)
-    );
+    const absoluteIgnores = getIgnoreEntries(includeEntry);
 
     files = glob
       .sync(path.join(absolutePath, "**"), {
@@ -50,8 +50,6 @@ export function getFiles(includePath: string, includeEntry: InternalIncludeEntry
     return includeEntry.ext.includes(path.extname(absolutePath));
   });
 
-  // TODO ignore files
-  // TODO ignorefile
   // TODO do sourcemap rewriting?
   // TODO do sourcefile rewriting? (adding source map reference to bottom - search for "guess_sourcemap_reference")
 
@@ -69,4 +67,44 @@ export function getFiles(includePath: string, includeEntry: InternalIncludeEntry
 
 function convertWindowsPathToPosix(windowsPath: string): string {
   return windowsPath.split(path.sep).join(path.posix.sep);
+}
+
+function getIgnoreEntries(includeEntry: InternalIncludeEntry): InternalIncludeEntry["ignore"] {
+  const absoluteIgnores = includeEntry.ignore.map((ignoreEntry) => {
+    if (ignoreEntry.startsWith("!")) {
+      return `!${path.join(process.cwd(), ignoreEntry.replace(/^!/, ""))}`;
+    }
+    return path.join(process.cwd(), ignoreEntry);
+  });
+
+  const absoluteIgnoreFileIgnores = getIgnoreEntriesFromIgnoreFile(includeEntry.ignoreFile);
+
+  return [...absoluteIgnores, ...absoluteIgnoreFileIgnores];
+}
+
+function getIgnoreEntriesFromIgnoreFile(ignoreFile: InternalIncludeEntry["ignoreFile"]): string[] {
+  // This is what parse-gitignore actually returns after version 2.0.0
+  // (including a few other properties we don't need).
+  // Using this as a type until the library updates its type declarations.
+  type ParseIgnoreReturn = {
+    patterns: string[];
+  };
+
+  if (!ignoreFile) {
+    return [];
+  }
+
+  // The parse-gitignore library's types declaration file was not updated to v2.0.0.
+  // Hence, we have to override its return value (and ignore the linter who rightfully complains)
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+  const fileContent = parseIgnoreFile(fs.readFileSync(ignoreFile)) as unknown as ParseIgnoreReturn;
+  const patterns = fileContent.patterns;
+
+  return patterns.map((ignoreEntry) => {
+    const ignoreFileDir = path.dirname(path.resolve(ignoreFile));
+    if (ignoreEntry.startsWith("!")) {
+      return `!${path.join(ignoreFileDir, ignoreEntry.replace(/^!/, ""))}`;
+    }
+    return path.join(path.join(ignoreFileDir, ignoreEntry));
+  });
 }

--- a/packages/playground/.sentryignore
+++ b/packages/playground/.sentryignore
@@ -1,0 +1,5 @@
+#out/vite-smallNodeApp/\*\*
+
+# some comment
+
+!out/vite-smallNodeApp/index.js

--- a/packages/playground/vite.config.smallNodeApp.js
+++ b/packages/playground/vite.config.smallNodeApp.js
@@ -17,14 +17,16 @@ export default defineConfig({
   },
   plugins: [
     sentryVitePlugin({
-      url: process.env.SENTRY_URL,
-      authToken: process.env.SENTRY_AUTH_TOKEN,
-      org: process.env.SENTRY_ORG,
-      project: process.env.SENTRY_PROJECT,
+      authToken: process.env.SENTRY_AUTH_TOKEN || "",
+      org: process.env.SENTRY_ORG || "",
+      project: process.env.SENTRY_PROJECT || "",
       debug: true,
-      release: "0.0.11",
+      release: "0.0.14",
       include: "out/vite-smallNodeApp",
       cleanArtifacts: true,
+      // ignore: ["out/*", "!out/vite-smallNodeApp/index.js.map"],
+      ignore: ["!out/vite-smallNodeApp/index.js.map"],
+      ignoreFile: ".sentryignore",
     }),
   ],
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2993,6 +2993,13 @@
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz#d3357479a0fdfdd5907fe67e17e0a85c906e1301"
   integrity sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==
 
+"@types/parse-gitignore@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@types/parse-gitignore/-/parse-gitignore-1.0.0.tgz#782b2b6179cef4daaf9b8bd312bfe796fdc8aa18"
+  integrity sha512-GCL7NIxhUzJ1M5bp68T8DtDVTbQdw93MPIIII+YASs3icSozMEG9ZjX7pp7ldRJrVgrRtJBwy+/g+aBzCIttlg==
+  dependencies:
+    "@types/node" "*"
+
 "@types/parse-json@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
@@ -9566,6 +9573,11 @@ parse-conflict-json@^2.0.1:
     json-parse-even-better-errors "^2.3.1"
     just-diff "^5.0.1"
     just-diff-apply "^5.2.0"
+
+parse-gitignore@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/parse-gitignore/-/parse-gitignore-2.0.0.tgz#81156b265115c507129f3faea067b8476da3b642"
+  integrity sha512-RmVuCHWsfu0QPNW+mraxh/xjQVw/lhUCUru8Zni3Ctq3AoMhpDTq0OVdKS6iesd6Kqb7viCV3isAL43dciOSog==
 
 parse-json@^4.0.0:
   version "4.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2993,13 +2993,6 @@
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz#d3357479a0fdfdd5907fe67e17e0a85c906e1301"
   integrity sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==
 
-"@types/parse-gitignore@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@types/parse-gitignore/-/parse-gitignore-1.0.0.tgz#782b2b6179cef4daaf9b8bd312bfe796fdc8aa18"
-  integrity sha512-GCL7NIxhUzJ1M5bp68T8DtDVTbQdw93MPIIII+YASs3icSozMEG9ZjX7pp7ldRJrVgrRtJBwy+/g+aBzCIttlg==
-  dependencies:
-    "@types/node" "*"
-
 "@types/parse-json@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
@@ -9573,11 +9566,6 @@ parse-conflict-json@^2.0.1:
     json-parse-even-better-errors "^2.3.1"
     just-diff "^5.0.1"
     just-diff-apply "^5.2.0"
-
-parse-gitignore@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/parse-gitignore/-/parse-gitignore-2.0.0.tgz#81156b265115c507129f3faea067b8476da3b642"
-  integrity sha512-RmVuCHWsfu0QPNW+mraxh/xjQVw/lhUCUru8Zni3Ctq3AoMhpDTq0OVdKS6iesd6Kqb7viCV3isAL43dciOSog==
 
 parse-json@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
This PR implements the `ignoreFile` option and rewrites the `ignore` option behaviour. Previously, we used `glob`'s `ignore` option to pass an array of ignore rules to the library. This meant we'd get back a set of filtered files where ignore rules were already applied. However, `glob` does not support negated ignore rules, meaning ignore patterns like "ignore everything except file x" wouldn't work. 

With this PR, we introduce a new library to the project: [ignore](https://www.npmjs.com/package/ignore). It lets us add rules to a rule checker (regardless of if these rules come from a file or an array). We now first collect all files with `glob` and subsequently filter out the ones that are ignored by the specified ignore rules. This rule checker supports all rules as specified in `.gitignore` specs. Therefore, it also supports negated ignore rules.

ref: #62 
