### PR TITLE
ref(core): Use Sentry-CLI to finalize release

### DIFF
--- a/packages/bundler-plugin-core/src/sentry/api.ts
+++ b/packages/bundler-plugin-core/src/sentry/api.ts
@@ -80,36 +80,3 @@ export async function deleteAllReleaseArtifacts({
     throw e;
   }
 }
-
-export async function updateRelease({
-  release,
-  org,
-  authToken,
-  sentryUrl,
-  project,
-  sentryHub,
-  customHeader,
-}: {
-  release: string;
-  org: string;
-  authToken: string;
-  sentryUrl: string;
-  project: string;
-  sentryHub: Hub;
-  customHeader: Record<string, string>;
-}): Promise<void> {
-  const requestUrl = `${sentryUrl}${API_PATH}/projects/${org}/${project}/releases/${release}/`;
-
-  const releasePayload = {
-    dateReleased: new Date().toISOString(),
-  };
-
-  try {
-    await sentryApiAxiosInstance({ authToken, customHeader }).put(requestUrl, releasePayload, {
-      headers: { Authorization: `Bearer ${authToken}` },
-    });
-  } catch (e) {
-    captureMinimalError(e, sentryHub);
-    throw e;
-  }
-}

--- a/packages/integration-tests/fixtures/array-entries-option/setup.ts
+++ b/packages/integration-tests/fixtures/array-entries-option/setup.ts
@@ -14,5 +14,6 @@ createCjsBundles(
     release: "I AM A RELEASE!",
     include: outputDir,
     entries: [/entrypoint1\.js/, entryPoint3Path],
+    dryRun: true,
   } as Options
 );

--- a/packages/integration-tests/fixtures/basic-release-injection/setup.ts
+++ b/packages/integration-tests/fixtures/basic-release-injection/setup.ts
@@ -8,4 +8,5 @@ const outputDir = path.resolve(__dirname, "./out");
 createCjsBundles({ index: entryPointPath }, outputDir, {
   release: "I AM A RELEASE!",
   include: outputDir,
+  dryRun: true,
 } as Options);

--- a/packages/integration-tests/fixtures/function-entries-option/setup.ts
+++ b/packages/integration-tests/fixtures/function-entries-option/setup.ts
@@ -15,5 +15,6 @@ createCjsBundles(
     include: outputDir,
     entries: (entrypointPath) =>
       entrypointPath === entryPoint1Path || entrypointPath === entryPoint3Path,
+    dryRun: true,
   } as Options
 );

--- a/packages/integration-tests/fixtures/regex-entries-option/setup.ts
+++ b/packages/integration-tests/fixtures/regex-entries-option/setup.ts
@@ -9,5 +9,6 @@ const outputDir = path.resolve(__dirname, "./out");
 createCjsBundles({ entrypoint1: entryPoint1Path, entrypoint2: entryPoint2Path }, outputDir, {
   release: "I AM A RELEASE!",
   include: outputDir,
+  dryRun: true,
   entries: /entrypoint1\.js/,
 } as Options);

--- a/packages/integration-tests/fixtures/string-entries-option/setup.ts
+++ b/packages/integration-tests/fixtures/string-entries-option/setup.ts
@@ -10,4 +10,5 @@ createCjsBundles({ entrypoint1: entryPoint1Path, entrypoint2: entryPoint2Path },
   release: "I AM A RELEASE!",
   include: outputDir,
   entries: entryPoint1Path,
+  dryRun: true,
 } as Options);


### PR DESCRIPTION
This replaces our own release finalization logic with Sentry CLI's implementation

RIP

Note: Since integration tests were failing because the CLI expects parameters that we didn't specify, I opted to set the `dryRun` option in our test setups. We're only testing release injection in these tests, so apart from the CLI's version detection (which still works as expected in dry run mode) we don't need any of its functionality.

ref #85