### PR TITLE
ref(core): Don't send `org` and `project` to Sentry

### DIFF
--- a/packages/bundler-plugin-core/src/index.ts
+++ b/packages/bundler-plugin-core/src/index.ts
@@ -115,12 +115,8 @@ const unplugin = createUnplugin<Options>((options, unpluginMetaContext) => {
   }
 
   sentryHub.setTags({
-    organization: internalOptions.org,
-    project: internalOptions.project,
     bundler: unpluginMetaContext.framework,
   });
-
-  sentryHub.setUser({ id: internalOptions.org });
 
   // This is `nonEntrypointSet` instead of `entrypointSet` because this set is filled in the `resolveId` hook and there
   // we don't have guaranteed access to *absolute* paths of files if they're entrypoints. For non-entrypoints we're


### PR DESCRIPTION
⚠️ Needs Discussion!

We currently send the org and project as tags in each error or transaction to Sentry (if `telemetry` is enabled). Furthermore, we also set the user to `org`. 

This PR would remove all mentions or org and project in Sentry events. Happy to merge it if we say that this is necessary.

ref: #99