### PR TITLE
ref(core): Change customHeaders option to customHeader

### DIFF
--- a/packages/bundler-plugin-core/src/options-mapping.ts
+++ b/packages/bundler-plugin-core/src/options-mapping.ts
@@ -12,7 +12,6 @@ type RequiredInternalOptions = Required<
     | "finalize"
     | "validate"
     | "vcsRemote"
-    | "customHeaders"
     | "dryRun"
     | "debug"
     | "silent"
@@ -28,6 +27,7 @@ type OptionalInternalOptions = Partial<
 type NormalizedInternalOptions = {
   entries: (string | RegExp)[] | ((filePath: string) => boolean) | undefined;
   include: InternalIncludeEntry[];
+  customHeader: Record<string, string>;
 };
 
 export type InternalOptions = RequiredInternalOptions &
@@ -85,7 +85,7 @@ export function normalizeUserOptions(userOptions: UserOptions): InternalOptions 
     finalize: userOptions.finalize ?? true,
     validate: userOptions.validate ?? false,
     vcsRemote: userOptions.vcsRemote ?? "origin",
-    customHeaders: userOptions.customHeaders ?? {},
+    customHeader: normalizeCustomHeader(userOptions.customHeader),
     dryRun: userOptions.dryRun ?? false,
     debug: userOptions.debug ?? false,
     silent: userOptions.silent ?? false,
@@ -133,4 +133,14 @@ function normalizeIncludeEntry(
     sourceMapReference: includeEntry.sourceMapReference ?? userOptions.sourceMapReference ?? true,
     rewrite: includeEntry.rewrite ?? userOptions.rewrite ?? true,
   };
+}
+
+function normalizeCustomHeader(
+  userCustomHeader: UserOptions["customHeader"]
+): InternalOptions["customHeader"] {
+  if (!userCustomHeader || !userCustomHeader.includes(":")) {
+    return {};
+  }
+  const [key, value] = userCustomHeader.split(/:(.*)/, 2).map((s) => s.trim()) as [string, string];
+  return { [key]: value };
 }

--- a/packages/bundler-plugin-core/src/sentry/api.ts
+++ b/packages/bundler-plugin-core/src/sentry/api.ts
@@ -1,7 +1,7 @@
 import { Hub } from "@sentry/node";
 import axios from "axios";
 import FormData from "form-data";
-import { Options } from "../types";
+import { InternalOptions } from "../options-mapping";
 import { captureMinimalError } from "./telemetry";
 
 const API_PATH = "api/0";
@@ -9,10 +9,10 @@ const USER_AGENT = `sentry-bundler-plugin/${__PACKAGE_VERSION__}`;
 
 const sentryApiAxiosInstance = ({
   authToken,
-  customHeaders,
-}: Required<Pick<Options, "authToken">> & Pick<Options, "customHeaders">) =>
+  customHeader,
+}: Required<Pick<InternalOptions, "authToken">> & Pick<InternalOptions, "customHeader">) =>
   axios.create({
-    headers: { ...customHeaders, "User-Agent": USER_AGENT, Authorization: `Bearer ${authToken}` },
+    headers: { ...customHeader, "User-Agent": USER_AGENT, Authorization: `Bearer ${authToken}` },
   });
 
 export async function createRelease({
@@ -22,7 +22,7 @@ export async function createRelease({
   authToken,
   sentryUrl,
   sentryHub,
-  customHeaders,
+  customHeader,
 }: {
   release: string;
   project: string;
@@ -30,7 +30,7 @@ export async function createRelease({
   authToken: string;
   sentryUrl: string;
   sentryHub: Hub;
-  customHeaders?: Record<string, string>;
+  customHeader: Record<string, string>;
 }): Promise<void> {
   const requestUrl = `${sentryUrl}${API_PATH}/organizations/${org}/releases/`;
 
@@ -42,7 +42,7 @@ export async function createRelease({
   };
 
   try {
-    await sentryApiAxiosInstance({ authToken, customHeaders }).post(requestUrl, releasePayload, {
+    await sentryApiAxiosInstance({ authToken, customHeader }).post(requestUrl, releasePayload, {
       headers: { Authorization: `Bearer ${authToken}` },
     });
   } catch (e) {
@@ -58,7 +58,7 @@ export async function deleteAllReleaseArtifacts({
   authToken,
   sentryUrl,
   sentryHub,
-  customHeaders,
+  customHeader,
 }: {
   org: string;
   release: string;
@@ -66,12 +66,12 @@ export async function deleteAllReleaseArtifacts({
   authToken: string;
   project: string;
   sentryHub: Hub;
-  customHeaders?: Record<string, string>;
+  customHeader: Record<string, string>;
 }): Promise<void> {
   const requestUrl = `${sentryUrl}${API_PATH}/projects/${org}/${project}/files/source-maps/?name=${release}`;
 
   try {
-    await sentryApiAxiosInstance({ authToken, customHeaders }).delete(requestUrl, {
+    await sentryApiAxiosInstance({ authToken, customHeader }).delete(requestUrl, {
       headers: {
         Authorization: `Bearer ${authToken}`,
       },
@@ -89,7 +89,7 @@ export async function updateRelease({
   sentryUrl,
   project,
   sentryHub,
-  customHeaders,
+  customHeader,
 }: {
   release: string;
   org: string;
@@ -97,7 +97,7 @@ export async function updateRelease({
   sentryUrl: string;
   project: string;
   sentryHub: Hub;
-  customHeaders?: Record<string, string>;
+  customHeader: Record<string, string>;
 }): Promise<void> {
   const requestUrl = `${sentryUrl}${API_PATH}/projects/${org}/${project}/releases/${release}/`;
 
@@ -106,7 +106,7 @@ export async function updateRelease({
   };
 
   try {
-    await sentryApiAxiosInstance({ authToken, customHeaders }).put(requestUrl, releasePayload, {
+    await sentryApiAxiosInstance({ authToken, customHeader }).put(requestUrl, releasePayload, {
       headers: { Authorization: `Bearer ${authToken}` },
     });
   } catch (e) {
@@ -124,7 +124,7 @@ export async function uploadReleaseFile({
   filename,
   fileContent,
   sentryHub,
-  customHeaders,
+  customHeader,
 }: {
   org: string;
   release: string;
@@ -134,7 +134,7 @@ export async function uploadReleaseFile({
   filename: string;
   fileContent: string;
   sentryHub: Hub;
-  customHeaders?: Record<string, string>;
+  customHeader: Record<string, string>;
 }) {
   const requestUrl = `${sentryUrl}${API_PATH}/projects/${org}/${project}/releases/${release}/files/`;
 
@@ -143,7 +143,7 @@ export async function uploadReleaseFile({
   form.append("file", Buffer.from(fileContent, "utf-8"), { filename });
 
   try {
-    await sentryApiAxiosInstance({ authToken, customHeaders }).post(requestUrl, form, {
+    await sentryApiAxiosInstance({ authToken, customHeader }).post(requestUrl, form, {
       headers: {
         Authorization: `Bearer ${authToken}`,
         "Content-Type": "multipart/form-data",

--- a/packages/bundler-plugin-core/src/sentry/releasePipeline.ts
+++ b/packages/bundler-plugin-core/src/sentry/releasePipeline.ts
@@ -40,7 +40,7 @@ export async function createNewRelease(
     project: options.project,
     sentryUrl: options.url,
     sentryHub: ctx.hub,
-    customHeaders: options.customHeaders,
+    customHeader: options.customHeader,
   });
 
   ctx.logger.info("Successfully created release.");
@@ -130,7 +130,7 @@ export async function uploadSourceMaps(
         filename: file.name,
         fileContent: file.content,
         sentryHub: ctx.hub,
-        customHeaders: options.customHeaders,
+        customHeader: options.customHeader,
       })
     )
   ).then(() => {
@@ -160,7 +160,7 @@ export async function finalizeRelease(
       sentryUrl: url,
       project,
       sentryHub: ctx.hub,
-      customHeaders: options.customHeaders,
+      customHeader: options.customHeader,
     });
 
     ctx.logger.info("Successfully finalized release.");
@@ -196,7 +196,7 @@ export async function cleanArtifacts(options: InternalOptions, ctx: BuildContext
       sentryUrl: options.url,
       project: options.project,
       sentryHub: ctx.hub,
-      customHeaders: options.customHeaders,
+      customHeader: options.customHeader,
     });
 
     ctx.logger.info("Successfully cleaned previous artifacts.");

--- a/packages/bundler-plugin-core/src/types.ts
+++ b/packages/bundler-plugin-core/src/types.ts
@@ -107,12 +107,8 @@ export type Options = Omit<IncludeEntry, "paths"> & {
   /**
    * A header added to every outgoing network request.
    * The format should be `header-key: header-value`.
-   *
-   * TODO: This is currently different from the webpack plugin. There, this property is
-   *       called `customHeader` and it only accepts one header as a string.
-   *       Change in follow-up PR.
    */
-  customHeaders?: Record<string, string>;
+  customHeader?: string;
 
   /**
    * Attempts a dry run (useful for dev environments).

--- a/packages/bundler-plugin-core/test/option-mappings.test.ts
+++ b/packages/bundler-plugin-core/test/option-mappings.test.ts
@@ -14,7 +14,7 @@ describe("normalizeUserOptions()", () => {
     expect(normalizeUserOptions(userOptions)).toEqual({
       authToken: "my-auth-token",
       cleanArtifacts: false,
-      customHeaders: {},
+      customHeader: {},
       debug: false,
       dryRun: false,
       finalize: true,
@@ -58,7 +58,7 @@ describe("normalizeUserOptions()", () => {
     expect(normalizeUserOptions(userOptions)).toEqual({
       authToken: "my-auth-token",
       cleanArtifacts: false,
-      customHeaders: {},
+      customHeader: {},
       debug: false,
       dryRun: false,
       finalize: true,
@@ -81,5 +81,20 @@ describe("normalizeUserOptions()", () => {
       validate: false,
       vcsRemote: "origin",
     });
+  });
+
+  test("should convert string customHeader to internal representation", () => {
+    const userOptions: Options = {
+      org: "my-org",
+      project: "my-project",
+      authToken: "my-auth-token",
+      release: "my-release",
+      include: "dist",
+      customHeader: "customKey: CustomValue",
+    };
+
+    expect(normalizeUserOptions(userOptions)).toEqual(
+      expect.objectContaining({ customHeader: { customKey: "CustomValue" } })
+    );
   });
 });


### PR DESCRIPTION
Rename `customHeaders` to `customHeader` and change user-facing data type to string. This change aligns the option with the Sentry Webpack Plugin.

Note: For internal usage, I left it as `Record<string, string>` because it makes it easier for us to work with. We might consider merging other Http headers into this property in the future. For instance authToken and UserAgent. Then we'd have one internal option (e.g. `headers`) that we could populate during the internal option conversion. 

fixes #83 