### PR TITLE
docs: Remove WIP warning from READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,7 @@
   </a>
 </p>
 
-# Sentry Bundler Plugins (WIP)
-
-**WARNING: This project is work in progress! Do not yet use it in production. We're happy to receive your feedback!**
+# Sentry Bundler Plugins
 
 Universal Sentry plugin for various JavaScript bundlers. Based on [unjs/uplugin](https://github.com/unjs/unplugin). Currently supports Rollup, Vite, esbuild, Webpack 4 and Webpack 5.
 

--- a/packages/bundler-plugin-core/README.md
+++ b/packages/bundler-plugin-core/README.md
@@ -6,8 +6,6 @@
 
 # Sentry Bundler Plugin Core
 
-**WARNING: This package is work in progress! Do not yet use it in production. We're happy to receive your feedback!**
-
 Core package containing the bundler-agnostic functionality used by the bundler plugins.
 
 Check out the individual packages for more information and examples:

--- a/packages/esbuild-plugin/README.md
+++ b/packages/esbuild-plugin/README.md
@@ -4,9 +4,7 @@
   </a>
 </p>
 
-# Sentry Esbuild Plugin (WIP)
-
-**WARNING: This package is work in progress! Use with caution and do not yet use it in production. We're happy to receive your feedback!**
+# Sentry Esbuild Plugin
 
 A esbuild plugin that provides release management features for Sentry:
 

--- a/packages/rollup-plugin/README.md
+++ b/packages/rollup-plugin/README.md
@@ -6,8 +6,6 @@
 
 # Sentry Rollup Plugin
 
-**WARNING: This package is work in progress! Use with caution and do not yet use it in production. We're happy to receive your feedback!**
-
 A Rollup plugin that provides release management features for Sentry:
 
 - Sourcemap upload

--- a/packages/vite-plugin/README.md
+++ b/packages/vite-plugin/README.md
@@ -4,9 +4,7 @@
   </a>
 </p>
 
-# Sentry Vite Plugin (WIP)
-
-**WARNING: This package is work in progress! Use with caution and do not yet use it in production. We're happy to receive your feedback!**
+# Sentry Vite Plugin
 
 A Vite plugin that provides release management features for Sentry:
 

--- a/packages/webpack-plugin/README.md
+++ b/packages/webpack-plugin/README.md
@@ -4,9 +4,7 @@
   </a>
 </p>
 
-# Sentry Webpack Plugin (WIP)
-
-**WARNING: This package is work in progress! Use with caution and do not yet use it in production. We're happy to receive your feedback!**
+# Sentry Webpack Plugin
 
 A Webpack plugin that provides release management features for Sentry:
 


### PR DESCRIPTION
Ref: https://github.com/getsentry/sentry-javascript-bundler-plugins/issues/50

Removes the "Work in progress" warnings from the package READMEs as we are approaching the first proper release of the plugins.