### PR TITLE
feat(core): Add plugin options as tags

### DIFF
--- a/packages/bundler-plugin-core/src/index.ts
+++ b/packages/bundler-plugin-core/src/index.ts
@@ -10,7 +10,12 @@ import {
   uploadSourceMaps,
 } from "./sentry/releasePipeline";
 import "@sentry/tracing";
-import { addSpanToTransaction, captureMinimalError, makeSentryClient } from "./sentry/telemetry";
+import {
+  addPluginOptionTags,
+  addSpanToTransaction,
+  captureMinimalError,
+  makeSentryClient,
+} from "./sentry/telemetry";
 import { Span, Transaction } from "@sentry/types";
 import { createLogger, Logger } from "./sentry/logger";
 import { InternalOptions, normalizeUserOptions, validateOptions } from "./options-mapping";
@@ -90,6 +95,7 @@ const unplugin = createUnplugin<Options>((options, unpluginMetaContext) => {
     "https://4c2bae7d9fbc413e8f7385f55c515d51@o1.ingest.sentry.io/6690737",
     internalOptions.telemetry
   );
+  addPluginOptionTags(internalOptions, sentryHub);
 
   const logger = createLogger({
     hub: sentryHub,

--- a/packages/bundler-plugin-core/src/sentry/telemetry.ts
+++ b/packages/bundler-plugin-core/src/sentry/telemetry.ts
@@ -7,6 +7,7 @@ import {
   NodeClient,
 } from "@sentry/node";
 import { Span } from "@sentry/tracing";
+import { InternalOptions } from "../options-mapping";
 import { BuildContext } from "../types";
 
 export function makeSentryClient(
@@ -75,4 +76,33 @@ export function captureMinimalError(error: unknown | Error, hub: Hub) {
   }
 
   hub.captureException(sentryError);
+}
+
+export function addPluginOptionTags(options: InternalOptions, hub: Hub) {
+  const {
+    cleanArtifacts,
+    finalize,
+    setCommits,
+    injectReleasesMap,
+    dryRun,
+    errorHandler,
+    deploy,
+    include,
+  } = options;
+
+  hub.setTags({
+    include: include.length > 1 ? "multiple-entries" : "single-entry",
+    "clean-artifacts": cleanArtifacts,
+    "finalize-release": finalize,
+    "deploy-release": deploy ? true : false,
+    "inject-releases-map": injectReleasesMap,
+    "dry-run": dryRun,
+    "error-handler": errorHandler ? "custom" : "none",
+  });
+
+  if (setCommits) {
+    hub.setTag("set-commits", setCommits.auto ? "auto" : "manual");
+  } else {
+    hub.setTag("set-commits", false);
+  }
 }

--- a/packages/bundler-plugin-core/src/sentry/telemetry.ts
+++ b/packages/bundler-plugin-core/src/sentry/telemetry.ts
@@ -90,19 +90,30 @@ export function addPluginOptionTags(options: InternalOptions, hub: Hub) {
     include,
   } = options;
 
-  hub.setTags({
-    include: include.length > 1 ? "multiple-entries" : "single-entry",
-    "clean-artifacts": cleanArtifacts,
-    "finalize-release": finalize,
-    "add-deploy": deploy ? true : false,
-    "inject-releases-map": injectReleasesMap,
-    "dry-run": dryRun,
-    "error-handler": errorHandler ? "custom" : "none",
-  });
+  hub.setTag("include", include.length > 1 ? "multiple-entries" : "single-entry");
 
+  // Optional release pipeline steps
+  if (cleanArtifacts) {
+    hub.setTag("clean-artifacts", true);
+  }
   if (setCommits) {
     hub.setTag("set-commits", setCommits.auto === true ? "auto" : "manual");
-  } else {
-    hub.setTag("set-commits", false);
+  }
+  if (finalize) {
+    hub.setTag("finalize-release", true);
+  }
+  if (deploy) {
+    hub.setTag("add-deploy", true);
+  }
+
+  // Miscelaneous options
+  if (dryRun) {
+    hub.setTag("dry-run", true);
+  }
+  if (injectReleasesMap) {
+    hub.setTag("inject-releases-map", true);
+  }
+  if (errorHandler) {
+    hub.setTag("error-handler", "custom");
   }
 }

--- a/packages/bundler-plugin-core/src/sentry/telemetry.ts
+++ b/packages/bundler-plugin-core/src/sentry/telemetry.ts
@@ -94,14 +94,14 @@ export function addPluginOptionTags(options: InternalOptions, hub: Hub) {
     include: include.length > 1 ? "multiple-entries" : "single-entry",
     "clean-artifacts": cleanArtifacts,
     "finalize-release": finalize,
-    "deploy-release": deploy ? true : false,
+    "add-deploy": deploy ? true : false,
     "inject-releases-map": injectReleasesMap,
     "dry-run": dryRun,
     "error-handler": errorHandler ? "custom" : "none",
   });
 
   if (setCommits) {
-    hub.setTag("set-commits", setCommits.auto ? "auto" : "manual");
+    hub.setTag("set-commits", setCommits.auto === true ? "auto" : "manual");
   } else {
     hub.setTag("set-commits", false);
   }

--- a/packages/bundler-plugin-core/test/sentry/telemetry.test.ts
+++ b/packages/bundler-plugin-core/test/sentry/telemetry.test.ts
@@ -61,7 +61,6 @@ describe("captureMinimalError", () => {
 
 describe("addPluginOptionTags", () => {
   const mockedHub = {
-    setTags: jest.fn(),
     setTag: jest.fn(),
   };
 
@@ -75,18 +74,14 @@ describe("addPluginOptionTags", () => {
 
   it("should set include tag according to number of entries (single entry)", () => {
     addPluginOptionTags(defaultOptions as unknown as InternalOptions, mockedHub as unknown as Hub);
-    expect(mockedHub.setTags).toHaveBeenCalledWith(
-      expect.objectContaining({ include: "single-entry" })
-    );
+    expect(mockedHub.setTag).toHaveBeenCalledWith("include", "single-entry");
   });
   it("should set include tag according to number of entries (multiple entries)", () => {
     addPluginOptionTags(
       { include: [{}, {}, {}] } as unknown as InternalOptions,
       mockedHub as unknown as Hub
     );
-    expect(mockedHub.setTags).toHaveBeenCalledWith(
-      expect.objectContaining({ include: "multiple-entries" })
-    );
+    expect(mockedHub.setTag).toHaveBeenCalledWith("include", "multiple-entries");
   });
 
   it("should set deploy tag to true if the deploy option is specified", () => {
@@ -94,13 +89,7 @@ describe("addPluginOptionTags", () => {
       { ...defaultOptions, deploy: { env: "production" } } as unknown as InternalOptions,
       mockedHub as unknown as Hub
     );
-    expect(mockedHub.setTags).toHaveBeenCalledWith(expect.objectContaining({ "add-deploy": true }));
-  });
-  it("should set deploy tag to false if the deploy option is not specified", () => {
-    addPluginOptionTags(defaultOptions as unknown as InternalOptions, mockedHub as unknown as Hub);
-    expect(mockedHub.setTags).toHaveBeenCalledWith(
-      expect.objectContaining({ "add-deploy": false })
-    );
+    expect(mockedHub.setTag).toHaveBeenCalledWith("add-deploy", true);
   });
 
   it("should set errorHandler tag to `custom` if the errorHandler option is specified", () => {
@@ -109,19 +98,10 @@ describe("addPluginOptionTags", () => {
       { ...defaultOptions, errorHandler: () => {} } as unknown as InternalOptions,
       mockedHub as unknown as Hub
     );
-    expect(mockedHub.setTags).toHaveBeenCalledWith(
-      expect.objectContaining({ "error-handler": "custom" })
-    );
-  });
-  it("should set errorHandler tag to `none` if the errorHandler option is not specified", () => {
-    addPluginOptionTags(defaultOptions as unknown as InternalOptions, mockedHub as unknown as Hub);
-    expect(mockedHub.setTags).toHaveBeenCalledWith(
-      expect.objectContaining({ "error-handler": "none" })
-    );
+    expect(mockedHub.setTag).toHaveBeenCalledWith("error-handler", "custom");
   });
 
   it.each([
-    [false, undefined],
     ["auto", { auto: true }],
     ["manual", { repo: "", commit: "" }],
   ])(
@@ -147,13 +127,15 @@ describe("addPluginOptionTags", () => {
       mockedHub as unknown as Hub
     );
 
-    expect(mockedHub.setTags).toHaveBeenCalledWith(
-      expect.objectContaining({
-        "clean-artifacts": true,
-        "finalize-release": true,
-        "inject-releases-map": true,
-        "dry-run": true,
-      })
-    );
+    expect(mockedHub.setTag).toHaveBeenCalledWith("clean-artifacts", true);
+    expect(mockedHub.setTag).toHaveBeenCalledWith("finalize-release", true);
+    expect(mockedHub.setTag).toHaveBeenCalledWith("inject-releases-map", true);
+    expect(mockedHub.setTag).toHaveBeenCalledWith("dry-run", true);
+  });
+
+  it("shouldn't set any tags other than include if no opional options are specified", () => {
+    addPluginOptionTags(defaultOptions as unknown as InternalOptions, mockedHub as unknown as Hub);
+    expect(mockedHub.setTag).toHaveBeenCalledTimes(1);
+    expect(mockedHub.setTag).toHaveBeenCalledWith("include", "single-entry");
   });
 });


### PR DESCRIPTION
This PR adds a subset of our plugin options as tags to Sentry events. Obviously, we cannot send all options but we have to be careful to only send insensitive data, such as if an optional step (e.g. `deploy`) was selected or not. 

Going forward, we can use this data to evaluate which options are used and for debugging issues. 
As suggested by @AbhiPrasad we're sending this data as tags rather than context.

This PR also adds some tests (thanks GH copilot for the help)

ref #99 