### PR TITLE
ref(core): Remove customHeader conversion in internal options

### DIFF
--- a/packages/bundler-plugin-core/src/options-mapping.ts
+++ b/packages/bundler-plugin-core/src/options-mapping.ts
@@ -20,13 +20,15 @@ type RequiredInternalOptions = Required<
 >;
 
 type OptionalInternalOptions = Partial<
-  Pick<UserOptions, "dist" | "errorHandler" | "setCommits" | "deploy" | "configFile">
+  Pick<
+    UserOptions,
+    "dist" | "errorHandler" | "setCommits" | "deploy" | "configFile" | "customHeader"
+  >
 >;
 
 type NormalizedInternalOptions = {
   entries: (string | RegExp)[] | ((filePath: string) => boolean) | undefined;
   include: InternalIncludeEntry[];
-  customHeader: Record<string, string>;
 };
 
 export type InternalOptions = RequiredInternalOptions &
@@ -84,7 +86,7 @@ export function normalizeUserOptions(userOptions: UserOptions): InternalOptions 
     finalize: userOptions.finalize ?? true,
     validate: userOptions.validate ?? false,
     vcsRemote: userOptions.vcsRemote ?? "origin",
-    customHeader: normalizeCustomHeader(userOptions.customHeader),
+    customHeader: userOptions.customHeader,
     dryRun: userOptions.dryRun ?? false,
     debug: userOptions.debug ?? false,
     silent: userOptions.silent ?? false,
@@ -133,14 +135,4 @@ function normalizeIncludeEntry(
     sourceMapReference: includeEntry.sourceMapReference ?? userOptions.sourceMapReference ?? true,
     rewrite: includeEntry.rewrite ?? userOptions.rewrite ?? true,
   };
-}
-
-function normalizeCustomHeader(
-  userCustomHeader: UserOptions["customHeader"]
-): InternalOptions["customHeader"] {
-  if (!userCustomHeader || !userCustomHeader.includes(":")) {
-    return {};
-  }
-  const [key, value] = userCustomHeader.split(/:(.*)/, 2).map((s) => s.trim()) as [string, string];
-  return { [key]: value };
 }

--- a/packages/bundler-plugin-core/src/sentry/cli.ts
+++ b/packages/bundler-plugin-core/src/sentry/cli.ts
@@ -12,13 +12,15 @@ export type SentryCLILike = SentryCli | SentryDryRunCLI;
  * that makes no-ops out of most CLI operations
  */
 export function getSentryCli(internalOptions: InternalOptions, logger: Logger): SentryCLILike {
+  const { silent, org, project, authToken, url, vcsRemote, customHeader } = internalOptions;
   const cli = new SentryCli(internalOptions.configFile, {
-    silent: internalOptions.silent,
-    org: internalOptions.org,
-    project: internalOptions.project,
-    authToken: internalOptions.authToken,
-    url: internalOptions.url,
-    vcsRemote: internalOptions.vcsRemote,
+    silent,
+    org,
+    project,
+    authToken,
+    url,
+    vcsRemote,
+    customHeader,
   });
 
   if (internalOptions.dryRun) {

--- a/packages/bundler-plugin-core/test/option-mappings.test.ts
+++ b/packages/bundler-plugin-core/test/option-mappings.test.ts
@@ -14,7 +14,6 @@ describe("normalizeUserOptions()", () => {
     expect(normalizeUserOptions(userOptions)).toEqual({
       authToken: "my-auth-token",
       cleanArtifacts: false,
-      customHeader: {},
       debug: false,
       dryRun: false,
       finalize: true,
@@ -58,7 +57,6 @@ describe("normalizeUserOptions()", () => {
     expect(normalizeUserOptions(userOptions)).toEqual({
       authToken: "my-auth-token",
       cleanArtifacts: false,
-      customHeader: {},
       debug: false,
       dryRun: false,
       finalize: true,
@@ -81,20 +79,5 @@ describe("normalizeUserOptions()", () => {
       validate: false,
       vcsRemote: "origin",
     });
-  });
-
-  test("should convert string customHeader to internal representation", () => {
-    const userOptions: Options = {
-      org: "my-org",
-      project: "my-project",
-      authToken: "my-auth-token",
-      release: "my-release",
-      include: "dist",
-      customHeader: "customKey: CustomValue",
-    };
-
-    expect(normalizeUserOptions(userOptions)).toEqual(
-      expect.objectContaining({ customHeader: { customKey: "CustomValue" } })
-    );
   });
 });


### PR DESCRIPTION
Previously, we coverted the user-facing `customHeader` option, typed as string to an internal option typed `Record<string, string>`. This was handy for adding the header to our outgoing API requests. Since we don't do these ourselves anymore but rely on Sentry CLI, it's just easier to pass this option through to the CLI which also expects the string representation.

ref: #91  