### PR TITLE
ref(core): Refactor options validation

### DIFF
--- a/packages/bundler-plugin-core/src/options-mapping.ts
+++ b/packages/bundler-plugin-core/src/options-mapping.ts
@@ -1,3 +1,4 @@
+import { Logger } from "./sentry/logger";
 import { IncludeEntry as UserIncludeEntry, Options as UserOptions } from "./types";
 import { arrayify } from "./utils";
 
@@ -174,4 +175,47 @@ function normalizeIncludeEntry(
     rewrite: includeEntry.rewrite ?? userOptions.rewrite ?? true,
     validate: includeEntry.validate ?? userOptions.validate ?? false,
   };
+}
+
+/**
+ * Validates a few combinations of options that are not checked by Sentry CLI.
+ *
+ * For all other options, we can rely on Sentry CLI to validate them. In fact,
+ * we can't validate them in the plugin because Sentry CLI might pick up options from
+ * its config file.
+ *
+ * @param options the internal options
+ * @param logger the logger
+ *
+ * @returns `true` if the options are valid, `false` otherwise
+ */
+export function validateOptions(options: InternalOptions, logger: Logger): boolean {
+  if (options.injectReleasesMap && !options.org) {
+    logger.error(
+      "The `injectReleasesMap` option was set but it is only supported when the `org` option is also specified.",
+      "Please set the `org` option (you can also set the SENTRY_ORG environment variable) or disable the `injectReleasesMap` option."
+    );
+    return false;
+  }
+
+  const setCommits = options.setCommits;
+  if (setCommits) {
+    if (!setCommits.auto && !(setCommits.repo && setCommits.commit)) {
+      logger.error(
+        "The `setCommits` option was specified but is missing required properties.",
+        "Please set either `auto` or both, `repo` and `commit`."
+      );
+      return false;
+    }
+  }
+
+  if (options.deploy && !options.deploy.env) {
+    logger.error(
+      "The `deploy` option was specified but is missing the required `env` property.",
+      "Please set the `env` property."
+    );
+    return false;
+  }
+
+  return true;
 }

--- a/packages/bundler-plugin-core/src/options-mapping.ts
+++ b/packages/bundler-plugin-core/src/options-mapping.ts
@@ -207,6 +207,13 @@ export function validateOptions(options: InternalOptions, logger: Logger): boole
       );
       return false;
     }
+    if (setCommits.auto && setCommits.repo && setCommits) {
+      logger.warn(
+        "The `setCommits` options includes `auto` but also `repo` and `commit`.",
+        "Ignoring `repo` and `commit`.",
+        "Please only set either `auto` or both, `repo` and `commit`."
+      );
+    }
   }
 
   if (options.deploy && !options.deploy.env) {

--- a/packages/bundler-plugin-core/src/sentry/releasePipeline.ts
+++ b/packages/bundler-plugin-core/src/sentry/releasePipeline.ts
@@ -13,40 +13,14 @@ import { addSpanToTransaction } from "./telemetry";
 export async function createNewRelease(options: InternalOptions, ctx: BuildContext): Promise<void> {
   const span = addSpanToTransaction(ctx, "function.plugin.create_release");
 
-  // TODO: pull these checks out of here and simplify them
-  if (options.authToken === undefined) {
-    ctx.logger.warn('Missing "authToken" option. Will not create release.');
-    return;
-  } else if (options.org === undefined) {
-    ctx.logger.warn('Missing "org" option. Will not create release.');
-    return;
-  } else if (options.project === undefined) {
-    ctx.logger.warn('Missing "project" option. Will not create release.');
-    return;
-  }
-
   await ctx.cli.releases.new(options.release);
 
   ctx.logger.info("Successfully created release.");
-
   span?.finish();
 }
 
 export async function uploadSourceMaps(options: InternalOptions, ctx: BuildContext): Promise<void> {
   const span = addSpanToTransaction(ctx, "function.plugin.upload_sourcemaps");
-
-  // TODO: pull these checks out of here and simplify them
-  if (options.authToken === undefined) {
-    ctx.logger.warn('Missing "authToken" option. Will not create release.');
-    return Promise.resolve();
-  } else if (options.org === undefined) {
-    ctx.logger.warn('Missing "org" option. Will not create release.');
-    return Promise.resolve();
-  } else if (options.project === undefined) {
-    ctx.logger.warn('Missing "project" option. Will not create release.');
-    return Promise.resolve();
-  }
-
   ctx.logger.info("Uploading Sourcemaps.");
 
   // Since our internal include entries contain all top-level sourcemaps options,
@@ -54,7 +28,6 @@ export async function uploadSourceMaps(options: InternalOptions, ctx: BuildConte
   await ctx.cli.releases.uploadSourceMaps(options.release, { include: options.include });
 
   ctx.logger.info("Successfully uploaded Sourcemaps.");
-
   span?.finish();
 }
 
@@ -73,20 +46,7 @@ export async function cleanArtifacts(options: InternalOptions, ctx: BuildContext
   const span = addSpanToTransaction(ctx, "function.plugin.clean_artifacts");
 
   if (options.cleanArtifacts) {
-    // TODO: pull these checks out of here and simplify them
-    if (options.authToken === undefined) {
-      ctx.logger.warn('Missing "authToken" option. Will not clean existing artifacts.');
-      return;
-    } else if (options.org === undefined) {
-      ctx.logger.warn('Missing "org" option. Will not clean existing artifacts.');
-      return;
-    } else if (options.project === undefined) {
-      ctx.logger.warn('Missing "project" option. Will not clean existing artifacts.');
-      return;
-    }
-
     await ctx.cli.releases.execute(["releases", "files", options.release, "delete", "--all"], true);
-
     ctx.logger.info("Successfully cleaned previous artifacts.");
   }
 
@@ -99,22 +59,16 @@ export async function setCommits(options: InternalOptions, ctx: BuildContext): P
   if (options.setCommits) {
     const { auto, repo, commit, previousCommit, ignoreMissing, ignoreEmpty } = options.setCommits;
 
-    if (auto || (repo && commit)) {
-      await ctx.cli.releases.setCommits(options.release, {
-        commit,
-        previousCommit,
-        repo,
-        auto,
-        ignoreMissing,
-        ignoreEmpty,
-      });
-      ctx.logger.info("Successfully set commits.");
-    } else {
-      ctx.logger.error(
-        "Couldn't set commits - neither the `auto` nor the `repo` and `commit` options were specified!",
-        "Make sure to either set `auto` to `true` or to manually set `repo` and `commit`."
-      );
-    }
+    await ctx.cli.releases.setCommits(options.release, {
+      commit,
+      previousCommit,
+      repo,
+      auto,
+      ignoreMissing,
+      ignoreEmpty,
+    });
+
+    ctx.logger.info("Successfully set commits.");
   }
 
   span?.finish();
@@ -126,22 +80,16 @@ export async function addDeploy(options: InternalOptions, ctx: BuildContext): Pr
   if (options.deploy) {
     const { env, started, finished, time, name, url } = options.deploy;
 
-    if (env) {
-      await ctx.cli.releases.newDeploy(options.release, {
-        env,
-        started,
-        finished,
-        time,
-        name,
-        url,
-      });
-      ctx.logger.info("Successfully added deploy.");
-    } else {
-      ctx.logger.error(
-        "Couldn't add deploy - the `env` option was not specified!",
-        "Make sure to set `deploy.env` (e.g. to 'production')."
-      );
-    }
+    await ctx.cli.releases.newDeploy(options.release, {
+      env,
+      started,
+      finished,
+      time,
+      name,
+      url,
+    });
+
+    ctx.logger.info("Successfully added deploy.");
   }
 
   span?.finish();

--- a/packages/bundler-plugin-core/src/sentry/telemetry.ts
+++ b/packages/bundler-plugin-core/src/sentry/telemetry.ts
@@ -12,8 +12,7 @@ import { BuildContext } from "../types";
 
 export function makeSentryClient(
   dsn: string,
-  telemetryEnabled: boolean,
-  org?: string
+  telemetryEnabled: boolean
 ): { client: NodeClient; hub: Hub } {
   const client = new NodeClient({
     dsn,
@@ -33,12 +32,6 @@ export function makeSentryClient(
   });
 
   const hub = new Hub(client);
-
-  hub.configureScope((scope) => {
-    if (org) {
-      scope.setTag("org", org);
-    }
-  });
 
   //TODO: This call is problematic because as soon as we set our hub as the current hub
   //      we might interfere with other plugins that use Sentry. However, for now, we'll

--- a/packages/bundler-plugin-core/src/types.ts
+++ b/packages/bundler-plugin-core/src/types.ts
@@ -280,31 +280,7 @@ export type IncludeEntry = {
   validate?: boolean;
 };
 
-type SetCommitsOptions = {
-  /**
-   * Automatically sets `commit` and `previousCommit`. Sets `commit` to `HEAD`
-   * and `previousCommit` as described in the option's documentation.
-   *
-   * If you set this to `true`, manually specified `commit` and `previousCommit`
-   * options will be overridden. It is best to not specify them at all if you
-   * set this option to `true`.
-   */
-  auto?: boolean;
-
-  /**
-   * The full repo name as defined in Sentry.
-   *
-   * Required if `auto` option is not set to `true`.
-   */
-  repo?: string;
-
-  /**
-   * The current (last) commit in the release.
-   *
-   * Required if `auto` option is not set to `true`.
-   */
-  commit?: string;
-
+type SetCommitsOptions = (AutoSetCommitsOptions | ManualSetCommitsOptions) & {
   /**
    * The commit before the beginning of this release (in other words,
    * the last commit of the previous release).
@@ -331,6 +307,39 @@ type SetCommitsOptions = {
    * Defaults to `false`.
    */
   ignoreEmpty?: boolean;
+};
+
+type AutoSetCommitsOptions = {
+  /**
+   * Automatically sets `commit` and `previousCommit`. Sets `commit` to `HEAD`
+   * and `previousCommit` as described in the option's documentation.
+   *
+   * If you set this to `true`, manually specified `commit` and `previousCommit`
+   * options will be overridden. It is best to not specify them at all if you
+   * set this option to `true`.
+   */
+  auto: true;
+
+  repo?: undefined;
+  commit?: undefined;
+};
+
+type ManualSetCommitsOptions = {
+  auto?: false | undefined;
+
+  /**
+   * The full repo name as defined in Sentry.
+   *
+   * Required if `auto` option is not set to `true`.
+   */
+  repo: string;
+
+  /**
+   * The current (last) commit in the release.
+   *
+   * Required if `auto` option is not set to `true`.
+   */
+  commit: string;
 };
 
 type DeployOptions = {

--- a/packages/bundler-plugin-core/test/releasePipeline.test.ts
+++ b/packages/bundler-plugin-core/test/releasePipeline.test.ts
@@ -47,17 +47,6 @@ describe("Release Pipeline", () => {
       expect(mockedChildSpan.finish).toHaveBeenCalled();
     });
 
-    it.skip("logs an error if neither `auto` nor `repo` && `commit` options are specified", async () => {
-      await setCommits({ setCommits: {} } as InternalOptions, ctx as unknown as BuildContext);
-      expect(mockedCLI.releases.setCommits).not.toHaveBeenCalled();
-      expect(mockedLogger.error).toHaveBeenLastCalledWith(
-        expect.stringMatching(/Couldn't set commits.*auto.*repo.*commit/),
-        expect.stringMatching(/.*auto.*repo.*commit/)
-      );
-      expect(mockedAddSpanToTxn).toHaveBeenCalled();
-      expect(mockedChildSpan.finish).toHaveBeenCalled();
-    });
-
     it("makes a call to Sentry CLI if the correct options are specified", async () => {
       await setCommits(
         { setCommits: { auto: true }, release: "1.0.0" } as InternalOptions,
@@ -75,17 +64,6 @@ describe("Release Pipeline", () => {
       await addDeploy({} as InternalOptions, ctx as unknown as BuildContext);
 
       expect(mockedCLI.releases.newDeploy).not.toHaveBeenCalled();
-      expect(mockedAddSpanToTxn).toHaveBeenCalled();
-      expect(mockedChildSpan.finish).toHaveBeenCalled();
-    });
-
-    it.skip("logs an error and does nothing if `env` isn't specified", async () => {
-      await addDeploy({ deploy: {} } as InternalOptions, ctx as unknown as BuildContext);
-      expect(mockedCLI.releases.newDeploy).not.toHaveBeenCalled();
-      expect(mockedLogger.error).toHaveBeenLastCalledWith(
-        expect.stringMatching(/Couldn't add deploy.*env/),
-        expect.stringMatching(/env/)
-      );
       expect(mockedAddSpanToTxn).toHaveBeenCalled();
       expect(mockedChildSpan.finish).toHaveBeenCalled();
     });

--- a/packages/bundler-plugin-core/test/releasePipeline.test.ts
+++ b/packages/bundler-plugin-core/test/releasePipeline.test.ts
@@ -47,7 +47,7 @@ describe("Release Pipeline", () => {
       expect(mockedChildSpan.finish).toHaveBeenCalled();
     });
 
-    it("logs an error if neither `auto` nor `repo` && `commit` options are specified", async () => {
+    it.skip("logs an error if neither `auto` nor `repo` && `commit` options are specified", async () => {
       await setCommits({ setCommits: {} } as InternalOptions, ctx as unknown as BuildContext);
       expect(mockedCLI.releases.setCommits).not.toHaveBeenCalled();
       expect(mockedLogger.error).toHaveBeenLastCalledWith(
@@ -79,7 +79,7 @@ describe("Release Pipeline", () => {
       expect(mockedChildSpan.finish).toHaveBeenCalled();
     });
 
-    it("logs an error and does nothing if `env` isn't specified", async () => {
+    it.skip("logs an error and does nothing if `env` isn't specified", async () => {
       await addDeploy({ deploy: {} } as InternalOptions, ctx as unknown as BuildContext);
       expect(mockedCLI.releases.newDeploy).not.toHaveBeenCalled();
       expect(mockedLogger.error).toHaveBeenLastCalledWith(

--- a/packages/playground/vite.config.smallNodeApp.js
+++ b/packages/playground/vite.config.smallNodeApp.js
@@ -28,7 +28,8 @@ export default defineConfig({
       ignore: ["!out/vite-smallNodeApp/index.js.map"],
       ignoreFile: ".sentryignore",
       setCommits: {
-        auto: true,
+        repo: "",
+        commit: "",
         ignoreMissing: true,
       },
       deploy: {


### PR DESCRIPTION
This PR refactors the validation of the plugin options. Since Sentry CLI does most of the validation work out of the box, we only need to take care of a few special cases. Therefore:

* Deleted the ugly and duplicated org, project, auth, etc. checks in the release pipeline steps as most of them aren't necessary at all in that form
* Added a centralized validation function that validates certain combinations of options that Sentry CLI doesn't do (these validations are also present in the webpack plugin, albeit in a little different form)
* Added special validation of the `release` value as it simply has to be present to continue with release injection and the release creation pipeline
* All validation errors will cause the plugin to throw unless the user specified an error handler. Happy to discuss this point but I think it makes sense to only continue with valid options.

ref #91 