### PR TITLE
docs: Add examples to individual READMEs

### DIFF
--- a/packages/esbuild-plugin/README.md
+++ b/packages/esbuild-plugin/README.md
@@ -15,7 +15,41 @@ A esbuild plugin that provides release management features for Sentry:
 - Automatic release name discovery (based on CI environment - Vercel, AWS, Heroku, CircleCI, or current Git SHA)
 - Automatically association of errors with releases (Release injection)
 
-### Configuration
+## Installation
+
+Using npm:
+
+```bash
+$ npm install @sentry/esbuild-plugin --save-dev
+```
+
+Using yarn:
+
+```bash
+$ yarn add @sentry/esbuild-plugin --dev
+```
+
+## Usage
+
+```js
+const sentryEsbuildPlugin = require("@sentry/esbuild-plugin");
+
+require("esbuild").build({
+  plugins: [
+    sentryEsbuildPlugin({
+      include: ".",
+      ignore: ["node_modules", "esbuild.config.js"],
+      org: process.env.SENTRY_ORG,
+      project: process.env.SENTRY_PROJECT,
+      authToken: process.env.SENTRY_AUTH_TOKEN,
+    }),
+  ],
+});
+```
+
+As an alternative to passing options explicitly, you can also use a `.sentryclirc` file or environment variables as described in https://docs.sentry.io/product/cli/configuration/.
+
+## Configuration
 
 Every plugin takes an options argument with the following properties:
 

--- a/packages/esbuild-plugin/README.md
+++ b/packages/esbuild-plugin/README.md
@@ -32,6 +32,7 @@ $ yarn add @sentry/esbuild-plugin --dev
 ## Usage
 
 ```js
+// esbuild.config.js
 const sentryEsbuildPlugin = require("@sentry/esbuild-plugin");
 
 require("esbuild").build({

--- a/packages/rollup-plugin/README.md
+++ b/packages/rollup-plugin/README.md
@@ -32,6 +32,7 @@ $ yarn add @sentry/rollup-plugin --dev
 ## Usage
 
 ```js
+// rollup.config.js
 import sentryRollupPlugin from "@sentry/rollup-plugin";
 
 export default {

--- a/packages/rollup-plugin/README.md
+++ b/packages/rollup-plugin/README.md
@@ -15,7 +15,41 @@ A Rollup plugin that provides release management features for Sentry:
 - Automatic release name discovery (based on CI environment - Vercel, AWS, Heroku, CircleCI, or current Git SHA)
 - Automatically association of errors with releases (Release injection)
 
-### Configuration
+## Installation
+
+Using npm:
+
+```bash
+$ npm install @sentry/rollup-plugin --save-dev
+```
+
+Using yarn:
+
+```bash
+$ yarn add @sentry/rollup-plugin --dev
+```
+
+## Usage
+
+```js
+import sentryRollupPlugin from "@sentry/rollup-plugin";
+
+export default {
+  plugins: [
+    sentryRollupPlugin({
+      include: ".",
+      ignore: ["node_modules", "rollup.config.js"],
+      org: process.env.SENTRY_ORG,
+      project: process.env.SENTRY_PROJECT,
+      authToken: process.env.SENTRY_AUTH_TOKEN,
+    }),
+  ],
+};
+```
+
+As an alternative to passing options explicitly, you can also use a `.sentryclirc` file or environment variables as described in https://docs.sentry.io/product/cli/configuration/.
+
+## Configuration
 
 Every plugin takes an options argument with the following properties:
 
@@ -34,7 +68,7 @@ Every plugin takes an options argument with the following properties:
 | cleanArtifacts | `boolean`                                                                                 | optional | Remove all existing artifacts in the Sentry release before uploading sourcemaps. Defaults to `false`.                                                                                                                                                                               |
 | errorHandler   | `function(err: Error): void`                                                              | optional | Function that is called when an error occurs during rlease creation or sourcemaps upload. When this function is provided, thrown errors will not cause the process to abort. If you still want to abort the process you can throw an error in the function.                         |
 
-### More information
+## More information
 
 - [Sentry Documentation](https://docs.sentry.io/quickstart/)
 - [Troubleshooting Sourcemaps](https://docs.sentry.io/platforms/javascript/sourcemaps/troubleshooting_js/)

--- a/packages/vite-plugin/README.md
+++ b/packages/vite-plugin/README.md
@@ -32,6 +32,7 @@ $ yarn add @sentry/vite-plugin --dev
 ## Usage
 
 ```ts
+// vite.config.ts
 import sentryVitePlugin from "@sentry/vite-plugin";
 
 export default {

--- a/packages/vite-plugin/README.md
+++ b/packages/vite-plugin/README.md
@@ -15,7 +15,41 @@ A Vite plugin that provides release management features for Sentry:
 - Automatic release name discovery (based on CI environment - Vercel, AWS, Heroku, CircleCI, or current Git SHA)
 - Automatically association of errors with releases (Release injection)
 
-### Configuration
+## Installation
+
+Using npm:
+
+```bash
+$ npm install @sentry/vite-plugin --save-dev
+```
+
+Using yarn:
+
+```bash
+$ yarn add @sentry/vite-plugin --dev
+```
+
+## Usage
+
+```ts
+import sentryVitePlugin from "@sentry/vite-plugin";
+
+export default {
+  plugins: [
+    sentryVitePlugin({
+      include: ".",
+      ignore: ["node_modules", "vite.config.ts"],
+      org: process.env.SENTRY_ORG,
+      project: process.env.SENTRY_PROJECT,
+      authToken: process.env.SENTRY_AUTH_TOKEN,
+    }),
+  ],
+};
+```
+
+As an alternative to passing options explicitly, you can also use a `.sentryclirc` file or environment variables as described in https://docs.sentry.io/product/cli/configuration/.
+
+## Configuration
 
 Every plugin takes an options argument with the following properties:
 
@@ -34,7 +68,7 @@ Every plugin takes an options argument with the following properties:
 | cleanArtifacts | `boolean`                                                                                 | optional | Remove all existing artifacts in the Sentry release before uploading sourcemaps. Defaults to `false`.                                                                                                                                                                               |
 | errorHandler   | `function(err: Error): void`                                                              | optional | Function that is called when an error occurs during rlease creation or sourcemaps upload. When this function is provided, thrown errors will not cause the process to abort. If you still want to abort the process you can throw an error in the function.                         |
 
-### More information
+## More information
 
 - [Sentry Documentation](https://docs.sentry.io/quickstart/)
 - [Troubleshooting Sourcemaps](https://docs.sentry.io/platforms/javascript/sourcemaps/troubleshooting_js/)

--- a/packages/webpack-plugin/README.md
+++ b/packages/webpack-plugin/README.md
@@ -32,6 +32,7 @@ $ yarn add @sentry/webpack-plugin --dev
 ## Usage
 
 ```js
+// webpack.config.js
 const sentryWebpackPlugin = require("@sentry/webpack-plugin");
 
 module.exports = {

--- a/packages/webpack-plugin/README.md
+++ b/packages/webpack-plugin/README.md
@@ -15,7 +15,41 @@ A Webpack plugin that provides release management features for Sentry:
 - Automatic release name discovery (based on CI environment - Vercel, AWS, Heroku, CircleCI, or current Git SHA)
 - Automatically association of errors with releases (Release injection)
 
-### Configuration
+## Installation
+
+Using npm:
+
+```bash
+$ npm install @sentry/webpack-plugin --save-dev
+```
+
+Using yarn:
+
+```bash
+$ yarn add @sentry/webpack-plugin --dev
+```
+
+## Usage
+
+```js
+const sentryWebpackPlugin = require("@sentry/webpack-plugin");
+
+module.exports = {
+  plugins: [
+    sentryWebpackPlugin({
+      include: ".",
+      ignore: ["node_modules", "webpack.config.js"],
+      org: process.env.SENTRY_ORG,
+      project: process.env.SENTRY_PROJECT,
+      authToken: process.env.SENTRY_AUTH_TOKEN,
+    }),
+  ],
+};
+```
+
+As an alternative to passing options explicitly, you can also use a `.sentryclirc` file or environment variables as described in https://docs.sentry.io/product/cli/configuration/.
+
+## Configuration
 
 Every plugin takes an options argument with the following properties:
 
@@ -34,7 +68,7 @@ Every plugin takes an options argument with the following properties:
 | cleanArtifacts | `boolean`                                                                                 | optional | Remove all existing artifacts in the Sentry release before uploading sourcemaps. Defaults to `false`.                                                                                                                                                                               |
 | errorHandler   | `function(err: Error): void`                                                              | optional | Function that is called when an error occurs during rlease creation or sourcemaps upload. When this function is provided, thrown errors will not cause the process to abort. If you still want to abort the process you can throw an error in the function.                         |
 
-### More information
+## More information
 
 - [Sentry Documentation](https://docs.sentry.io/quickstart/)
 - [Troubleshooting Sourcemaps](https://docs.sentry.io/platforms/javascript/sourcemaps/troubleshooting_js/)


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry-javascript-bundler-plugins/issues/114

Adds examples to the READMEs of the individual bundlers.