### PR TITLE
feat: Use `SENTRY_HEADER` env var when available

### DIFF
--- a/packages/bundler-plugin-core/src/options-mapping.ts
+++ b/packages/bundler-plugin-core/src/options-mapping.ts
@@ -90,7 +90,13 @@ export function normalizeUserOptions(userOptions: UserOptions): InternalOptions 
     // Sentry CLI will internally query env variables and read its config file if
     // the passed options are undefined.
     authToken: userOptions.authToken, // env var: `SENTRY_AUTH_TOKEN`
-    customHeader: userOptions.customHeader, // env var: `CUSTOM_HEADER`
+
+    // CLI v1 (and the "old" webpack plugin) use `CUSTOM_HEADER`,
+    // but CLI v2 uses `SENTRY_HEADER` (which is also better aligned with other naming)
+    // In the spirit of maximum compatibility, we allow both here.
+    customHeader:
+      userOptions.customHeader ?? process.env["SENTRY_HEADER"] ?? process.env["CUSTOM_HEADER"],
+
     url: userOptions.url, // env var: `SENTRY_URL`
     vcsRemote: userOptions.vcsRemote, // env var: `SENTRY_VSC_REMOTE`
 

--- a/packages/bundler-plugin-core/test/option-mappings.test.ts
+++ b/packages/bundler-plugin-core/test/option-mappings.test.ts
@@ -78,6 +78,32 @@ describe("normalizeUserOptions()", () => {
       injectReleasesMap: false,
     });
   });
+
+  test("should handle `SENTRY_HEADER` & `CUSTOM_HEADER` env", () => {
+    const userOptions: Options = {
+      org: "my-org",
+      project: "my-project",
+      authToken: "my-auth-token",
+      release: "my-release",
+      include: "./out",
+    };
+
+    const _original_SENTRY_HEADER = process.env["SENTRY_HEADER"];
+    const _original_CUSTOM_HEADER = process.env["CUSTOM_HEADER"];
+
+    expect(normalizeUserOptions(userOptions).customHeader).toBeUndefined();
+
+    process.env["CUSTOM_HEADER"] = "custom-header";
+
+    expect(normalizeUserOptions(userOptions).customHeader).toBe("custom-header");
+
+    process.env["SENTRY_HEADER"] = "sentry-header";
+
+    expect(normalizeUserOptions(userOptions).customHeader).toBe("sentry-header");
+
+    process.env["SENTRY_HEADER"] = _original_SENTRY_HEADER;
+    process.env["CUSTOM_HEADER"] = _original_CUSTOM_HEADER;
+  });
 });
 
 describe("validateOptions", () => {


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry-javascript-bundler-plugins/issues/106

Not 100% sure if the test is the "best", but couldn't think of a better way to test this easily. I'd say it is OK, but if you have another idea, I'm happy to change it.