### PR TITLE
feat(core): Add `deploy` command

### DIFF
--- a/packages/bundler-plugin-core/src/index.ts
+++ b/packages/bundler-plugin-core/src/index.ts
@@ -289,10 +289,8 @@ const unplugin = createUnplugin<Options>((options, unpluginMetaContext) => {
         .then(() => uploadSourceMaps(internalOptions, ctx))
         .then(() => setCommits(internalOptions, ctx))
         .then(() => finalizeRelease(internalOptions, ctx))
-        .then(() => addDeploy(ctx)) // this is a noop for now
-        .then(() => {
-          transaction?.setStatus("ok");
-        })
+        .then(() => addDeploy(internalOptions, ctx))
+        .then(() => transaction?.setStatus("ok"))
         .catch((e: Error) => {
           captureMinimalError(e, sentryHub);
           transaction?.setStatus("cancelled");

--- a/packages/bundler-plugin-core/src/sentry/releasePipeline.ts
+++ b/packages/bundler-plugin-core/src/sentry/releasePipeline.ts
@@ -127,12 +127,29 @@ export async function setCommits(options: InternalOptions, ctx: BuildContext): P
   span?.finish();
 }
 
-export async function addDeploy(
-  /* version: string, */
-  ctx: BuildContext
-): Promise<string> {
-  const span = addSpanToTransaction(ctx, "function.plugin.add_deploy");
+export async function addDeploy(options: InternalOptions, ctx: BuildContext): Promise<void> {
+  const span = addSpanToTransaction(ctx, "function.plugin.deploy");
+
+  if (options.deploy) {
+    const { env, started, finished, time, name, url } = options.deploy;
+
+    if (env) {
+      await ctx.cli.releases.newDeploy(options.release, {
+        env,
+        started,
+        finished,
+        time,
+        name,
+        url,
+      });
+      ctx.logger.info("Successfully added deploy.");
+    } else {
+      ctx.logger.error(
+        "Couldn't add deploy - the `env` option was not specified!",
+        "Make sure to set `deploy.env` (e.g. to 'production')."
+      );
+    }
+  }
 
   span?.finish();
-  return Promise.resolve("Noop");
 }

--- a/packages/bundler-plugin-core/src/types.ts
+++ b/packages/bundler-plugin-core/src/types.ts
@@ -326,12 +326,12 @@ type DeployOptions = {
   /**
    * Deployment start time in Unix timestamp (in seconds) or ISO 8601 format.
    */
-  started?: number;
+  started?: number | string;
 
   /**
    * Deployment finish time in Unix timestamp (in seconds) or ISO 8601 format.
    */
-  finished?: number;
+  finished?: number | string;
 
   /**
    * Deployment duration (in seconds). Can be used instead of started and finished.

--- a/packages/playground/vite.config.smallNodeApp.js
+++ b/packages/playground/vite.config.smallNodeApp.js
@@ -31,6 +31,10 @@ export default defineConfig({
         auto: true,
         ignoreMissing: true,
       },
+      deploy: {
+        env: "myEnv",
+        time: 10,
+      },
     }),
   ],
 });


### PR DESCRIPTION
This PR adds the implementation of the `deploy` option and its step in the release pipeline. The implementation is mostly taken from the [webpack plugin](https://github.com/getsentry/sentry-webpack-plugin/blob/137503f3ac6fe423b16c5c50379859c86e689017/src/index.js#L524-L536) and relies on Sentry CLI.

fixes #95 