### PR TITLE
ref(core): Add missing and change unused options

### DIFF
--- a/packages/bundler-plugin-core/src/index.ts
+++ b/packages/bundler-plugin-core/src/index.ts
@@ -86,6 +86,7 @@ const unplugin = createUnplugin<Options>((options, unpluginMetaContext) => {
     hub: sentryHub,
     prefix: `[sentry-${unpluginMetaContext.framework}-plugin]`,
     silent: internalOptions.silent,
+    debug: internalOptions.debug,
   });
 
   const cli = getSentryCli(internalOptions, logger);

--- a/packages/bundler-plugin-core/src/options-mapping.ts
+++ b/packages/bundler-plugin-core/src/options-mapping.ts
@@ -9,7 +9,6 @@ type RequiredInternalOptions = Required<
     | "url"
     | "release"
     | "finalize"
-    | "validate"
     | "vcsRemote"
     | "dryRun"
     | "debug"
@@ -36,7 +35,10 @@ export type InternalOptions = RequiredInternalOptions &
   NormalizedInternalOptions;
 
 type RequiredInternalIncludeEntry = Required<
-  Pick<UserIncludeEntry, "paths" | "ext" | "stripCommonPrefix" | "sourceMapReference" | "rewrite">
+  Pick<
+    UserIncludeEntry,
+    "paths" | "ext" | "stripCommonPrefix" | "sourceMapReference" | "rewrite" | "validate"
+  >
 >;
 
 type OptionalInternalIncludeEntry = Partial<
@@ -84,7 +86,6 @@ export function normalizeUserOptions(userOptions: UserOptions): InternalOptions 
     url: userOptions.url ?? "https://sentry.io/",
     release: userOptions.release ?? "",
     finalize: userOptions.finalize ?? true,
-    validate: userOptions.validate ?? false,
     vcsRemote: userOptions.vcsRemote ?? "origin",
     customHeader: userOptions.customHeader,
     dryRun: userOptions.dryRun ?? false,
@@ -134,5 +135,6 @@ function normalizeIncludeEntry(
     stripCommonPrefix: includeEntry.stripCommonPrefix ?? userOptions.stripCommonPrefix ?? false,
     sourceMapReference: includeEntry.sourceMapReference ?? userOptions.sourceMapReference ?? true,
     rewrite: includeEntry.rewrite ?? userOptions.rewrite ?? true,
+    validate: includeEntry.validate ?? userOptions.validate ?? false,
   };
 }

--- a/packages/bundler-plugin-core/src/sentry/cli.ts
+++ b/packages/bundler-plugin-core/src/sentry/cli.ts
@@ -12,14 +12,15 @@ export type SentryCLILike = SentryCli | SentryDryRunCLI;
  * that makes no-ops out of most CLI operations
  */
 export function getSentryCli(internalOptions: InternalOptions, logger: Logger): SentryCLILike {
-  const { silent, org, project, authToken, url, vcsRemote, customHeader } = internalOptions;
+  const { silent, org, project, authToken, url, vcsRemote, customHeader, dist } = internalOptions;
   const cli = new SentryCli(internalOptions.configFile, {
-    silent,
+    url,
+    authToken,
     org,
     project,
-    authToken,
-    url,
     vcsRemote,
+    dist,
+    silent,
     customHeader,
   });
 

--- a/packages/bundler-plugin-core/src/sentry/logger.ts
+++ b/packages/bundler-plugin-core/src/sentry/logger.ts
@@ -1,7 +1,8 @@
 import { SeverityLevel, Hub } from "@sentry/node";
 
 interface LoggerOptions {
-  silent?: boolean;
+  silent: boolean;
+  debug: boolean;
   hub: Hub;
   prefix: string;
 }
@@ -24,7 +25,7 @@ export function createLogger(options: LoggerOptions): Logger {
 
   return {
     info(message: string, ...params: unknown[]) {
-      if (!options?.silent) {
+      if (!options.silent) {
         // eslint-disable-next-line no-console
         console.log(`${options.prefix} Info: ${message}`, ...params);
       }
@@ -32,7 +33,7 @@ export function createLogger(options: LoggerOptions): Logger {
       addBreadcrumb("info", message);
     },
     warn(message: string, ...params: unknown[]) {
-      if (!options?.silent) {
+      if (!options.silent) {
         // eslint-disable-next-line no-console
         console.log(`${options.prefix} Warning: ${message}`, ...params);
       }
@@ -40,7 +41,7 @@ export function createLogger(options: LoggerOptions): Logger {
       addBreadcrumb("warning", message);
     },
     error(message: string, ...params: unknown[]) {
-      if (!options?.silent) {
+      if (!options.silent) {
         // eslint-disable-next-line no-console
         console.log(`${options.prefix} Error: ${message}`, ...params);
       }
@@ -49,7 +50,7 @@ export function createLogger(options: LoggerOptions): Logger {
     },
 
     debug(message: string, ...params: unknown[]) {
-      if (!options?.silent) {
+      if (!options.silent && options.debug) {
         // eslint-disable-next-line no-console
         console.log(`${options.prefix} Debug: ${message}`, ...params);
       }

--- a/packages/bundler-plugin-core/src/sentry/releasePipeline.ts
+++ b/packages/bundler-plugin-core/src/sentry/releasePipeline.ts
@@ -55,6 +55,8 @@ export async function uploadSourceMaps(options: InternalOptions, ctx: BuildConte
 
   ctx.logger.info("Uploading Sourcemaps.");
 
+  // Since our internal include entries contain all top-level sourcemaps options,
+  // we only need to pass the include option here.
   await ctx.cli.releases.uploadSourceMaps(options.release, { include: options.include });
 
   ctx.logger.info("Successfully uploaded Sourcemaps.");

--- a/packages/bundler-plugin-core/src/types.ts
+++ b/packages/bundler-plugin-core/src/types.ts
@@ -88,14 +88,6 @@ export type Options = Omit<IncludeEntry, "paths"> & {
    */
   include: string | IncludeEntry | Array<string | IncludeEntry>;
 
-  /**
-   * When `true`, attempts source map validation before upload if rewriting is not enabled.
-   * It will spot a variety of issues with source maps and cancel the upload if any are found.
-   *
-   * Defaults to `false` as this can cause false positives.
-   */
-  validate?: boolean;
-
   /* --- other unimportant (for now) stuff- properties: */
 
   /**
@@ -261,6 +253,14 @@ export type IncludeEntry = {
    * Defaults to true
    */
   rewrite?: boolean;
+
+  /**
+   * When `true`, attempts source map validation before upload if rewriting is not enabled.
+   * It will spot a variety of issues with source maps and cancel the upload if any are found.
+   *
+   * Defaults to `false` as this can cause false positives.
+   */
+  validate?: boolean;
 };
 
 type SetCommitsOptions = {

--- a/packages/bundler-plugin-core/test/logger.test.ts
+++ b/packages/bundler-plugin-core/test/logger.test.ts
@@ -26,7 +26,7 @@ describe("Logger", () => {
     ["debug", "Debug"],
   ] as const)(".%s() should log correctly", (loggerMethod, logLevel) => {
     const prefix = "[some-prefix]";
-    const logger = createLogger({ hub, prefix });
+    const logger = createLogger({ hub, prefix, silent: false, debug: true });
 
     logger[loggerMethod]("Hey!");
 
@@ -45,7 +45,7 @@ describe("Logger", () => {
     ["debug", "Debug"],
   ] as const)(".%s() should log multiple params correctly", (loggerMethod, logLevel) => {
     const prefix = "[some-prefix]";
-    const logger = createLogger({ hub, prefix });
+    const logger = createLogger({ hub, prefix, silent: false, debug: true });
 
     logger[loggerMethod]("Hey!", "this", "is", "a test with", 5, "params");
 
@@ -65,9 +65,9 @@ describe("Logger", () => {
   });
 
   describe("doesn't log when `silent` option is `true`", () => {
-    it.each(["info", "warn", "error"] as const)(".%s()", (loggerMethod) => {
+    it.each(["info", "warn", "error", "debug"] as const)(".%s()", (loggerMethod) => {
       const prefix = "[some-prefix]";
-      const logger = createLogger({ silent: true, hub, prefix });
+      const logger = createLogger({ hub, prefix, silent: true, debug: true });
 
       logger[loggerMethod]("Hey!");
 

--- a/packages/bundler-plugin-core/test/option-mappings.test.ts
+++ b/packages/bundler-plugin-core/test/option-mappings.test.ts
@@ -25,6 +25,7 @@ describe("normalizeUserOptions()", () => {
           rewrite: true,
           sourceMapReference: true,
           stripCommonPrefix: false,
+          validate: false,
         },
       ],
       org: "my-org",
@@ -33,7 +34,6 @@ describe("normalizeUserOptions()", () => {
       silent: false,
       telemetry: true,
       url: "https://sentry.io/",
-      validate: false,
       vcsRemote: "origin",
     });
   });
@@ -68,6 +68,7 @@ describe("normalizeUserOptions()", () => {
           rewrite: true,
           sourceMapReference: false,
           stripCommonPrefix: true,
+          validate: false,
         },
       ],
       org: "my-org",
@@ -76,7 +77,6 @@ describe("normalizeUserOptions()", () => {
       silent: false,
       telemetry: true,
       url: "https://sentry.io/",
-      validate: false,
       vcsRemote: "origin",
     });
   });


### PR DESCRIPTION
This PR revisits our options after checking them for completeness against the webpack plugin and Sentry CLI: 

* Add the missing `debug` options to the plugin and make the `logger.debug` output depend on it
* Pass the previously unused `dist` option to the CLI constructor
* Move the previously top-level `validate` option to `IncludeEntry`

ref #91   