### PR TITLE
fix(core): Fix telemetry option logic

### DIFF
--- a/packages/bundler-plugin-core/src/index.ts
+++ b/packages/bundler-plugin-core/src/index.ts
@@ -11,6 +11,7 @@ import {
 } from "./sentry/releasePipeline";
 import "@sentry/tracing";
 import {
+  addPluginOptionInformationToHub,
   addSpanToTransaction,
   captureMinimalError,
   makeSentryClient,
@@ -63,10 +64,10 @@ const unplugin = createUnplugin<Options>((options, unpluginMetaContext) => {
 
   const { sentryHub, sentryClient } = makeSentryClient(
     "https://4c2bae7d9fbc413e8f7385f55c515d51@o1.ingest.sentry.io/6690737",
-    internalOptions,
-    unpluginMetaContext.framework,
     allowedToSendTelemetryPromise
   );
+
+  addPluginOptionInformationToHub(internalOptions, sentryHub, unpluginMetaContext.framework);
 
   //TODO: This call is problematic because as soon as we set our hub as the current hub
   //      we might interfere with other plugins that use Sentry. However, for now, we'll

--- a/packages/bundler-plugin-core/src/index.ts
+++ b/packages/bundler-plugin-core/src/index.ts
@@ -11,17 +11,16 @@ import {
 } from "./sentry/releasePipeline";
 import "@sentry/tracing";
 import {
-  addPluginOptionTags,
   addSpanToTransaction,
   captureMinimalError,
   makeSentryClient,
-  turnOffTelemetryForSelfHostedSentry,
+  shouldSendTelemetry,
 } from "./sentry/telemetry";
 import { Span, Transaction } from "@sentry/types";
 import { createLogger, Logger } from "./sentry/logger";
 import { InternalOptions, normalizeUserOptions, validateOptions } from "./options-mapping";
 import { getSentryCli } from "./sentry/cli";
-import { Hub } from "@sentry/node";
+import { Hub, makeMain } from "@sentry/node";
 
 // We prefix the polyfill id with \0 to tell other plugins not to try to load or transform it.
 // This hack is taken straight from https://rollupjs.org/guide/en/#resolveid.
@@ -60,11 +59,21 @@ const ALLOWED_TRANSFORMATION_FILE_ENDINGS = [".js", ".ts", ".jsx", ".tsx", ".cjs
 const unplugin = createUnplugin<Options>((options, unpluginMetaContext) => {
   const internalOptions = normalizeUserOptions(options);
 
-  const { hub: sentryHub } = makeSentryClient(
+  const allowedToSendTelemetryPromise = shouldSendTelemetry(internalOptions);
+
+  const { sentryHub, sentryClient } = makeSentryClient(
     "https://4c2bae7d9fbc413e8f7385f55c515d51@o1.ingest.sentry.io/6690737",
-    internalOptions.telemetry
+    internalOptions,
+    unpluginMetaContext.framework,
+    allowedToSendTelemetryPromise
   );
-  addPluginOptionTags(internalOptions, sentryHub);
+
+  //TODO: This call is problematic because as soon as we set our hub as the current hub
+  //      we might interfere with other plugins that use Sentry. However, for now, we'll
+  //      leave it in because without it, we can't get distributed traces (which are pretty nice)
+  //      Let's keep it until someone complains about interference.
+  //      The ideal solution would be a code change in the JS SDK but it's not a straight-forward fix.
+  makeMain(sentryHub);
 
   const logger = createLogger({
     hub: sentryHub,
@@ -83,18 +92,13 @@ const unplugin = createUnplugin<Options>((options, unpluginMetaContext) => {
 
   const cli = getSentryCli(internalOptions, logger);
 
-  if (internalOptions.telemetry) {
-    logger.info("Sending error and performance telemetry data to Sentry.");
-    logger.info("To disable telemetry, set `options.telemetry` to `false`.");
-  }
-
-  sentryHub.setTags({
-    organization: internalOptions.org,
-    project: internalOptions.project,
-    bundler: unpluginMetaContext.framework,
+  const releaseNamePromise = new Promise<string>((resolve) => {
+    if (options.release) {
+      resolve(options.release);
+    } else {
+      resolve(cli.releases.proposeVersion());
+    }
   });
-
-  sentryHub.setUser({ id: internalOptions.org });
 
   let transaction: Transaction | undefined;
   let releaseInjectionSpan: Span | undefined;
@@ -107,14 +111,18 @@ const unplugin = createUnplugin<Options>((options, unpluginMetaContext) => {
      * Responsible for starting the plugin execution transaction and the release injection span
      */
     async buildStart() {
-      await turnOffTelemetryForSelfHostedSentry(cli, sentryHub);
+      logger.debug("Called 'buildStart'");
 
-      if (!internalOptions.release) {
-        internalOptions.release = await cli.releases.proposeVersion();
+      const isAllowedToSendToSendTelemetry = await allowedToSendTelemetryPromise;
+      if (isAllowedToSendToSendTelemetry) {
+        logger.info("Sending error and performance telemetry data to Sentry.");
+        logger.info("To disable telemetry, set `options.telemetry` to `false`.");
       }
 
+      const releaseName = await releaseNamePromise;
+
       // At this point, we either have determined a release or we have to bail
-      if (!internalOptions.release) {
+      if (!releaseName) {
         handleError(
           new Error(
             "Unable to determine a release name. Make sure to set the `release` option or use an environment that supports auto-detection https://docs.sentry.io/cli/releases/#creating-releases`"
@@ -129,6 +137,7 @@ const unplugin = createUnplugin<Options>((options, unpluginMetaContext) => {
         op: "function.plugin",
         name: "Sentry Bundler Plugin execution",
       });
+
       releaseInjectionSpan = addSpanToTransaction(
         { hub: sentryHub, parentSpan: transaction, logger, cli },
         "function.plugin.inject_release",
@@ -148,11 +157,7 @@ const unplugin = createUnplugin<Options>((options, unpluginMetaContext) => {
      * @returns `"sentry-release-injector"` when the imported file is called `"sentry-release-injector"`. Otherwise returns `undefined`.
      */
     resolveId(id, importer, { isEntry }) {
-      sentryHub.addBreadcrumb({
-        category: "resolveId",
-        message: `isEntry: ${String(isEntry)}`,
-        level: "info",
-      });
+      logger.debug('Called "resolveId":', { id, importer, isEntry });
 
       if (id === RELEASE_INJECTOR_ID) {
         return RELEASE_INJECTOR_ID;
@@ -162,7 +167,7 @@ const unplugin = createUnplugin<Options>((options, unpluginMetaContext) => {
     },
 
     loadInclude(id) {
-      logger.info(`Called "loadInclude": ${JSON.stringify({ id })}`);
+      logger.debug('Called "loadInclude":', { id });
       return id === RELEASE_INJECTOR_ID;
     },
 
@@ -173,15 +178,12 @@ const unplugin = createUnplugin<Options>((options, unpluginMetaContext) => {
      * @param id Always the absolute (fully resolved) path to the module.
      * @returns The global injector code when we load the "sentry-release-injector" module. Otherwise returns `undefined`.
      */
-    load(id) {
-      sentryHub.addBreadcrumb({
-        category: "load",
-        level: "info",
-      });
+    async load(id) {
+      logger.debug('Called "load":', { id });
 
       if (id === RELEASE_INJECTOR_ID) {
         return generateGlobalInjectorCode({
-          release: internalOptions.release,
+          release: await releaseNamePromise,
           injectReleasesMap: internalOptions.injectReleasesMap,
           org: internalOptions.org,
           project: internalOptions.project,
@@ -200,10 +202,7 @@ const unplugin = createUnplugin<Options>((options, unpluginMetaContext) => {
      * want to transform the release injector file.
      */
     transformInclude(id) {
-      sentryHub.addBreadcrumb({
-        category: "transformInclude",
-        level: "info",
-      });
+      logger.debug('Called "transformInclude":', { id });
 
       // We don't want to transform our injected code.
       if (id === RELEASE_INJECTOR_ID) {
@@ -242,11 +241,8 @@ const unplugin = createUnplugin<Options>((options, unpluginMetaContext) => {
      * @param id Always the absolute (fully resolved) path to the module.
      * @returns transformed code + source map
      */
-    transform(code) {
-      sentryHub.addBreadcrumb({
-        category: "transform",
-        level: "info",
-      });
+    transform(code, id) {
+      logger.debug('Called "transform":', { id });
 
       // The MagicString library allows us to generate sourcemaps for the changes we make to the user code.
       const ms = new MagicString(code);
@@ -272,7 +268,9 @@ const unplugin = createUnplugin<Options>((options, unpluginMetaContext) => {
      * Responsible for executing the sentry release creation pipeline (i.e. creating a release on
      * Sentry.io, uploading sourcemaps, associating commits and deploys and finalizing the release)
      */
-    writeBundle() {
+    async writeBundle() {
+      logger.debug('Called "writeBundle"');
+
       releaseInjectionSpan?.finish();
       const releasePipelineSpan =
         transaction &&
@@ -289,45 +287,58 @@ const unplugin = createUnplugin<Options>((options, unpluginMetaContext) => {
 
       const ctx: BuildContext = { hub: sentryHub, parentSpan: releasePipelineSpan, logger, cli };
 
-      createNewRelease(internalOptions, ctx)
-        .then(() => cleanArtifacts(internalOptions, ctx))
-        .then(() => uploadSourceMaps(internalOptions, ctx))
-        .then(() => setCommits(internalOptions, ctx))
-        .then(() => finalizeRelease(internalOptions, ctx))
-        .then(() => addDeploy(internalOptions, ctx))
-        .then(() => transaction?.setStatus("ok"))
-        .catch((e: Error) => {
-          transaction?.setStatus("cancelled");
-          handleError(e, logger, internalOptions.errorHandler, sentryHub);
-        })
-        .finally(() => {
-          sentryHub.addBreadcrumb({
-            category: "writeBundle:finish",
-            level: "info",
-          });
-          releasePipelineSpan?.finish();
-          transaction?.finish();
+      const releaseName = await releaseNamePromise;
+
+      try {
+        await createNewRelease(internalOptions, ctx, releaseName);
+        await cleanArtifacts(internalOptions, ctx, releaseName);
+        await uploadSourceMaps(internalOptions, ctx, releaseName);
+        await setCommits(internalOptions, ctx, releaseName);
+        await finalizeRelease(internalOptions, ctx, releaseName);
+        await addDeploy(internalOptions, ctx, releaseName);
+        transaction?.setStatus("ok");
+      } catch (e: unknown) {
+        transaction?.setStatus("cancelled");
+        handleError(e, logger, internalOptions.errorHandler, sentryHub);
+      } finally {
+        sentryHub.addBreadcrumb({
+          category: "writeBundle:finish",
+          level: "info",
         });
+        releasePipelineSpan?.finish();
+        transaction?.finish();
+        await sentryClient.flush().then(null, () => {
+          logger.warn("Sending of telemetry failed");
+        });
+      }
     },
   };
 });
 
 function handleError(
-  error: Error,
+  unknownError: unknown,
   logger: Logger,
   errorHandler: InternalOptions["errorHandler"],
   sentryHub?: Hub
 ) {
-  logger.error(error.message);
+  if (unknownError instanceof Error) {
+    logger.error(unknownError.message);
+  } else {
+    logger.error(String(unknownError));
+  }
 
   if (sentryHub) {
-    captureMinimalError(error, sentryHub);
+    captureMinimalError(unknownError, sentryHub);
   }
 
   if (errorHandler) {
-    errorHandler(error);
+    if (unknownError instanceof Error) {
+      errorHandler(unknownError);
+    } else {
+      errorHandler(new Error("An unknown error occured"));
+    }
   } else {
-    throw error;
+    throw unknownError;
   }
 }
 

--- a/packages/bundler-plugin-core/src/options-mapping.ts
+++ b/packages/bundler-plugin-core/src/options-mapping.ts
@@ -5,7 +5,6 @@ import { arrayify } from "./utils";
 type RequiredInternalOptions = Required<
   Pick<
     UserOptions,
-    | "release"
     | "finalize"
     | "dryRun"
     | "debug"
@@ -113,12 +112,6 @@ export function normalizeUserOptions(userOptions: UserOptions): InternalOptions 
     errorHandler: userOptions.errorHandler,
     configFile: userOptions.configFile,
   };
-
-  // We only want to enable telemetry for SaaS users
-  // This is not the final check (we need to call Sentry CLI at a later point)
-  // but we can already at this point make a first decision.
-  // @see `turnOffTelemetryForSelfHostedSentry` (telemetry.ts) for the second check.
-  options.telemetry = options.telemetry && options.url === SENTRY_SAAS_URL;
 
   return options;
 }

--- a/packages/bundler-plugin-core/src/sentry/logger.ts
+++ b/packages/bundler-plugin-core/src/sentry/logger.ts
@@ -48,14 +48,12 @@ export function createLogger(options: LoggerOptions): Logger {
 
       addBreadcrumb("error", message);
     },
-
     debug(message: string, ...params: unknown[]) {
       if (!options.silent && options.debug) {
         // eslint-disable-next-line no-console
         console.log(`${options.prefix} Debug: ${message}`, ...params);
+        // We're not creating breadcrumbs for debug logs because it is super spammy
       }
-
-      addBreadcrumb("debug", message);
     },
   };
 }

--- a/packages/bundler-plugin-core/src/sentry/releasePipeline.ts
+++ b/packages/bundler-plugin-core/src/sentry/releasePipeline.ts
@@ -11,16 +11,24 @@ import { InternalOptions } from "../options-mapping";
 import { BuildContext } from "../types";
 import { addSpanToTransaction } from "./telemetry";
 
-export async function createNewRelease(options: InternalOptions, ctx: BuildContext): Promise<void> {
+export async function createNewRelease(
+  options: InternalOptions,
+  ctx: BuildContext,
+  releaseName: string
+): Promise<void> {
   const span = addSpanToTransaction(ctx, "function.plugin.create_release");
 
-  await ctx.cli.releases.new(options.release);
+  await ctx.cli.releases.new(releaseName);
 
   ctx.logger.info("Successfully created release.");
   span?.finish();
 }
 
-export async function cleanArtifacts(options: InternalOptions, ctx: BuildContext): Promise<void> {
+export async function cleanArtifacts(
+  options: InternalOptions,
+  ctx: BuildContext,
+  releaseName: string
+): Promise<void> {
   if (!options.cleanArtifacts) {
     logger.debug("Skipping artifact cleanup.");
     return;
@@ -28,25 +36,33 @@ export async function cleanArtifacts(options: InternalOptions, ctx: BuildContext
 
   const span = addSpanToTransaction(ctx, "function.plugin.clean_artifacts");
 
-  await ctx.cli.releases.execute(["releases", "files", options.release, "delete", "--all"], true);
+  await ctx.cli.releases.execute(["releases", "files", releaseName, "delete", "--all"], true);
 
   ctx.logger.info("Successfully cleaned previous artifacts.");
   span?.finish();
 }
 
-export async function uploadSourceMaps(options: InternalOptions, ctx: BuildContext): Promise<void> {
+export async function uploadSourceMaps(
+  options: InternalOptions,
+  ctx: BuildContext,
+  releaseName: string
+): Promise<void> {
   const span = addSpanToTransaction(ctx, "function.plugin.upload_sourcemaps");
   ctx.logger.info("Uploading Sourcemaps.");
 
   // Since our internal include entries contain all top-level sourcemaps options,
   // we only need to pass the include option here.
-  await ctx.cli.releases.uploadSourceMaps(options.release, { include: options.include });
+  await ctx.cli.releases.uploadSourceMaps(releaseName, { include: options.include });
 
   ctx.logger.info("Successfully uploaded Sourcemaps.");
   span?.finish();
 }
 
-export async function setCommits(options: InternalOptions, ctx: BuildContext): Promise<void> {
+export async function setCommits(
+  options: InternalOptions,
+  ctx: BuildContext,
+  releaseName: string
+): Promise<void> {
   if (!options.setCommits) {
     logger.debug("Skipping setting commits to release.");
     return;
@@ -55,7 +71,7 @@ export async function setCommits(options: InternalOptions, ctx: BuildContext): P
   const span = addSpanToTransaction(ctx, "function.plugin.set_commits");
 
   const { auto, repo, commit, previousCommit, ignoreMissing, ignoreEmpty } = options.setCommits;
-  await ctx.cli.releases.setCommits(options.release, {
+  await ctx.cli.releases.setCommits(releaseName, {
     commit,
     previousCommit,
     repo,
@@ -68,7 +84,11 @@ export async function setCommits(options: InternalOptions, ctx: BuildContext): P
   span?.finish();
 }
 
-export async function finalizeRelease(options: InternalOptions, ctx: BuildContext): Promise<void> {
+export async function finalizeRelease(
+  options: InternalOptions,
+  ctx: BuildContext,
+  releaseName: string
+): Promise<void> {
   if (!options.finalize) {
     logger.debug("Skipping release finalization.");
     return;
@@ -76,13 +96,17 @@ export async function finalizeRelease(options: InternalOptions, ctx: BuildContex
 
   const span = addSpanToTransaction(ctx, "function.plugin.finalize_release");
 
-  await ctx.cli.releases.finalize(options.release);
+  await ctx.cli.releases.finalize(releaseName);
 
   ctx.logger.info("Successfully finalized release.");
   span?.finish();
 }
 
-export async function addDeploy(options: InternalOptions, ctx: BuildContext): Promise<void> {
+export async function addDeploy(
+  options: InternalOptions,
+  ctx: BuildContext,
+  releaseName: string
+): Promise<void> {
   if (!options.deploy) {
     logger.debug("Skipping adding deploy info to release.");
     return;
@@ -91,7 +115,7 @@ export async function addDeploy(options: InternalOptions, ctx: BuildContext): Pr
   const span = addSpanToTransaction(ctx, "function.plugin.deploy");
 
   const { env, started, finished, time, name, url } = options.deploy;
-  await ctx.cli.releases.newDeploy(options.release, {
+  await ctx.cli.releases.newDeploy(releaseName, {
     env,
     started,
     finished,

--- a/packages/bundler-plugin-core/src/sentry/telemetry.ts
+++ b/packages/bundler-plugin-core/src/sentry/telemetry.ts
@@ -138,11 +138,15 @@ export function addPluginOptionInformationToHub(
 }
 
 export async function shouldSendTelemetry(options: InternalOptions): Promise<boolean> {
-  const { silent, org, project, authToken, url, vcsRemote, customHeader, dist, telemetry } =
+  const { silent, org, project, authToken, url, vcsRemote, customHeader, dist, telemetry, dryRun } =
     options;
 
   // `options.telemetry` defaults to true
   if (telemetry === false) {
+    return false;
+  }
+
+  if (dryRun) {
     return false;
   }
 

--- a/packages/bundler-plugin-core/src/sentry/telemetry.ts
+++ b/packages/bundler-plugin-core/src/sentry/telemetry.ts
@@ -1,45 +1,99 @@
-import {
-  defaultStackParser,
-  Hub,
-  Integrations,
-  makeMain,
-  makeNodeTransport,
-  NodeClient,
-  Span,
-} from "@sentry/node";
-import { InternalOptions, SENTRY_SAAS_URL } from "../options-mapping";
+import SentryCli from "@sentry/cli";
+import { defaultStackParser, Hub, makeNodeTransport, NodeClient, Span } from "@sentry/node";
+import { InternalOptions } from "../options-mapping";
 import { BuildContext } from "../types";
-import { SentryCLILike } from "./cli";
+
+const SENTRY_SAAS_HOSTNAME = "sentry.io";
 
 export function makeSentryClient(
   dsn: string,
-  telemetryEnabled: boolean
-): { client: NodeClient; hub: Hub } {
+  options: InternalOptions,
+  bundler: "rollup" | "webpack" | "vite" | "esbuild",
+  allowedToSendTelemetryPromise: Promise<boolean>
+): { sentryHub: Hub; sentryClient: NodeClient } {
+  const {
+    org,
+    project,
+    cleanArtifacts,
+    finalize,
+    setCommits,
+    injectReleasesMap,
+    dryRun,
+    errorHandler,
+    deploy,
+    include,
+  } = options;
+
   const client = new NodeClient({
     dsn,
 
-    enabled: telemetryEnabled,
-    tracesSampleRate: telemetryEnabled ? 1.0 : 0.0,
-    sampleRate: telemetryEnabled ? 1.0 : 0.0,
+    tracesSampleRate: 1,
+    sampleRate: 1,
 
     release: __PACKAGE_VERSION__,
-    integrations: [new Integrations.Http({ tracing: true })],
+    integrations: [],
     tracePropagationTargets: ["sentry.io/api"],
 
     stackParser: defaultStackParser,
-    transport: makeNodeTransport,
+
+    // We create a transport that stalls sending events until we know that we're allowed to (i.e. when Sentry CLI told
+    // us that the upload URL is the Sentry SaaS URL)
+    transport: (nodeTransportOptions) => {
+      const nodeTransport = makeNodeTransport(nodeTransportOptions);
+      return {
+        flush: (timeout) => nodeTransport.flush(timeout),
+        send: async (request) => {
+          const isAllowedToSend = await allowedToSendTelemetryPromise;
+          if (isAllowedToSend) {
+            return nodeTransport.send(request);
+          } else {
+            return undefined;
+          }
+        },
+      };
+    },
   });
 
   const hub = new Hub(client);
 
-  //TODO: This call is problematic because as soon as we set our hub as the current hub
-  //      we might interfere with other plugins that use Sentry. However, for now, we'll
-  //      leave it in because without it, we can't get distributed traces (which are pretty nice)
-  //      Let's keep it until someone complains about interference.
-  //      The ideal solution would be a code change in the JS SDK but it's not a straight-forward fix.
-  makeMain(hub);
+  hub.setTag("include", include.length > 1 ? "multiple-entries" : "single-entry");
 
-  return { client, hub };
+  // Optional release pipeline steps
+  if (cleanArtifacts) {
+    hub.setTag("clean-artifacts", true);
+  }
+  if (setCommits) {
+    hub.setTag("set-commits", setCommits.auto === true ? "auto" : "manual");
+  }
+  if (finalize) {
+    hub.setTag("finalize-release", true);
+  }
+  if (deploy) {
+    hub.setTag("add-deploy", true);
+  }
+
+  // Miscelaneous options
+  if (dryRun) {
+    hub.setTag("dry-run", true);
+  }
+  if (injectReleasesMap) {
+    hub.setTag("inject-releases-map", true);
+  }
+  if (errorHandler) {
+    hub.setTag("error-handler", "custom");
+  }
+
+  hub.setTag("node", process.version);
+
+  hub.setTags({
+    organization: org,
+    project,
+    bundler,
+  });
+
+  hub.setUser({ id: org });
+
+  return { sentryClient: client, sentryHub: hub };
 }
 
 /**
@@ -79,69 +133,44 @@ export function captureMinimalError(error: unknown | Error, hub: Hub) {
   hub.captureException(sentryError);
 }
 
-export function addPluginOptionTags(options: InternalOptions, hub: Hub) {
-  const {
-    cleanArtifacts,
-    finalize,
-    setCommits,
-    injectReleasesMap,
-    dryRun,
-    errorHandler,
-    deploy,
-    include,
-  } = options;
-
-  hub.setTag("include", include.length > 1 ? "multiple-entries" : "single-entry");
-
-  // Optional release pipeline steps
-  if (cleanArtifacts) {
-    hub.setTag("clean-artifacts", true);
-  }
-  if (setCommits) {
-    hub.setTag("set-commits", setCommits.auto === true ? "auto" : "manual");
-  }
-  if (finalize) {
-    hub.setTag("finalize-release", true);
-  }
-  if (deploy) {
-    hub.setTag("add-deploy", true);
+export async function shouldSendTelemetry(options: InternalOptions): Promise<boolean> {
+  if (!options.telemetry) {
+    return false;
   }
 
-  // Miscelaneous options
-  if (dryRun) {
-    hub.setTag("dry-run", true);
-  }
-  if (injectReleasesMap) {
-    hub.setTag("inject-releases-map", true);
-  }
-  if (errorHandler) {
-    hub.setTag("error-handler", "custom");
+  const { silent, org, project, authToken, url, vcsRemote, customHeader, dist } = options;
+  const cli = new SentryCli(options.configFile, {
+    url,
+    authToken,
+    org,
+    project,
+    vcsRemote,
+    dist,
+    silent,
+    customHeader,
+  });
+
+  let cliInfo;
+  try {
+    // Makes a call to SentryCLI to get the Sentry server URL the CLI uses.
+    // We need to check and decide to use telemetry based on the CLI's respone to this call
+    // because only at this time we checked a possibly existing .sentryclirc file. This file
+    // could point to another URL than the default URL.
+    cliInfo = await cli.execute(["info"], false);
+  } catch (e) {
+    throw new Error(
+      'Sentry CLI "info" command failed, make sure you have an auth token configured, your `url` option is correct, and the `url` option uses the https protocol.'
+    );
   }
 
-  hub.setTag("node", process.version);
-}
-
-/**
- * Makes a call to SentryCLI to get the Sentry server URL the CLI uses.
- *
- * We need to check and decide to use telemetry based on the CLI's respone to this call
- * because only at this time we checked a possibly existing .sentryclirc file. This file
- * could point to another URL than the default URL.
- */
-export async function turnOffTelemetryForSelfHostedSentry(cli: SentryCLILike, hub: Hub) {
-  const cliInfo = await cli.execute(["info"], false);
-
-  const url = cliInfo
-    ?.split(/(\r\n|\n|\r)/)[0]
+  const cliInfoUrl = cliInfo
+    .split(/(\r\n|\n|\r)/)[0]
     ?.replace(/^Sentry Server: /, "")
     ?.trim();
 
-  if (url !== SENTRY_SAAS_URL) {
-    const client = hub.getClient();
-    if (client) {
-      client.getOptions().enabled = false;
-      client.getOptions().tracesSampleRate = 0;
-      client.getOptions().sampleRate = 0;
-    }
+  if (cliInfoUrl === undefined) {
+    return false;
   }
+
+  return new URL(cliInfoUrl).hostname === SENTRY_SAAS_HOSTNAME;
 }

--- a/packages/bundler-plugin-core/test/option-mappings.test.ts
+++ b/packages/bundler-plugin-core/test/option-mappings.test.ts
@@ -118,23 +118,6 @@ describe("normalizeUserOptions()", () => {
       expect(normalizeUserOptions(options).telemetry).toBe(true);
     }
   );
-
-  test.each([
-    [true, "https://selfhostedSentry.io"],
-    [false, "https://sentry.io"],
-    [false, "https://selfhostedSentry.io"],
-  ])(
-    "should disable telemetry if `telemetry` is %s and Sentry SaaS URL (%s) is used",
-    (telemetry, url) => {
-      const options = {
-        include: "",
-        telemetry,
-        url,
-      };
-
-      expect(normalizeUserOptions(options).telemetry).toBe(false);
-    }
-  );
 });
 
 describe("validateOptions", () => {

--- a/packages/bundler-plugin-core/test/sentry/logger.test.ts
+++ b/packages/bundler-plugin-core/test/sentry/logger.test.ts
@@ -23,7 +23,6 @@ describe("Logger", () => {
     ["info", "Info"],
     ["warn", "Warning"],
     ["error", "Error"],
-    ["debug", "Debug"],
   ] as const)(".%s() should log correctly", (loggerMethod, logLevel) => {
     const prefix = "[some-prefix]";
     const logger = createLogger({ hub, prefix, silent: false, debug: true });
@@ -42,7 +41,6 @@ describe("Logger", () => {
     ["info", "Info"],
     ["warn", "Warning"],
     ["error", "Error"],
-    ["debug", "Debug"],
   ] as const)(".%s() should log multiple params correctly", (loggerMethod, logLevel) => {
     const prefix = "[some-prefix]";
     const logger = createLogger({ hub, prefix, silent: false, debug: true });
@@ -64,8 +62,35 @@ describe("Logger", () => {
     });
   });
 
+  it(".debug() should log correctly", () => {
+    const prefix = "[some-prefix]";
+    const logger = createLogger({ hub, prefix, silent: false, debug: true });
+
+    logger.debug("Hey!");
+
+    expect(consoleLogSpy).toHaveBeenCalledWith(`[some-prefix] Debug: Hey!`);
+    expect(mockedAddBreadcrumb).not.toHaveBeenCalled();
+  });
+
+  it(".debug() should log multiple params correctly", () => {
+    const prefix = "[some-prefix]";
+    const logger = createLogger({ hub, prefix, silent: false, debug: true });
+
+    logger.debug("Hey!", "this", "is", "a test with", 5, "params");
+
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      `[some-prefix] Debug: Hey!`,
+      "this",
+      "is",
+      "a test with",
+      5,
+      "params"
+    );
+    expect(mockedAddBreadcrumb).not.toHaveBeenCalled();
+  });
+
   describe("doesn't log when `silent` option is `true`", () => {
-    it.each(["info", "warn", "error", "debug"] as const)(".%s()", (loggerMethod) => {
+    it.each(["info", "warn", "error"] as const)(".%s()", (loggerMethod) => {
       const prefix = "[some-prefix]";
       const logger = createLogger({ hub, prefix, silent: true, debug: true });
 
@@ -79,5 +104,15 @@ describe("Logger", () => {
         message: "Hey!",
       });
     });
+  });
+
+  it(".debug() doesn't log when `silent` option is `true`", () => {
+    const prefix = "[some-prefix]";
+    const logger = createLogger({ hub, prefix, silent: true, debug: true });
+
+    logger.debug("Hey!");
+
+    expect(consoleLogSpy).not.toHaveBeenCalled();
+    expect(mockedAddBreadcrumb).not.toHaveBeenCalled();
   });
 });

--- a/packages/bundler-plugin-core/test/sentry/releasePipeline.test.ts
+++ b/packages/bundler-plugin-core/test/sentry/releasePipeline.test.ts
@@ -55,10 +55,7 @@ describe("Release Pipeline", () => {
 
   describe("createNewRelease", () => {
     it("makes a call to Sentry CLI's releases creation command", async () => {
-      await createNewRelease(
-        { release: "1.0.0" } as InternalOptions,
-        ctx as unknown as BuildContext
-      );
+      await createNewRelease({} as InternalOptions, ctx as unknown as BuildContext, "1.0.0");
 
       expect(mockedCLI.releases.new).toHaveBeenCalledWith("1.0.0");
       expect(mockedAddSpanToTxn).toHaveBeenCalledWith(ctx, "function.plugin.create_release");
@@ -68,7 +65,7 @@ describe("Release Pipeline", () => {
 
   describe("cleanArtifacts", () => {
     it("doest do anything if cleanArtifacts is not true", async () => {
-      await cleanArtifacts({} as InternalOptions, ctx as unknown as BuildContext);
+      await cleanArtifacts({} as InternalOptions, ctx as unknown as BuildContext, "my-release");
 
       expect(mockedCLI.releases.execute).not.toHaveBeenCalled();
       expect(mockedAddSpanToTxn).not.toHaveBeenCalled();
@@ -77,8 +74,9 @@ describe("Release Pipeline", () => {
 
     it("makes a call to Sentry CLI's artifact removal command if `cleanArtifacts` is set", async () => {
       await cleanArtifacts(
-        { release: "1.0.0", cleanArtifacts: true } as InternalOptions,
-        ctx as unknown as BuildContext
+        { cleanArtifacts: true } as InternalOptions,
+        ctx as unknown as BuildContext,
+        "1.0.0"
       );
 
       expect(mockedCLI.releases.execute).toHaveBeenCalledWith(
@@ -93,11 +91,10 @@ describe("Release Pipeline", () => {
   describe("uploadSourceMaps", () => {
     it("makes a call to Sentry CLI's sourcemaps upload command", async () => {
       const options = {
-        release: "1.0.0",
         include: [{ paths: ["dist"] }],
       } as InternalOptions;
 
-      await uploadSourceMaps(options, ctx as unknown as BuildContext);
+      await uploadSourceMaps(options, ctx as unknown as BuildContext, "1.0.0");
 
       expect(mockedCLI.releases.uploadSourceMaps).toHaveBeenCalledWith("1.0.0", {
         include: [{ paths: ["dist"] }],
@@ -109,7 +106,7 @@ describe("Release Pipeline", () => {
 
   describe("setCommits", () => {
     it("doesn't do anything if `setCommits` option is not specified", async () => {
-      await setCommits({} as InternalOptions, ctx as unknown as BuildContext);
+      await setCommits({} as InternalOptions, ctx as unknown as BuildContext, "1.0.0");
 
       expect(mockedCLI.releases.setCommits).not.toHaveBeenCalled();
       expect(mockedAddSpanToTxn).not.toHaveBeenCalled();
@@ -118,8 +115,9 @@ describe("Release Pipeline", () => {
 
     it("makes a call to Sentry CLI if the correct options are specified", async () => {
       await setCommits(
-        { setCommits: { auto: true }, release: "1.0.0" } as InternalOptions,
-        ctx as unknown as BuildContext
+        { setCommits: { auto: true } } as InternalOptions,
+        ctx as unknown as BuildContext,
+        "1.0.0"
       );
 
       expect(mockedCLI.releases.setCommits).toHaveBeenCalledWith("1.0.0", { auto: true });
@@ -130,7 +128,7 @@ describe("Release Pipeline", () => {
 
   describe("finalizeRelease", () => {
     it("doesn't do anything if `finalize` is not set", async () => {
-      await finalizeRelease({} as InternalOptions, ctx as unknown as BuildContext);
+      await finalizeRelease({} as InternalOptions, ctx as unknown as BuildContext, "1.0.0");
 
       expect(mockedCLI.releases.finalize).not.toHaveBeenCalled();
       expect(mockedAddSpanToTxn).not.toHaveBeenCalled();
@@ -139,8 +137,9 @@ describe("Release Pipeline", () => {
 
     it("makes a call to Sentry CLI's release finalization command if `finalize` is true", async () => {
       await finalizeRelease(
-        { release: "1.0.0", finalize: true } as InternalOptions,
-        ctx as unknown as BuildContext
+        { finalize: true } as InternalOptions,
+        ctx as unknown as BuildContext,
+        "1.0.0"
       );
 
       expect(mockedCLI.releases.finalize).toHaveBeenCalledWith("1.0.0");
@@ -151,7 +150,7 @@ describe("Release Pipeline", () => {
 
   describe("addDeploy", () => {
     it("doesn't do anything if `deploy` option is not specified", async () => {
-      await addDeploy({} as InternalOptions, ctx as unknown as BuildContext);
+      await addDeploy({} as InternalOptions, ctx as unknown as BuildContext, "1.0.0");
 
       expect(mockedCLI.releases.newDeploy).not.toHaveBeenCalled();
       expect(mockedAddSpanToTxn).not.toHaveBeenCalled();
@@ -168,8 +167,9 @@ describe("Release Pipeline", () => {
       };
 
       await addDeploy(
-        { deploy: deployOptions, release: "1.0.0" } as InternalOptions,
-        ctx as unknown as BuildContext
+        { deploy: deployOptions } as InternalOptions,
+        ctx as unknown as BuildContext,
+        "1.0.0"
       );
 
       expect(mockedCLI.releases.newDeploy).toHaveBeenCalledWith("1.0.0", deployOptions);


### PR DESCRIPTION
Fixes #129

- Introduces a custom transport that only sends telemetry events to our Sentry instance when Sentry CLI has determined that the target URL for the source maps is the Sentry SaaS URL. (this is due to PII reasons)
- Refactors usage of the telemetry option so we don't mutate it.
- Gets rid of manually mutating client options
- Reduces noise of log messages and breadcrumbs sent to our Sentry instance by not logging debug log statements - these are for our users to debug