### PR TITLE
feat(core): Add `SENTRY_RELEASES` variable during release injection

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -51,6 +51,6 @@ The `ignore` and `ignoreFile` options will still allow globbing patterns.
 
 ### Injecting `SENTRY_RELEASES` Map
 
-Previously, the webpack plugin always injected a `SENTRY_RELEASES` map into the global object which would map from `project@org` to the `release` value. In version 2, we made this behaviour opt-in by setting the `injectReleasesMap` option in the plugin options to `true`.
+Previously, the webpack plugin always injected a `SENTRY_RELEASES` variable into the global object which would map from `project@org` to the `release` value. In version 2, we made this behaviour opt-in by setting the `injectReleasesMap` option in the plugin options to `true`.
 
-The purpose was to support module-federated projects or micro frontend setups where multiple projects would want to access the global release variable. However, Sentry SDKs by default never accessed this variable so it would require manual user-intervention to only make use of it. Making this behaviour opt-in decreases the bundle size impact of our plugin for the majority of users.
+The purpose of this option is to support module-federated projects or micro frontend setups where multiple projects would want to access the global release variable. However, Sentry SDKs by default never accessed this variable so it would require manual user-intervention to make use of it. Making this behaviour opt-in decreases the bundle size impact of our plugin for the majority of users.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -48,3 +48,9 @@ In version 2 we removed this functionality because it lead to intransparent nami
 
 Going forward, if you need similar functionality, we recommend providing folder paths in the `include` and `include.paths` options and narrowing down the matched files with the `ignore`, `ignoreFile` or `ext` options.
 The `ignore` and `ignoreFile` options will still allow globbing patterns.
+
+### Injecting `SENTRY_RELEASES` Map
+
+Previously, the webpack plugin always injected a `SENTRY_RELEASES` map into the global object which would map from `project@org` to the `release` value. In version 2, we made this behaviour opt-in by setting the `injectReleasesMap` option in the plugin options to `true`.
+
+The purpose was to support module-federated projects or micro frontend setups where multiple projects would want to access the global release variable. However, Sentry SDKs by default never accessed this variable so it would require manual user-intervention to only make use of it. Making this behaviour opt-in decreases the bundle size impact of our plugin for the majority of users.

--- a/packages/bundler-plugin-core/src/index.ts
+++ b/packages/bundler-plugin-core/src/index.ts
@@ -187,6 +187,7 @@ const unplugin = createUnplugin<Options>((options, unpluginMetaContext) => {
       if (id === RELEASE_INJECTOR_ID) {
         return generateGlobalInjectorCode({
           release: internalOptions.release,
+          injectReleasesMap: internalOptions.injectReleasesMap,
           org: internalOptions.org,
           project: internalOptions.project,
         });
@@ -326,10 +327,12 @@ const unplugin = createUnplugin<Options>((options, unpluginMetaContext) => {
  */
 function generateGlobalInjectorCode({
   release,
+  injectReleasesMap,
   org,
   project,
 }: {
   release: string;
+  injectReleasesMap: boolean;
   org?: string;
   project?: string;
 }) {
@@ -347,7 +350,7 @@ function generateGlobalInjectorCode({
 
     _global.SENTRY_RELEASE={id:"${release}"};`;
 
-  if (project) {
+  if (injectReleasesMap && project) {
     const key = org ? `${project}@${org}` : project;
     code += `
       _global.SENTRY_RELEASES=_global.SENTRY_RELEASES || {};

--- a/packages/bundler-plugin-core/src/index.ts
+++ b/packages/bundler-plugin-core/src/index.ts
@@ -13,7 +13,7 @@ import "@sentry/tracing";
 import { addSpanToTransaction, captureMinimalError, makeSentryClient } from "./sentry/telemetry";
 import { Span, Transaction } from "@sentry/types";
 import { createLogger } from "./sentry/logger";
-import { InternalOptions, normalizeUserOptions } from "./options-mapping";
+import { normalizeUserOptions } from "./options-mapping";
 import { getSentryCli } from "./sentry/cli";
 
 // We prefix the polyfill id with \0 to tell other plugins not to try to load or transform it.

--- a/packages/bundler-plugin-core/src/options-mapping.ts
+++ b/packages/bundler-plugin-core/src/options-mapping.ts
@@ -15,6 +15,7 @@ type RequiredInternalOptions = Required<
     | "silent"
     | "cleanArtifacts"
     | "telemetry"
+    | "injectReleasesMap"
   >
 >;
 
@@ -100,6 +101,7 @@ export function normalizeUserOptions(userOptions: UserOptions): InternalOptions 
     entries,
     include,
     configFile: userOptions.configFile,
+    injectReleasesMap: userOptions.injectReleasesMap ?? false,
   };
 }
 

--- a/packages/bundler-plugin-core/src/types.ts
+++ b/packages/bundler-plugin-core/src/types.ts
@@ -179,6 +179,15 @@ export type Options = Omit<IncludeEntry, "paths"> & {
    * defaults from ~/.sentryclirc are always loaded
    */
   configFile?: string;
+
+  /**
+   * If set to true, the plugin will inject an additional `SENTRY_RELEASES` variable that
+   * maps from `{org}@{project}` to the `release` value. This might be helpful for webpack
+   * module federation or micro frontend setups.
+   *
+   * Defaults to `false`
+   */
+  injectReleasesMap?: boolean;
 };
 
 export type IncludeEntry = {

--- a/packages/bundler-plugin-core/test/option-mappings.test.ts
+++ b/packages/bundler-plugin-core/test/option-mappings.test.ts
@@ -35,6 +35,7 @@ describe("normalizeUserOptions()", () => {
       telemetry: true,
       url: "https://sentry.io/",
       vcsRemote: "origin",
+      injectReleasesMap: false,
     });
   });
 
@@ -78,6 +79,7 @@ describe("normalizeUserOptions()", () => {
       telemetry: true,
       url: "https://sentry.io/",
       vcsRemote: "origin",
+      injectReleasesMap: false,
     });
   });
 });

--- a/packages/integration-tests/fixtures/releases-injection/input/entrypoint.js
+++ b/packages/integration-tests/fixtures/releases-injection/input/entrypoint.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+process.stdout.write(global.SENTRY_RELEASES["releasesProject@releasesOrg"].id.toString());

--- a/packages/integration-tests/fixtures/releases-injection/releases-injection.test.ts
+++ b/packages/integration-tests/fixtures/releases-injection/releases-injection.test.ts
@@ -1,0 +1,38 @@
+import childProcess from "child_process";
+import path from "path";
+
+/**
+ * Runs a node file in a seprate process.
+ *
+ * @param bundlePath Path of node file to run
+ * @returns Stdout of the process
+ */
+function checkBundle(bundlePath: string): void {
+  const processOutput = childProcess.execSync(`node ${bundlePath}`, { encoding: "utf-8" });
+  expect(processOutput).toBe("I AM A RELEASE!");
+}
+
+test("esbuild bundle", () => {
+  expect.assertions(1);
+  checkBundle(path.join(__dirname, "./out/esbuild/index.js"));
+});
+
+test("rollup bundle", () => {
+  expect.assertions(1);
+  checkBundle(path.join(__dirname, "./out/rollup/index.js"));
+});
+
+test("vite bundle", () => {
+  expect.assertions(1);
+  checkBundle(path.join(__dirname, "./out/vite/index.js"));
+});
+
+test("webpack 4 bundle", () => {
+  expect.assertions(1);
+  checkBundle(path.join(__dirname, "./out/webpack4/index.js"));
+});
+
+test("webpack 5 bundle", () => {
+  expect.assertions(1);
+  checkBundle(path.join(__dirname, "./out/webpack5/index.js"));
+});

--- a/packages/integration-tests/fixtures/releases-injection/setup.ts
+++ b/packages/integration-tests/fixtures/releases-injection/setup.ts
@@ -1,0 +1,14 @@
+import { Options } from "@sentry/bundler-plugin-core";
+import * as path from "path";
+import { createCjsBundles } from "../../utils/create-cjs-bundles";
+
+const entryPointPath = path.resolve(__dirname, "./input/entrypoint.js");
+const outputDir = path.resolve(__dirname, "./out");
+
+createCjsBundles({ index: entryPointPath }, outputDir, {
+  release: "I AM A RELEASE!",
+  project: "releasesProject",
+  org: "releasesOrg",
+  include: outputDir,
+  dryRun: true,
+} as Options);

--- a/packages/integration-tests/fixtures/releases-injection/setup.ts
+++ b/packages/integration-tests/fixtures/releases-injection/setup.ts
@@ -11,4 +11,5 @@ createCjsBundles({ index: entryPointPath }, outputDir, {
   org: "releasesOrg",
   include: outputDir,
   dryRun: true,
+  injectReleasesMap: true,
 } as Options);


### PR DESCRIPTION
In our initial implementation of release injection, we did not inject the `SENTRY_RELEASES` global variable which was added to the webpack plugin in https://github.com/getsentry/sentry-webpack-plugin/pull/307. 

Although it is unlikely that people are actually using this feature, it doesn't hurt us a lot if we implement it to prevent breakage for anyone who might manually be relying on this variable (e.g. MFE projects). 

EDIT: We decided to make this behaviour opt-in by introducing a new `injectReleasesMap` option. 

---

A little more context:

The idea of this variable is to have a map of projects that point to the same release. This seems to be a request for module federation and MFEs where it seems that multiple projects want to access the same release.

This original PR was merged, however it seems like our SDK never reads `SENTRY_RELEASES`. The PR author added this in a comment: 

> If this is accepted, we can maybe open another PR on @sentry/browser so that the default release is read from SENTRY_RELEASES and retire SENTRY_RELEASE

So what I'm thinking is that this just never happened. This however still means that people could actually be using this feature by manually accessing `global.SENTRY_RELEASES` and setting the version based on that. 