### PR TITLE
feat(core): Add node version tag

### DIFF
--- a/packages/bundler-plugin-core/src/sentry/telemetry.ts
+++ b/packages/bundler-plugin-core/src/sentry/telemetry.ts
@@ -116,4 +116,6 @@ export function addPluginOptionTags(options: InternalOptions, hub: Hub) {
   if (errorHandler) {
     hub.setTag("error-handler", "custom");
   }
+
+  hub.setTag("node", process.version);
 }

--- a/packages/bundler-plugin-core/test/sentry/telemetry.test.ts
+++ b/packages/bundler-plugin-core/test/sentry/telemetry.test.ts
@@ -135,7 +135,8 @@ describe("addPluginOptionTags", () => {
 
   it("shouldn't set any tags other than include if no opional options are specified", () => {
     addPluginOptionTags(defaultOptions as unknown as InternalOptions, mockedHub as unknown as Hub);
-    expect(mockedHub.setTag).toHaveBeenCalledTimes(1);
+    expect(mockedHub.setTag).toHaveBeenCalledTimes(2);
     expect(mockedHub.setTag).toHaveBeenCalledWith("include", "single-entry");
+    expect(mockedHub.setTag).toHaveBeenCalledWith("node", expect.any(String));
   });
 });


### PR DESCRIPTION
This tiny PR just adds another tag to Sentry events containing the used node version. This can help us with seeing in which node versions the plugins (and possibly their respective projects) are used.

ref #99