### PR TITLE
chore(core): Remove unused dependencies

### DIFF
--- a/packages/bundler-plugin-core/package.json
+++ b/packages/bundler-plugin-core/package.json
@@ -38,10 +38,6 @@
     "@sentry/cli": "^1.74.6",
     "@sentry/node": "^7.11.1",
     "@sentry/tracing": "^7.11.1",
-    "axios": "^0.27.2",
-    "form-data": "^4.0.0",
-    "glob": "8.0.3",
-    "ignore": "^5.2.0",
     "magic-string": "0.26.2",
     "unplugin": "0.10.1"
   },
@@ -58,7 +54,6 @@
     "@sentry-internal/sentry-bundler-plugin-tsconfig": "0.0.1-alpha.0",
     "@swc/core": "^1.2.205",
     "@swc/jest": "^0.2.21",
-    "@types/glob": "8.0.0",
     "@types/jest": "^28.1.3",
     "@types/node": "^18.6.3",
     "eslint": "^8.18.0",

--- a/packages/bundler-plugin-core/src/sentry/telemetry.ts
+++ b/packages/bundler-plugin-core/src/sentry/telemetry.ts
@@ -59,17 +59,18 @@ export function addSpanToTransaction(
 export function captureMinimalError(error: unknown | Error, hub: Hub) {
   let sentryError;
 
-  if (typeof error === "object") {
+  if (error && typeof error === "object") {
     const e = error as { name?: string; message?: string; stack?: string };
     sentryError = {
       name: e.name,
       message: e.message,
       stack: e.stack,
     };
-  } else if (typeof error === "string") {
+  } else {
     sentryError = {
       name: "Error",
-      message: error,
+      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+      message: `${error}`,
     };
   }
 

--- a/packages/bundler-plugin-core/test/sentry/cli.test.ts
+++ b/packages/bundler-plugin-core/test/sentry/cli.test.ts
@@ -1,5 +1,5 @@
 import SentryCli from "@sentry/cli";
-import { getSentryCli } from "../src/sentry/cli";
+import { getSentryCli } from "../../src/sentry/cli";
 
 describe("getSentryCLI", () => {
   it("returns a valid CLI instance if dryRun is not specified", () => {

--- a/packages/bundler-plugin-core/test/sentry/logger.test.ts
+++ b/packages/bundler-plugin-core/test/sentry/logger.test.ts
@@ -1,5 +1,5 @@
 import { Hub } from "@sentry/node";
-import { createLogger } from "../src/sentry/logger";
+import { createLogger } from "../../src/sentry/logger";
 
 describe("Logger", () => {
   const consoleLogSpy = jest.spyOn(console, "log").mockImplementation(() => undefined);

--- a/packages/bundler-plugin-core/test/sentry/releasePipeline.test.ts
+++ b/packages/bundler-plugin-core/test/sentry/releasePipeline.test.ts
@@ -1,4 +1,4 @@
-import { InternalOptions } from "../src/options-mapping";
+import { InternalOptions } from "../../src/options-mapping";
 import {
   addDeploy,
   cleanArtifacts,
@@ -6,14 +6,14 @@ import {
   finalizeRelease,
   setCommits,
   uploadSourceMaps,
-} from "../src/sentry/releasePipeline";
-import { BuildContext } from "../src/types";
+} from "../../src/sentry/releasePipeline";
+import { BuildContext } from "../../src/types";
 
 const mockedAddSpanToTxn = jest.fn();
 
-jest.mock("../src/sentry/telemetry", () => {
+jest.mock("../../src/sentry/telemetry", () => {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-  const original = jest.requireActual("../src/sentry/telemetry");
+  const original = jest.requireActual("../../src/sentry/telemetry");
 
   // eslint-disable-next-line @typescript-eslint/no-unsafe-return
   return {

--- a/packages/bundler-plugin-core/test/sentry/telemetry.test.ts
+++ b/packages/bundler-plugin-core/test/sentry/telemetry.test.ts
@@ -1,0 +1,59 @@
+import { Hub } from "@sentry/node";
+import { captureMinimalError } from "../../src/sentry/telemetry";
+
+describe("captureMinimalError", () => {
+  const mockedHub = {
+    captureException: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("Should capture a normal error", () => {
+    captureMinimalError(new Error("test"), mockedHub as unknown as Hub);
+    expect(mockedHub.captureException).toHaveBeenCalledWith({
+      name: "Error",
+      message: "test",
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      stack: expect.any(String),
+    });
+  });
+
+  it("Shouldn't capture an error with additional data", () => {
+    const error = new Error("test");
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    (error as any).additionalContext = { foo: "bar" };
+
+    captureMinimalError(error, mockedHub as unknown as Hub);
+
+    expect(mockedHub.captureException).toHaveBeenCalledWith({
+      name: "Error",
+      message: "test",
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      stack: expect.any(String),
+    });
+  });
+
+  it("Should handle string messages gracefully", () => {
+    const error = "Property x is missing!";
+
+    captureMinimalError(error, mockedHub as unknown as Hub);
+
+    expect(mockedHub.captureException).toHaveBeenCalledWith({
+      name: "Error",
+      message: error,
+    });
+  });
+
+  it("Should even handle undefined gracefully", () => {
+    const error = undefined;
+
+    captureMinimalError(error, mockedHub as unknown as Hub);
+
+    expect(mockedHub.captureException).toHaveBeenCalledWith({
+      name: "Error",
+      message: "undefined",
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -3837,14 +3837,6 @@ axios@*, axios@^1.0.0, axios@^1.1.3:
     form-data "^4.0.0"
     proxy-from-env "^1.1.0"
 
-axios@^0.27.2:
-  version "0.27.2"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.27.2.tgz#207658cc8621606e586c85db4b41a750e756d972"
-  integrity sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==
-  dependencies:
-    follow-redirects "^1.14.9"
-    form-data "^4.0.0"
-
 babel-jest@^27.5.1:
   version "27.5.1"
   resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-27.5.1.tgz#a1bf8d61928edfefd21da27eb86a695bfd691444"
@@ -6183,7 +6175,7 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
 
-follow-redirects@^1.0.0, follow-redirects@^1.14.9:
+follow-redirects@^1.0.0:
   version "1.15.1"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.1.tgz#0ca6a452306c9b276e4d3127483e29575e207ad5"
   integrity sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==


### PR DESCRIPTION
This PR just removes a few dependencies we don't need anymore after switching back to Sentry CLI. 

I made a small adjustment to our `captureMinimalError` function which treated Axios errors differently from other errors (we could also see this as a first step for #99)