### PR TITLE
ref(core): Add Sentry CLI

### DIFF
--- a/packages/bundler-plugin-core/package.json
+++ b/packages/bundler-plugin-core/package.json
@@ -31,7 +31,8 @@
     "clean:build": "rimraf ./dist *.tgz",
     "clean:deps": "rimraf node_modules",
     "test": "jest",
-    "lint": "eslint ./src ./test"
+    "lint": "eslint ./src ./test",
+    "fix": "eslint ./src ./test --format stylish --fix"
   },
   "dependencies": {
     "@sentry/cli": "^1.74.6",

--- a/packages/bundler-plugin-core/package.json
+++ b/packages/bundler-plugin-core/package.json
@@ -34,6 +34,7 @@
     "lint": "eslint ./src ./test"
   },
   "dependencies": {
+    "@sentry/cli": "^1.74.6",
     "@sentry/node": "^7.11.1",
     "@sentry/tracing": "^7.11.1",
     "axios": "^0.27.2",

--- a/packages/bundler-plugin-core/src/index.ts
+++ b/packages/bundler-plugin-core/src/index.ts
@@ -14,7 +14,6 @@ import { addSpanToTransaction, captureMinimalError, makeSentryClient } from "./s
 import { Span, Transaction } from "@sentry/types";
 import { createLogger } from "./sentry/logger";
 import { normalizeUserOptions } from "./options-mapping";
-import SentryCli from "@sentry/cli";
 
 // We prefix the polyfill id with \0 to tell other plugins not to try to load or transform it.
 // This hack is taken straight from https://rollupjs.org/guide/en/#resolveid.

--- a/packages/bundler-plugin-core/src/index.ts
+++ b/packages/bundler-plugin-core/src/index.ts
@@ -14,6 +14,7 @@ import { addSpanToTransaction, captureMinimalError, makeSentryClient } from "./s
 import { Span, Transaction } from "@sentry/types";
 import { createLogger } from "./sentry/logger";
 import { normalizeUserOptions } from "./options-mapping";
+import SentryCli from "@sentry/cli";
 
 // We prefix the polyfill id with \0 to tell other plugins not to try to load or transform it.
 // This hack is taken straight from https://rollupjs.org/guide/en/#resolveid.

--- a/packages/bundler-plugin-core/src/options-mapping.ts
+++ b/packages/bundler-plugin-core/src/options-mapping.ts
@@ -21,7 +21,7 @@ type RequiredInternalOptions = Required<
 >;
 
 type OptionalInternalOptions = Partial<
-  Pick<UserOptions, "dist" | "errorHandler" | "setCommits" | "deploy">
+  Pick<UserOptions, "dist" | "errorHandler" | "setCommits" | "deploy" | "configFile">
 >;
 
 type NormalizedInternalOptions = {
@@ -97,6 +97,7 @@ export function normalizeUserOptions(userOptions: UserOptions): InternalOptions 
     deploy: userOptions.deploy,
     entries,
     include,
+    configFile: userOptions.configFile,
   };
 }
 

--- a/packages/bundler-plugin-core/src/sentry/cli.ts
+++ b/packages/bundler-plugin-core/src/sentry/cli.ts
@@ -1,6 +1,9 @@
-import SentryCli from "@sentry/cli";
+import SentryCli, { SentryCliReleases } from "@sentry/cli";
 import { InternalOptions } from "../options-mapping";
 import { Logger } from "./logger";
+
+type SentryDryRunCLI = { releases: Omit<SentryCliReleases, "listDeploys" | "execute"> };
+type SentryCLILike = SentryCli | SentryDryRunCLI;
 
 /**
  * Creates a new Sentry CLI instance.
@@ -8,7 +11,7 @@ import { Logger } from "./logger";
  * In case, users selected the `dryRun` options, this returns a stub
  * that makes no-ops out of most CLI operations
  */
-export function getSentryCli(internalOptions: InternalOptions, logger: Logger) {
+export function getSentryCli(internalOptions: InternalOptions, logger: Logger): SentryCLILike {
   const cli = new SentryCli(internalOptions.configFile, {
     silent: internalOptions.silent,
     org: internalOptions.org,
@@ -19,36 +22,40 @@ export function getSentryCli(internalOptions: InternalOptions, logger: Logger) {
   });
 
   if (internalOptions.dryRun) {
-    return {
-      releases: {
-        proposeVersion: () =>
-          cli.releases.proposeVersion().then((version) => {
-            logger.info("Proposed version:\n", version);
-            return version;
-          }),
-        new: (release: string) => {
-          logger.info("Creating new release:\n", release);
-          return Promise.resolve(release);
-        },
-        uploadSourceMaps: (release: string, config: unknown) => {
-          logger.info("Calling upload-sourcemaps with:\n", config);
-          return Promise.resolve(release);
-        },
-        finalize: (release: string) => {
-          logger.info("Finalizing release:\n", release);
-          return Promise.resolve(release);
-        },
-        setCommits: (release: string, config: unknown) => {
-          logger.info("Calling set-commits with:\n", config);
-          return Promise.resolve(release);
-        },
-        newDeploy: (release: string, config: unknown) => {
-          logger.info("Calling deploy with:\n", config);
-          return Promise.resolve(release);
-        },
-      },
-    };
+    return getDryRunCLI(cli, logger);
   }
 
   return cli;
+}
+
+function getDryRunCLI(cli: SentryCli, logger: Logger): SentryDryRunCLI {
+  return {
+    releases: {
+      proposeVersion: () =>
+        cli.releases.proposeVersion().then((version) => {
+          logger.info("Proposed version:\n", version);
+          return version;
+        }),
+      new: (release: string) => {
+        logger.info("Creating new release:\n", release);
+        return Promise.resolve(release);
+      },
+      uploadSourceMaps: (release: string, config: unknown) => {
+        logger.info("Calling upload-sourcemaps with:\n", config);
+        return Promise.resolve(release);
+      },
+      finalize: (release: string) => {
+        logger.info("Finalizing release:\n", release);
+        return Promise.resolve(release);
+      },
+      setCommits: (release: string, config: unknown) => {
+        logger.info("Calling set-commits with:\n", config);
+        return Promise.resolve(release);
+      },
+      newDeploy: (release: string, config: unknown) => {
+        logger.info("Calling deploy with:\n", config);
+        return Promise.resolve(release);
+      },
+    },
+  };
 }

--- a/packages/bundler-plugin-core/src/sentry/cli.ts
+++ b/packages/bundler-plugin-core/src/sentry/cli.ts
@@ -1,0 +1,54 @@
+import SentryCli from "@sentry/cli";
+import { InternalOptions } from "../options-mapping";
+import { Logger } from "./logger";
+
+/**
+ * Creates a new Sentry CLI instance.
+ *
+ * In case, users selected the `dryRun` options, this returns a stub
+ * that makes no-ops out of most CLI operations
+ */
+export function getSentryCli(internalOptions: InternalOptions, logger: Logger) {
+  const cli = new SentryCli(internalOptions.configFile, {
+    silent: internalOptions.silent,
+    org: internalOptions.org,
+    project: internalOptions.project,
+    authToken: internalOptions.authToken,
+    url: internalOptions.url,
+    vcsRemote: internalOptions.vcsRemote,
+  });
+
+  if (internalOptions.dryRun) {
+    return {
+      releases: {
+        proposeVersion: () =>
+          cli.releases.proposeVersion().then((version) => {
+            logger.info("Proposed version:\n", version);
+            return version;
+          }),
+        new: (release: string) => {
+          logger.info("Creating new release:\n", release);
+          return Promise.resolve(release);
+        },
+        uploadSourceMaps: (release: string, config: unknown) => {
+          logger.info("Calling upload-sourcemaps with:\n", config);
+          return Promise.resolve(release);
+        },
+        finalize: (release: string) => {
+          logger.info("Finalizing release:\n", release);
+          return Promise.resolve(release);
+        },
+        setCommits: (release: string, config: unknown) => {
+          logger.info("Calling set-commits with:\n", config);
+          return Promise.resolve(release);
+        },
+        newDeploy: (release: string, config: unknown) => {
+          logger.info("Calling deploy with:\n", config);
+          return Promise.resolve(release);
+        },
+      },
+    };
+  }
+
+  return cli;
+}

--- a/packages/bundler-plugin-core/src/sentry/logger.ts
+++ b/packages/bundler-plugin-core/src/sentry/logger.ts
@@ -6,7 +6,14 @@ interface LoggerOptions {
   prefix: string;
 }
 
-export function createLogger(options: LoggerOptions) {
+export type Logger = {
+  info(message: string, ...params: unknown[]): void;
+  warn(message: string, ...params: unknown[]): void;
+  error(message: string, ...params: unknown[]): void;
+  debug(message: string, ...params: unknown[]): void;
+};
+
+export function createLogger(options: LoggerOptions): Logger {
   function addBreadcrumb(level: SeverityLevel, message: string) {
     options.hub.addBreadcrumb({
       category: "logger",
@@ -16,29 +23,38 @@ export function createLogger(options: LoggerOptions) {
   }
 
   return {
-    info(message: string) {
+    info(message: string, ...params: unknown[]) {
       if (!options?.silent) {
         // eslint-disable-next-line no-console
-        console.log(`${options.prefix} ${message}`);
+        console.log(`${options.prefix} Info: ${message}`, ...params);
       }
 
       addBreadcrumb("info", message);
     },
-    warn(message: string) {
+    warn(message: string, ...params: unknown[]) {
       if (!options?.silent) {
         // eslint-disable-next-line no-console
-        console.log(`${options.prefix} Warning! ${message}`);
+        console.log(`${options.prefix} Warning: ${message}`, ...params);
       }
 
       addBreadcrumb("warning", message);
     },
-    error(message: string) {
+    error(message: string, ...params: unknown[]) {
       if (!options?.silent) {
         // eslint-disable-next-line no-console
-        console.log(`${options.prefix} Error: ${message}`);
+        console.log(`${options.prefix} Error: ${message}`, ...params);
       }
 
       addBreadcrumb("error", message);
+    },
+
+    debug(message: string, ...params: unknown[]) {
+      if (!options?.silent) {
+        // eslint-disable-next-line no-console
+        console.log(`${options.prefix} Debug: ${message}`, ...params);
+      }
+
+      addBreadcrumb("debug", message);
     },
   };
 }

--- a/packages/bundler-plugin-core/src/types.ts
+++ b/packages/bundler-plugin-core/src/types.ts
@@ -177,6 +177,15 @@ export type Options = Omit<IncludeEntry, "paths"> & {
    * Defaults to true
    */
   telemetry?: boolean;
+
+  /**
+   * Path to Sentry CLI config properties, as described in
+   * https://docs.sentry.io/product/cli/configuration/#configuration-file.
+   *
+   * By default, the config file is looked for upwards from the current path, and
+   * defaults from ~/.sentryclirc are always loaded
+   */
+  configFile?: string;
 };
 
 export type IncludeEntry = {

--- a/packages/bundler-plugin-core/test/cli.test.ts
+++ b/packages/bundler-plugin-core/test/cli.test.ts
@@ -1,0 +1,16 @@
+import SentryCli from "@sentry/cli";
+import { getSentryCli } from "../src/sentry/cli";
+
+describe("getSentryCLI", () => {
+  it("returns a valid CLI instance if dryRun is not specified", () => {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-explicit-any
+    const cli = getSentryCli({} as any, {} as any);
+    expect(cli).toBeInstanceOf(SentryCli);
+  });
+
+  it("returns a valid CLI instance if dryRun is set to true", () => {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-explicit-any
+    const cli = getSentryCli({ dryRun: true } as any, {} as any);
+    expect(cli).not.toBeInstanceOf(SentryCli);
+  });
+});

--- a/packages/bundler-plugin-core/test/logger.test.ts
+++ b/packages/bundler-plugin-core/test/logger.test.ts
@@ -19,41 +19,47 @@ describe("Logger", () => {
     mockedAddBreadcrumb.mockReset();
   });
 
-  it(".info() should log correctly", () => {
+  it.each([
+    ["info", "Info"],
+    ["warn", "Warning"],
+    ["error", "Error"],
+    ["debug", "Debug"],
+  ] as const)(".%s() should log correctly", (loggerMethod, logLevel) => {
     const prefix = "[some-prefix]";
     const logger = createLogger({ hub, prefix });
-    logger.info("Hey!");
 
-    expect(consoleLogSpy).toHaveBeenCalledWith("[some-prefix] Hey!");
+    logger[loggerMethod]("Hey!");
+
+    expect(consoleLogSpy).toHaveBeenCalledWith(`[some-prefix] ${logLevel}: Hey!`);
     expect(mockedAddBreadcrumb).toHaveBeenCalledWith({
       category: "logger",
-      level: "info",
+      level: logLevel.toLowerCase(),
       message: "Hey!",
     });
   });
 
-  it(".warn() should log correctly", () => {
+  it.each([
+    ["info", "Info"],
+    ["warn", "Warning"],
+    ["error", "Error"],
+    ["debug", "Debug"],
+  ] as const)(".%s() should log multiple params correctly", (loggerMethod, logLevel) => {
     const prefix = "[some-prefix]";
     const logger = createLogger({ hub, prefix });
-    logger.warn("Hey!");
 
-    expect(consoleLogSpy).toHaveBeenCalledWith("[some-prefix] Warning! Hey!");
+    logger[loggerMethod]("Hey!", "this", "is", "a test with", 5, "params");
+
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      `[some-prefix] ${logLevel}: Hey!`,
+      "this",
+      "is",
+      "a test with",
+      5,
+      "params"
+    );
     expect(mockedAddBreadcrumb).toHaveBeenCalledWith({
       category: "logger",
-      level: "warning",
-      message: "Hey!",
-    });
-  });
-
-  it(".error() should log correctly", () => {
-    const prefix = "[some-prefix]";
-    const logger = createLogger({ hub, prefix });
-    logger.error("Hey!");
-
-    expect(consoleLogSpy).toHaveBeenCalledWith("[some-prefix] Error: Hey!");
-    expect(mockedAddBreadcrumb).toHaveBeenCalledWith({
-      category: "logger",
-      level: "error",
+      level: logLevel.toLowerCase(),
       message: "Hey!",
     });
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2564,6 +2564,19 @@
     estree-walker "^1.0.1"
     picomatch "^2.2.2"
 
+"@sentry/cli@^1.latest":
+  version "1.74.6"
+  resolved "https://registry.yarnpkg.com/@sentry/cli/-/cli-1.74.6.tgz#c4f276e52c6f5e8c8d692845a965988068ebc6f5"
+  integrity sha512-pJ7JJgozyjKZSTjOGi86chIngZMLUlYt2HOog+OJn+WGvqEkVymu8m462j1DiXAnex9NspB4zLLNuZ/R6rTQHg==
+  dependencies:
+    https-proxy-agent "^5.0.0"
+    mkdirp "^0.5.5"
+    node-fetch "^2.6.7"
+    npmlog "^4.1.2"
+    progress "^2.0.3"
+    proxy-from-env "^1.1.0"
+    which "^2.0.2"
+
 "@sentry/core@7.11.1":
   version "7.11.1"
   resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.11.1.tgz#d68e796f3b6428aefd6086a1db00118df7a9a9e4"
@@ -3603,6 +3616,11 @@ ansi-escapes@^4.2.1:
   dependencies:
     type-fest "^0.21.3"
 
+ansi-regex@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
+  integrity sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==
+
 ansi-regex@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
@@ -3643,15 +3661,15 @@ anymatch@^3.0.0, anymatch@^3.0.3, anymatch@~3.1.2:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
 
+aproba@^1.0.3, aproba@^1.1.1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a"
+  integrity sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==
+
 "aproba@^1.0.3 || ^2.0.0", aproba@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-2.0.0.tgz#52520b8ae5b569215b354efc0caa3fe1e45a8adc"
   integrity sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==
-
-aproba@^1.1.1:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a"
-  integrity sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==
 
 are-we-there-yet@^3.0.0:
   version "3.0.1"
@@ -3660,6 +3678,14 @@ are-we-there-yet@^3.0.0:
   dependencies:
     delegates "^1.0.0"
     readable-stream "^3.6.0"
+
+are-we-there-yet@~1.1.2:
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/are-we-there-yet/-/are-we-there-yet-1.1.7.tgz#b15474a932adab4ff8a50d9adfa7e4e926f21146"
+  integrity sha512-nxwy40TuMiUGqMyRHgCSWZ9FM4VAoRP4xUYSTv5ImRog+h9yISPbVH7H8fASCIzYn9wlEv4zvFL7uKDMCFQm3g==
+  dependencies:
+    delegates "^1.0.0"
+    readable-stream "^2.0.6"
 
 arg@^4.1.0:
   version "4.1.3"
@@ -4515,6 +4541,11 @@ co@^4.6.0:
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
   integrity sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==
 
+code-point-at@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
+  integrity sha512-RpAVKQA5T63xEj6/giIbUEtZwJ4UFIc3ZtvEkiaUERylqe8xb5IvqcgOurZLahv93CLKfxcw5YI+DZcUBRyLXA==
+
 collect-v8-coverage@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/collect-v8-coverage/-/collect-v8-coverage-1.0.1.tgz#cc2c8e94fc18bbdffe64d6534570c8a673b27f59"
@@ -4638,7 +4669,7 @@ console-browserify@^1.1.0:
   resolved "https://registry.yarnpkg.com/console-browserify/-/console-browserify-1.2.0.tgz#67063cef57ceb6cf4993a2ab3a55840ae8c49336"
   integrity sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==
 
-console-control-strings@^1.1.0:
+console-control-strings@^1.0.0, console-control-strings@^1.1.0, console-control-strings@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
   integrity sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==
@@ -6308,6 +6339,20 @@ gauge@^4.0.3:
     strip-ansi "^6.0.1"
     wide-align "^1.1.5"
 
+gauge@~2.7.3:
+  version "2.7.4"
+  resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.7.4.tgz#2c03405c7538c39d7eb37b317022e325fb018bf7"
+  integrity sha512-14x4kjc6lkD3ltw589k0NrPD6cCNTD6CWoVUNpB85+DrtONoZn+Rug6xZU5RvSC4+TZPxA5AnBibQYAvZn41Hg==
+  dependencies:
+    aproba "^1.0.3"
+    console-control-strings "^1.0.0"
+    has-unicode "^2.0.0"
+    object-assign "^4.1.0"
+    signal-exit "^3.0.0"
+    string-width "^1.0.1"
+    strip-ansi "^3.0.1"
+    wide-align "^1.1.0"
+
 gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
   resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0"
@@ -6573,7 +6618,7 @@ has-tostringtag@^1.0.0:
   dependencies:
     has-symbols "^1.0.2"
 
-has-unicode@^2.0.1:
+has-unicode@^2.0.0, has-unicode@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
   integrity sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==
@@ -7064,6 +7109,13 @@ is-extglob@^2.1.0, is-extglob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
   integrity sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==
+
+is-fullwidth-code-point@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz#ef9e31386f031a7f0d643af82fde50c457ef00cb"
+  integrity sha512-1pqUqRjkhPJ9miNq9SwMfdvi6lBJcd6eFxvfaivQhaH3SgisfiuudvFntdKOmxuee/77l+FPjKrQjWvmPjWrRw==
+  dependencies:
+    number-is-nan "^1.0.0"
 
 is-fullwidth-code-point@^3.0.0:
   version "3.0.0"
@@ -8781,7 +8833,7 @@ mkdirp-infer-owner@^2.0.0:
     infer-owner "^1.0.4"
     mkdirp "^1.0.3"
 
-mkdirp@^0.5.1, mkdirp@^0.5.3:
+mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@^0.5.5:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.6.tgz#7def03d2432dcae4ba1d611445c48396062255f6"
   integrity sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==
@@ -9137,6 +9189,16 @@ npm-run-path@^4.0.0, npm-run-path@^4.0.1:
   dependencies:
     path-key "^3.0.0"
 
+npmlog@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
+  integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
+  dependencies:
+    are-we-there-yet "~1.1.2"
+    console-control-strings "~1.1.0"
+    gauge "~2.7.3"
+    set-blocking "~2.0.0"
+
 npmlog@^6.0.0, npmlog@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-6.0.2.tgz#c8166017a42f2dea92d6453168dd865186a70830"
@@ -9146,6 +9208,11 @@ npmlog@^6.0.0, npmlog@^6.0.2:
     console-control-strings "^1.1.0"
     gauge "^4.0.3"
     set-blocking "^2.0.0"
+
+number-is-nan@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
+  integrity sha512-4jbtZXNAsfZbAHiiqjLPBiCl16dES1zI4Hpzzxw61Tk+loF+sBDBKx1ICKKKwIqQ7M0mFn1TmkN7euSncWgHiQ==
 
 nwsapi@^2.2.0:
   version "2.2.1"
@@ -9229,7 +9296,7 @@ nx@15.0.0, "nx@>=14.8.6 < 16":
     yargs "^17.4.0"
     yargs-parser "21.0.1"
 
-object-assign@^4.1.1:
+object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==
@@ -9811,6 +9878,11 @@ process@^0.11.10:
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
   integrity sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==
 
+progress@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
+  integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
+
 promise-all-reject-late@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/promise-all-reject-late/-/promise-all-reject-late-1.0.1.tgz#f8ebf13483e5ca91ad809ccc2fcf25f26f8643c2"
@@ -10091,7 +10163,7 @@ read@1, read@^1.0.7:
   dependencies:
     mute-stream "~0.0.4"
 
-"readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.3, readable-stream@^2.3.6, readable-stream@~2.3.6:
+"readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.3, readable-stream@^2.3.6, readable-stream@~2.3.6:
   version "2.3.7"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
   integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
@@ -10512,7 +10584,7 @@ serve-static@1.15.0:
     parseurl "~1.3.3"
     send "0.18.0"
 
-set-blocking@^2.0.0:
+set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==
@@ -10590,7 +10662,7 @@ side-channel@^1.0.4:
     get-intrinsic "^1.0.2"
     object-inspect "^1.9.0"
 
-signal-exit@^3.0.2, signal-exit@^3.0.3, signal-exit@^3.0.7:
+signal-exit@^3.0.0, signal-exit@^3.0.2, signal-exit@^3.0.3, signal-exit@^3.0.7:
   version "3.0.7"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
   integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
@@ -10859,6 +10931,15 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
+string-width@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-1.0.2.tgz#118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3"
+  integrity sha512-0XsVpQLnVCXHJfyEs8tC0zpTVIr5PKKsQtkT29IwupnPTjtPmQ3xT/4yCREF9hYkV/3M3kzcUTSAZT6a6h81tw==
+  dependencies:
+    code-point-at "^1.0.0"
+    is-fullwidth-code-point "^1.0.0"
+    strip-ansi "^3.0.0"
+
 "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
@@ -10922,6 +11003,13 @@ string_decoder@~1.1.1:
   integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
   dependencies:
     safe-buffer "~5.1.0"
+
+strip-ansi@^3.0.0, strip-ansi@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
+  integrity sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==
+  dependencies:
+    ansi-regex "^2.0.0"
 
 strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
@@ -11846,7 +11934,7 @@ which@^2.0.1, which@^2.0.2:
   dependencies:
     isexe "^2.0.0"
 
-wide-align@^1.1.5:
+wide-align@^1.1.0, wide-align@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.5.tgz#df1d4c206854369ecf3c9a4898f1b23fbd9d15d3"
   integrity sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2564,7 +2564,7 @@
     estree-walker "^1.0.1"
     picomatch "^2.2.2"
 
-"@sentry/cli@^1.latest":
+"@sentry/cli@^1.74.6":
   version "1.74.6"
   resolved "https://registry.yarnpkg.com/@sentry/cli/-/cli-1.74.6.tgz#c4f276e52c6f5e8c8d692845a965988068ebc6f5"
   integrity sha512-pJ7JJgozyjKZSTjOGi86chIngZMLUlYt2HOog+OJn+WGvqEkVymu8m462j1DiXAnex9NspB4zLLNuZ/R6rTQHg==


### PR DESCRIPTION
This PR brings back Sentry CLI as a dependency and it adjusts a few necessary things to be compatible with the CLI along the way:

* Add CLI dependency
* Add `getCLI()` function which creates a CLI or a stub if in `dryRun` mode
* Adjust logger (+ introduce a debug level)
  * dryrun mode of CLI needs it 
  * added variable args parameter to fully utilize `console.log` capabilities
* Bring back the `configFile` option as it is relevant again because of Sentry CLI

ref #85 