### PR TITLE
ci(integration-tests): Add OS and Node.js version matrix

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -49,10 +49,17 @@ jobs:
   test-integration:
     needs: build
     name: Integration Tests
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ["10.24.1", "12.22.12", "14.21.1", "16.18.1", "18.12.1"]
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
       - uses: volta-cli/action@v3
+        with:
+          node-version: ${{ matrix.node-version }}
       - run: yarn --frozen-lockfile
       - run: yarn test:integration
 

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -52,7 +52,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ["10.24.1", "12.22.12", "14.21.1", "16.18.1", "18.12.1"]
+        node-version: [
+            # nx uses a `yargs-parser` versision which isn't compatible with node 10
+            # "10.24.1",
+            # vite uses optional chaining which isn't compatible with node 12
+            # "12.22.12",
+            "14.21.1",
+            "16.18.1",
+            "18.12.1",
+          ]
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
@@ -60,7 +68,6 @@ jobs:
       - uses: volta-cli/action@v3
         with:
           node-version: ${{ matrix.node-version }}
-      # nx uses fs-extra which needs node >= 12 - we can ignore because its a dev dependency
       # husky uses fs-extra which needs node >= 14 - we can ignore because its a dev dependency
       - run: yarn --frozen-lockfile --ignore-engines
       - run: yarn test:integration

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -55,9 +55,6 @@ jobs:
         node-version: ["10.24.1", "12.22.12", "14.21.1", "16.18.1", "18.12.1"]
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
-    env:
-      # Needed for webpack4 on Node.js >= 18
-      NODE_OPTIONS: "--openssl-legacy-provider"
     steps:
       - uses: actions/checkout@v3
       - uses: volta-cli/action@v3

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -55,6 +55,9 @@ jobs:
         node-version: ["10.24.1", "12.22.12", "14.21.1", "16.18.1", "18.12.1"]
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
+    env:
+      # Needed for webpack4 on Node.js >= 18
+      NODE_OPTIONS: "--openssl-legacy-provider"
     steps:
       - uses: actions/checkout@v3
       - uses: volta-cli/action@v3

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -60,7 +60,9 @@ jobs:
       - uses: volta-cli/action@v3
         with:
           node-version: ${{ matrix.node-version }}
-      - run: yarn --frozen-lockfile
+      # nx uses fs-extra which needs node >= 12 - we can ignore because its a dev dependency
+      # husky uses fs-extra which needs node >= 14 - we can ignore because its a dev dependency
+      - run: yarn --frozen-lockfile --ignore-engines
       - run: yarn test:integration
 
   test-e2e:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -48,7 +48,7 @@ jobs:
 
   test-integration:
     needs: build
-    name: "Test (Node ${{ matrix.node-version }}, OS ${{ matrix.os }})"
+    name: "Integration Tests (Node ${{ matrix.node-version }}, OS ${{ matrix.os }})"
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -48,7 +48,7 @@ jobs:
 
   test-integration:
     needs: build
-    name: Integration Tests
+    name: "Test (Node ${{ matrix.node-version }}, OS ${{ matrix.os }})"
     strategy:
       fail-fast: false
       matrix:

--- a/packages/bundler-plugin-core/src/index.ts
+++ b/packages/bundler-plugin-core/src/index.ts
@@ -220,7 +220,7 @@ const unplugin = createUnplugin<Options>((options, unpluginMetaContext) => {
           if (entry instanceof RegExp) {
             return entry.test(id);
           } else {
-            console.log("foobar", { id, entry });
+            console.log("foobar", { bundler: unpluginMetaContext.framework, id, entry });
             return id === entry;
           }
         });

--- a/packages/bundler-plugin-core/src/index.ts
+++ b/packages/bundler-plugin-core/src/index.ts
@@ -220,6 +220,7 @@ const unplugin = createUnplugin<Options>((options, unpluginMetaContext) => {
           if (entry instanceof RegExp) {
             return entry.test(id);
           } else {
+            console.log("foobar", { id, entry });
             return id === entry;
           }
         });

--- a/packages/bundler-plugin-core/src/index.ts
+++ b/packages/bundler-plugin-core/src/index.ts
@@ -22,6 +22,7 @@ import { createLogger, Logger } from "./sentry/logger";
 import { InternalOptions, normalizeUserOptions, validateOptions } from "./options-mapping";
 import { getSentryCli } from "./sentry/cli";
 import { Hub } from "@sentry/node";
+import path from "path";
 
 // We prefix the polyfill id with \0 to tell other plugins not to try to load or transform it.
 // This hack is taken straight from https://rollupjs.org/guide/en/#resolveid.
@@ -205,30 +206,34 @@ const unplugin = createUnplugin<Options>((options, unpluginMetaContext) => {
         level: "info",
       });
 
+      // We normalize the id because vite always passes `id` as a unix style path which causes problems when a user passes
+      // a windows style path to `releaseInjectionTargets`
+      const normalizedId = path.normalize(id);
+
       // We don't want to transform our injected code.
-      if (id === RELEASE_INJECTOR_ID) {
+      if (normalizedId === RELEASE_INJECTOR_ID) {
         return false;
       }
 
       if (internalOptions.releaseInjectionTargets) {
         // If there's an `releaseInjectionTargets` option transform (ie. inject the release varible) when the file path matches the option.
         if (typeof internalOptions.releaseInjectionTargets === "function") {
-          return internalOptions.releaseInjectionTargets(id);
+          return internalOptions.releaseInjectionTargets(normalizedId);
         }
 
         return internalOptions.releaseInjectionTargets.some((entry) => {
           if (entry instanceof RegExp) {
-            return entry.test(id);
+            return entry.test(normalizedId);
           } else {
-            console.log("foobar", { bundler: unpluginMetaContext.framework, id, entry });
-            return id === entry;
+            const normalizedEntry = path.normalize(entry);
+            return normalizedId === normalizedEntry;
           }
         });
       } else {
-        const pathIsOrdinary = !id.includes("?") && !id.includes("#");
+        const pathIsOrdinary = !normalizedId.includes("?") && !normalizedId.includes("#");
 
         const pathHasAllowedFileEnding = ALLOWED_TRANSFORMATION_FILE_ENDINGS.some(
-          (allowedFileEnding) => id.endsWith(allowedFileEnding)
+          (allowedFileEnding) => normalizedId.endsWith(allowedFileEnding)
         );
 
         return pathIsOrdinary && pathHasAllowedFileEnding;

--- a/packages/e2e-tests/scenarios/basic-upload/config.ts
+++ b/packages/e2e-tests/scenarios/basic-upload/config.ts
@@ -6,7 +6,7 @@ import * as path from "path";
  */
 export const pluginConfig: Options = {
   release: "basic-upload",
-  include: path.resolve(__dirname, "./out"),
+  include: path.resolve(__dirname, "out"),
   authToken: process.env["SENTRY_AUTH_TOKEN"] || "",
   org: "sentry-sdks",
   project: "js-bundler-plugin-e2e-tests",

--- a/packages/e2e-tests/scenarios/basic-upload/setup.ts
+++ b/packages/e2e-tests/scenarios/basic-upload/setup.ts
@@ -6,8 +6,8 @@ import { createCjsBundles } from "../../utils/create-cjs-bundles";
 
 deleteAllReleases(pluginConfig.release || "")
   .then(() => {
-    const entryPointPath = path.resolve(__dirname, "./input/index.js");
-    const outputDir = path.resolve(__dirname, "./out");
+    const entryPointPath = path.resolve(__dirname, "input", "index.js");
+    const outputDir = path.resolve(__dirname, "out");
 
     createCjsBundles({ index: entryPointPath }, outputDir, pluginConfig);
   })

--- a/packages/e2e-tests/scripts/run-scenario-setups.ts
+++ b/packages/e2e-tests/scripts/run-scenario-setups.ts
@@ -2,8 +2,8 @@ import fs from "fs";
 import path from "path";
 
 const scenarioPaths = fs
-  .readdirSync(path.join(__dirname, "../scenarios"))
-  .map((fixtureDir) => path.join(__dirname, "../scenarios", fixtureDir));
+  .readdirSync(path.join(__dirname, "..", "scenarios"))
+  .map((fixtureDir) => path.join(__dirname, "..", "scenarios", fixtureDir));
 
 scenarioPaths.forEach((fixturePath) => {
   require(path.join(fixturePath, "setup.ts"));

--- a/packages/integration-tests/fixtures/array-entries-option/array-entries-option.test.ts
+++ b/packages/integration-tests/fixtures/array-entries-option/array-entries-option.test.ts
@@ -12,67 +12,67 @@ function getFileContents(bundlePath: string): string {
 
 describe("`releaseInjectionTargets` option should work as expected when given an array of RegEx and strings", () => {
   test("esbuild bundle", () => {
-    expect(getBundleOutput(path.join(__dirname, "./out/esbuild/entrypoint1.js"))).toBe(
+    expect(getBundleOutput(path.join(__dirname, "out", "esbuild", "entrypoint1.js"))).toBe(
       "I AM A RELEASE!"
     );
-    expect(getBundleOutput(path.join(__dirname, "./out/esbuild/entrypoint2.js"))).toBe("");
-    expect(getBundleOutput(path.join(__dirname, "./out/esbuild/entrypoint3.js"))).toBe(
+    expect(getBundleOutput(path.join(__dirname, "out", "esbuild", "entrypoint2.js"))).toBe("");
+    expect(getBundleOutput(path.join(__dirname, "out", "esbuild", "entrypoint3.js"))).toBe(
       "I AM A RELEASE!"
     );
-    expect(getFileContents(path.join(__dirname, "./out/esbuild/entrypoint2.js"))).not.toContain(
+    expect(getFileContents(path.join(__dirname, "out", "esbuild", "entrypoint2.js"))).not.toContain(
       "I AM A RELEASE!"
     );
   });
 
   test("rollup bundle", () => {
-    expect(getBundleOutput(path.join(__dirname, "./out/rollup/entrypoint1.js"))).toBe(
+    expect(getBundleOutput(path.join(__dirname, "out", "rollup", "entrypoint1.js"))).toBe(
       "I AM A RELEASE!"
     );
-    expect(getBundleOutput(path.join(__dirname, "./out/rollup/entrypoint2.js"))).toBe("");
-    expect(getBundleOutput(path.join(__dirname, "./out/rollup/entrypoint3.js"))).toBe(
+    expect(getBundleOutput(path.join(__dirname, "out", "rollup", "entrypoint2.js"))).toBe("");
+    expect(getBundleOutput(path.join(__dirname, "out", "rollup", "entrypoint3.js"))).toBe(
       "I AM A RELEASE!"
     );
-    expect(getFileContents(path.join(__dirname, "./out/rollup/entrypoint2.js"))).not.toContain(
+    expect(getFileContents(path.join(__dirname, "out", "rollup", "entrypoint2.js"))).not.toContain(
       "I AM A RELEASE!"
     );
   });
 
   test("vite bundle", () => {
-    expect(getBundleOutput(path.join(__dirname, "./out/vite/entrypoint1.js"))).toBe(
+    expect(getBundleOutput(path.join(__dirname, "out", "vite", "entrypoint1.js"))).toBe(
       "I AM A RELEASE!"
     );
-    expect(getBundleOutput(path.join(__dirname, "./out/vite/entrypoint2.js"))).toBe("");
-    expect(getBundleOutput(path.join(__dirname, "./out/vite/entrypoint3.js"))).toBe(
+    expect(getBundleOutput(path.join(__dirname, "out", "vite", "entrypoint2.js"))).toBe("");
+    expect(getBundleOutput(path.join(__dirname, "out", "vite", "entrypoint3.js"))).toBe(
       "I AM A RELEASE!"
     );
-    expect(getFileContents(path.join(__dirname, "./out/vite/entrypoint2.js"))).not.toContain(
+    expect(getFileContents(path.join(__dirname, "out", "vite", "entrypoint2.js"))).not.toContain(
       "I AM A RELEASE!"
     );
   });
 
   test("webpack 4 bundle", () => {
-    expect(getBundleOutput(path.join(__dirname, "./out/webpack4/entrypoint1.js"))).toBe(
+    expect(getBundleOutput(path.join(__dirname, "out", "webpack4", "entrypoint1.js"))).toBe(
       "I AM A RELEASE!"
     );
-    expect(getBundleOutput(path.join(__dirname, "./out/webpack4/entrypoint2.js"))).toBe("");
-    expect(getBundleOutput(path.join(__dirname, "./out/webpack4/entrypoint3.js"))).toBe(
+    expect(getBundleOutput(path.join(__dirname, "out", "webpack4", "entrypoint2.js"))).toBe("");
+    expect(getBundleOutput(path.join(__dirname, "out", "webpack4", "entrypoint3.js"))).toBe(
       "I AM A RELEASE!"
     );
-    expect(getFileContents(path.join(__dirname, "./out/webpack4/entrypoint2.js"))).not.toContain(
-      "I AM A RELEASE!"
-    );
+    expect(
+      getFileContents(path.join(__dirname, "out", "webpack4", "entrypoint2.js"))
+    ).not.toContain("I AM A RELEASE!");
   });
 
   test("webpack 5 bundle", () => {
-    expect(getBundleOutput(path.join(__dirname, "./out/webpack5/entrypoint1.js"))).toBe(
+    expect(getBundleOutput(path.join(__dirname, "out", "webpack5", "entrypoint1.js"))).toBe(
       "I AM A RELEASE!"
     );
-    expect(getBundleOutput(path.join(__dirname, "./out/webpack5/entrypoint2.js"))).toBe("");
-    expect(getBundleOutput(path.join(__dirname, "./out/webpack5/entrypoint3.js"))).toBe(
+    expect(getBundleOutput(path.join(__dirname, "out", "webpack5", "entrypoint2.js"))).toBe("");
+    expect(getBundleOutput(path.join(__dirname, "out", "webpack5", "entrypoint3.js"))).toBe(
       "I AM A RELEASE!"
     );
-    expect(getFileContents(path.join(__dirname, "./out/webpack5/entrypoint2.js"))).not.toContain(
-      "I AM A RELEASE!"
-    );
+    expect(
+      getFileContents(path.join(__dirname, "out", "webpack5", "entrypoint2.js"))
+    ).not.toContain("I AM A RELEASE!");
   });
 });

--- a/packages/integration-tests/fixtures/array-entries-option/array-entries-option.test.ts
+++ b/packages/integration-tests/fixtures/array-entries-option/array-entries-option.test.ts
@@ -1,10 +1,7 @@
 import childProcess from "child_process";
 import path from "path";
 import fs from "fs";
-import {
-  testIfNodeMajorVersionIsGreaterOrEqual14,
-  testIfNodeMajorVersionIsLessThan18,
-} from "../../utils/testIf";
+import { testIfNodeMajorVersionIsLessThan18 } from "../../utils/testIf";
 
 function getBundleOutput(bundlePath: string): string {
   return childProcess.execSync(`node ${bundlePath}`, { encoding: "utf-8" });
@@ -41,18 +38,14 @@ describe("`releaseInjectionTargets` option should work as expected when given an
     );
   });
 
-  testIfNodeMajorVersionIsGreaterOrEqual14("vite bundle", () => {
-    // eslint-disable-next-line jest/no-standalone-expect
+  test("vite bundle", () => {
     expect(getBundleOutput(path.join(__dirname, "out", "vite", "entrypoint1.js"))).toBe(
       "I AM A RELEASE!"
     );
-    // eslint-disable-next-line jest/no-standalone-expect
     expect(getBundleOutput(path.join(__dirname, "out", "vite", "entrypoint2.js"))).toBe("");
-    // eslint-disable-next-line jest/no-standalone-expect
     expect(getBundleOutput(path.join(__dirname, "out", "vite", "entrypoint3.js"))).toBe(
       "I AM A RELEASE!"
     );
-    // eslint-disable-next-line jest/no-standalone-expect
     expect(getFileContents(path.join(__dirname, "out", "vite", "entrypoint2.js"))).not.toContain(
       "I AM A RELEASE!"
     );

--- a/packages/integration-tests/fixtures/array-entries-option/array-entries-option.test.ts
+++ b/packages/integration-tests/fixtures/array-entries-option/array-entries-option.test.ts
@@ -17,6 +17,10 @@ describe("`releaseInjectionTargets` option should work as expected when given an
       "I AM A RELEASE!"
     );
     expect(getBundleOutput(path.join(__dirname, "out", "esbuild", "entrypoint2.js"))).toBe("");
+    console.log(
+      "bündle",
+      fs.readFileSync(path.join(__dirname, "out", "esbuild", "entrypoint3.js"), "utf-8")
+    );
     expect(getBundleOutput(path.join(__dirname, "out", "esbuild", "entrypoint3.js"))).toBe(
       "I AM A RELEASE!"
     );

--- a/packages/integration-tests/fixtures/array-entries-option/array-entries-option.test.ts
+++ b/packages/integration-tests/fixtures/array-entries-option/array-entries-option.test.ts
@@ -1,6 +1,7 @@
 import childProcess from "child_process";
 import path from "path";
 import fs from "fs";
+import { testIfNodeMajorVersionIsLessThan18 } from "../../utils/testIf";
 
 function getBundleOutput(bundlePath: string): string {
   return childProcess.execSync(`node ${bundlePath}`, { encoding: "utf-8" });
@@ -50,14 +51,18 @@ describe("`releaseInjectionTargets` option should work as expected when given an
     );
   });
 
-  test("webpack 4 bundle", () => {
+  testIfNodeMajorVersionIsLessThan18("webpack 4 bundle", () => {
+    // eslint-disable-next-line jest/no-standalone-expect
     expect(getBundleOutput(path.join(__dirname, "out", "webpack4", "entrypoint1.js"))).toBe(
       "I AM A RELEASE!"
     );
+    // eslint-disable-next-line jest/no-standalone-expect
     expect(getBundleOutput(path.join(__dirname, "out", "webpack4", "entrypoint2.js"))).toBe("");
+    // eslint-disable-next-line jest/no-standalone-expect
     expect(getBundleOutput(path.join(__dirname, "out", "webpack4", "entrypoint3.js"))).toBe(
       "I AM A RELEASE!"
     );
+    // eslint-disable-next-line jest/no-standalone-expect
     expect(
       getFileContents(path.join(__dirname, "out", "webpack4", "entrypoint2.js"))
     ).not.toContain("I AM A RELEASE!");

--- a/packages/integration-tests/fixtures/array-entries-option/array-entries-option.test.ts
+++ b/packages/integration-tests/fixtures/array-entries-option/array-entries-option.test.ts
@@ -17,10 +17,6 @@ describe("`releaseInjectionTargets` option should work as expected when given an
       "I AM A RELEASE!"
     );
     expect(getBundleOutput(path.join(__dirname, "out", "esbuild", "entrypoint2.js"))).toBe("");
-    console.log(
-      "bündle",
-      fs.readFileSync(path.join(__dirname, "out", "esbuild", "entrypoint3.js"), "utf-8")
-    );
     expect(getBundleOutput(path.join(__dirname, "out", "esbuild", "entrypoint3.js"))).toBe(
       "I AM A RELEASE!"
     );
@@ -47,6 +43,10 @@ describe("`releaseInjectionTargets` option should work as expected when given an
       "I AM A RELEASE!"
     );
     expect(getBundleOutput(path.join(__dirname, "out", "vite", "entrypoint2.js"))).toBe("");
+    console.log(
+      "bündle",
+      fs.readFileSync(path.join(__dirname, "out", "vite", "entrypoint3.js"), "utf-8")
+    );
     expect(getBundleOutput(path.join(__dirname, "out", "vite", "entrypoint3.js"))).toBe(
       "I AM A RELEASE!"
     );

--- a/packages/integration-tests/fixtures/array-entries-option/array-entries-option.test.ts
+++ b/packages/integration-tests/fixtures/array-entries-option/array-entries-option.test.ts
@@ -1,7 +1,10 @@
 import childProcess from "child_process";
 import path from "path";
 import fs from "fs";
-import { testIfNodeMajorVersionIsLessThan18 } from "../../utils/testIf";
+import {
+  testIfNodeMajorVersionIsGreaterOrEqual14,
+  testIfNodeMajorVersionIsLessThan18,
+} from "../../utils/testIf";
 
 function getBundleOutput(bundlePath: string): string {
   return childProcess.execSync(`node ${bundlePath}`, { encoding: "utf-8" });
@@ -38,14 +41,18 @@ describe("`releaseInjectionTargets` option should work as expected when given an
     );
   });
 
-  test("vite bundle", () => {
+  testIfNodeMajorVersionIsGreaterOrEqual14("vite bundle", () => {
+    // eslint-disable-next-line jest/no-standalone-expect
     expect(getBundleOutput(path.join(__dirname, "out", "vite", "entrypoint1.js"))).toBe(
       "I AM A RELEASE!"
     );
+    // eslint-disable-next-line jest/no-standalone-expect
     expect(getBundleOutput(path.join(__dirname, "out", "vite", "entrypoint2.js"))).toBe("");
+    // eslint-disable-next-line jest/no-standalone-expect
     expect(getBundleOutput(path.join(__dirname, "out", "vite", "entrypoint3.js"))).toBe(
       "I AM A RELEASE!"
     );
+    // eslint-disable-next-line jest/no-standalone-expect
     expect(getFileContents(path.join(__dirname, "out", "vite", "entrypoint2.js"))).not.toContain(
       "I AM A RELEASE!"
     );

--- a/packages/integration-tests/fixtures/array-entries-option/array-entries-option.test.ts
+++ b/packages/integration-tests/fixtures/array-entries-option/array-entries-option.test.ts
@@ -43,10 +43,6 @@ describe("`releaseInjectionTargets` option should work as expected when given an
       "I AM A RELEASE!"
     );
     expect(getBundleOutput(path.join(__dirname, "out", "vite", "entrypoint2.js"))).toBe("");
-    console.log(
-      "bündle",
-      fs.readFileSync(path.join(__dirname, "out", "vite", "entrypoint3.js"), "utf-8")
-    );
     expect(getBundleOutput(path.join(__dirname, "out", "vite", "entrypoint3.js"))).toBe(
       "I AM A RELEASE!"
     );

--- a/packages/integration-tests/fixtures/array-entries-option/setup.ts
+++ b/packages/integration-tests/fixtures/array-entries-option/setup.ts
@@ -2,10 +2,10 @@ import { Options } from "@sentry/bundler-plugin-core";
 import * as path from "path";
 import { createCjsBundles } from "../../utils/create-cjs-bundles";
 
-const entryPoint1Path = path.resolve(__dirname, "./input/entrypoint1.js");
-const entryPoint2Path = path.resolve(__dirname, "./input/entrypoint2.js");
-const entryPoint3Path = path.resolve(__dirname, "./input/entrypoint3.js");
-const outputDir = path.resolve(__dirname, "./out");
+const entryPoint1Path = path.resolve(__dirname, "input", "entrypoint1.js");
+const entryPoint2Path = path.resolve(__dirname, "input", "entrypoint2.js");
+const entryPoint3Path = path.resolve(__dirname, "input", "entrypoint3.js");
+const outputDir = path.resolve(__dirname, "out");
 
 createCjsBundles(
   { entrypoint1: entryPoint1Path, entrypoint2: entryPoint2Path, entrypoint3: entryPoint3Path },

--- a/packages/integration-tests/fixtures/basic-release-injection/basic-release-injection.test.ts
+++ b/packages/integration-tests/fixtures/basic-release-injection/basic-release-injection.test.ts
@@ -1,5 +1,6 @@
 import childProcess from "child_process";
 import path from "path";
+import { testIfNodeMajorVersionIsLessThan18 } from "../../utils/testIf";
 
 /**
  * Runs a node file in a seprate process.
@@ -27,7 +28,7 @@ test("vite bundle", () => {
   checkBundle(path.join(__dirname, "./out/vite/index.js"));
 });
 
-test("webpack 4 bundle", () => {
+testIfNodeMajorVersionIsLessThan18("webpack 4 bundle", () => {
   expect.assertions(1);
   checkBundle(path.join(__dirname, "./out/webpack4/index.js"));
 });

--- a/packages/integration-tests/fixtures/basic-release-injection/basic-release-injection.test.ts
+++ b/packages/integration-tests/fixtures/basic-release-injection/basic-release-injection.test.ts
@@ -1,6 +1,9 @@
 import childProcess from "child_process";
 import path from "path";
-import { testIfNodeMajorVersionIsLessThan18 } from "../../utils/testIf";
+import {
+  testIfNodeMajorVersionIsGreaterOrEqual14,
+  testIfNodeMajorVersionIsLessThan18,
+} from "../../utils/testIf";
 
 /**
  * Runs a node file in a seprate process.
@@ -23,7 +26,7 @@ test("rollup bundle", () => {
   checkBundle(path.join(__dirname, "./out/rollup/index.js"));
 });
 
-test("vite bundle", () => {
+testIfNodeMajorVersionIsGreaterOrEqual14("vite bundle", () => {
   expect.assertions(1);
   checkBundle(path.join(__dirname, "./out/vite/index.js"));
 });

--- a/packages/integration-tests/fixtures/basic-release-injection/basic-release-injection.test.ts
+++ b/packages/integration-tests/fixtures/basic-release-injection/basic-release-injection.test.ts
@@ -1,9 +1,6 @@
 import childProcess from "child_process";
 import path from "path";
-import {
-  testIfNodeMajorVersionIsGreaterOrEqual14,
-  testIfNodeMajorVersionIsLessThan18,
-} from "../../utils/testIf";
+import { testIfNodeMajorVersionIsLessThan18 } from "../../utils/testIf";
 
 /**
  * Runs a node file in a seprate process.
@@ -26,7 +23,7 @@ test("rollup bundle", () => {
   checkBundle(path.join(__dirname, "./out/rollup/index.js"));
 });
 
-testIfNodeMajorVersionIsGreaterOrEqual14("vite bundle", () => {
+test("vite bundle", () => {
   expect.assertions(1);
   checkBundle(path.join(__dirname, "./out/vite/index.js"));
 });

--- a/packages/integration-tests/fixtures/basic-release-injection/setup.ts
+++ b/packages/integration-tests/fixtures/basic-release-injection/setup.ts
@@ -2,8 +2,8 @@ import { Options } from "@sentry/bundler-plugin-core";
 import * as path from "path";
 import { createCjsBundles } from "../../utils/create-cjs-bundles";
 
-const entryPointPath = path.resolve(__dirname, "./input/entrypoint.js");
-const outputDir = path.resolve(__dirname, "./out");
+const entryPointPath = path.resolve(__dirname, "input", "entrypoint.js");
+const outputDir = path.resolve(__dirname, "out");
 
 createCjsBundles({ index: entryPointPath }, outputDir, {
   release: "I AM A RELEASE!",

--- a/packages/integration-tests/fixtures/function-entries-option/function-entries-option.test.ts
+++ b/packages/integration-tests/fixtures/function-entries-option/function-entries-option.test.ts
@@ -1,7 +1,10 @@
 import childProcess from "child_process";
 import path from "path";
 import fs from "fs";
-import { testIfNodeMajorVersionIsLessThan18 } from "../../utils/testIf";
+import {
+  testIfNodeMajorVersionIsGreaterOrEqual14,
+  testIfNodeMajorVersionIsLessThan18,
+} from "../../utils/testIf";
 
 function getBundleOutput(bundlePath: string): string {
   return childProcess.execSync(`node ${bundlePath}`, { encoding: "utf-8" });
@@ -38,14 +41,18 @@ describe("`releaseInjectionTargets` option should work as expected when given a 
     );
   });
 
-  test("vite bundle", () => {
+  testIfNodeMajorVersionIsGreaterOrEqual14("vite bundle", () => {
+    // eslint-disable-next-line jest/no-standalone-expect
     expect(getBundleOutput(path.join(__dirname, "out", "vite", "entrypoint1.js"))).toBe(
       "I AM A RELEASE!"
     );
+    // eslint-disable-next-line jest/no-standalone-expect
     expect(getBundleOutput(path.join(__dirname, "out", "vite", "entrypoint2.js"))).toBe("");
+    // eslint-disable-next-line jest/no-standalone-expect
     expect(getBundleOutput(path.join(__dirname, "out", "vite", "entrypoint3.js"))).toBe(
       "I AM A RELEASE!"
     );
+    // eslint-disable-next-line jest/no-standalone-expect
     expect(getFileContents(path.join(__dirname, "out", "vite", "entrypoint2.js"))).not.toContain(
       "I AM A RELEASE!"
     );

--- a/packages/integration-tests/fixtures/function-entries-option/function-entries-option.test.ts
+++ b/packages/integration-tests/fixtures/function-entries-option/function-entries-option.test.ts
@@ -1,6 +1,7 @@
 import childProcess from "child_process";
 import path from "path";
 import fs from "fs";
+import { testIfNodeMajorVersionIsLessThan18 } from "../../utils/testIf";
 
 function getBundleOutput(bundlePath: string): string {
   return childProcess.execSync(`node ${bundlePath}`, { encoding: "utf-8" });
@@ -50,14 +51,18 @@ describe("`releaseInjectionTargets` option should work as expected when given a 
     );
   });
 
-  test("webpack 4 bundle", () => {
+  testIfNodeMajorVersionIsLessThan18("webpack 4 bundle", () => {
+    // eslint-disable-next-line jest/no-standalone-expect
     expect(getBundleOutput(path.join(__dirname, "out", "webpack4", "entrypoint1.js"))).toBe(
       "I AM A RELEASE!"
     );
+    // eslint-disable-next-line jest/no-standalone-expect
     expect(getBundleOutput(path.join(__dirname, "out", "webpack4", "entrypoint2.js"))).toBe("");
+    // eslint-disable-next-line jest/no-standalone-expect
     expect(getBundleOutput(path.join(__dirname, "out", "webpack4", "entrypoint3.js"))).toBe(
       "I AM A RELEASE!"
     );
+    // eslint-disable-next-line jest/no-standalone-expect
     expect(
       getFileContents(path.join(__dirname, "out", "webpack4", "entrypoint2.js"))
     ).not.toContain("I AM A RELEASE!");

--- a/packages/integration-tests/fixtures/function-entries-option/function-entries-option.test.ts
+++ b/packages/integration-tests/fixtures/function-entries-option/function-entries-option.test.ts
@@ -12,67 +12,67 @@ function getFileContents(bundlePath: string): string {
 
 describe("`releaseInjectionTargets` option should work as expected when given a function", () => {
   test("esbuild bundle", () => {
-    expect(getBundleOutput(path.join(__dirname, "./out/esbuild/entrypoint1.js"))).toBe(
+    expect(getBundleOutput(path.join(__dirname, "out", "esbuild", "entrypoint1.js"))).toBe(
       "I AM A RELEASE!"
     );
-    expect(getBundleOutput(path.join(__dirname, "./out/esbuild/entrypoint2.js"))).toBe("");
-    expect(getBundleOutput(path.join(__dirname, "./out/esbuild/entrypoint3.js"))).toBe(
+    expect(getBundleOutput(path.join(__dirname, "out", "esbuild", "entrypoint2.js"))).toBe("");
+    expect(getBundleOutput(path.join(__dirname, "out", "esbuild", "entrypoint3.js"))).toBe(
       "I AM A RELEASE!"
     );
-    expect(getFileContents(path.join(__dirname, "./out/esbuild/entrypoint2.js"))).not.toContain(
+    expect(getFileContents(path.join(__dirname, "out", "esbuild", "entrypoint2.js"))).not.toContain(
       "I AM A RELEASE!"
     );
   });
 
   test("rollup bundle", () => {
-    expect(getBundleOutput(path.join(__dirname, "./out/rollup/entrypoint1.js"))).toBe(
+    expect(getBundleOutput(path.join(__dirname, "out", "rollup", "entrypoint1.js"))).toBe(
       "I AM A RELEASE!"
     );
-    expect(getBundleOutput(path.join(__dirname, "./out/rollup/entrypoint2.js"))).toBe("");
-    expect(getBundleOutput(path.join(__dirname, "./out/rollup/entrypoint3.js"))).toBe(
+    expect(getBundleOutput(path.join(__dirname, "out", "rollup", "entrypoint2.js"))).toBe("");
+    expect(getBundleOutput(path.join(__dirname, "out", "rollup", "entrypoint3.js"))).toBe(
       "I AM A RELEASE!"
     );
-    expect(getFileContents(path.join(__dirname, "./out/rollup/entrypoint2.js"))).not.toContain(
+    expect(getFileContents(path.join(__dirname, "out", "rollup", "entrypoint2.js"))).not.toContain(
       "I AM A RELEASE!"
     );
   });
 
   test("vite bundle", () => {
-    expect(getBundleOutput(path.join(__dirname, "./out/vite/entrypoint1.js"))).toBe(
+    expect(getBundleOutput(path.join(__dirname, "out", "vite", "entrypoint1.js"))).toBe(
       "I AM A RELEASE!"
     );
-    expect(getBundleOutput(path.join(__dirname, "./out/vite/entrypoint2.js"))).toBe("");
-    expect(getBundleOutput(path.join(__dirname, "./out/vite/entrypoint3.js"))).toBe(
+    expect(getBundleOutput(path.join(__dirname, "out", "vite", "entrypoint2.js"))).toBe("");
+    expect(getBundleOutput(path.join(__dirname, "out", "vite", "entrypoint3.js"))).toBe(
       "I AM A RELEASE!"
     );
-    expect(getFileContents(path.join(__dirname, "./out/vite/entrypoint2.js"))).not.toContain(
+    expect(getFileContents(path.join(__dirname, "out", "vite", "entrypoint2.js"))).not.toContain(
       "I AM A RELEASE!"
     );
   });
 
   test("webpack 4 bundle", () => {
-    expect(getBundleOutput(path.join(__dirname, "./out/webpack4/entrypoint1.js"))).toBe(
+    expect(getBundleOutput(path.join(__dirname, "out", "webpack4", "entrypoint1.js"))).toBe(
       "I AM A RELEASE!"
     );
-    expect(getBundleOutput(path.join(__dirname, "./out/webpack4/entrypoint2.js"))).toBe("");
-    expect(getBundleOutput(path.join(__dirname, "./out/webpack4/entrypoint3.js"))).toBe(
+    expect(getBundleOutput(path.join(__dirname, "out", "webpack4", "entrypoint2.js"))).toBe("");
+    expect(getBundleOutput(path.join(__dirname, "out", "webpack4", "entrypoint3.js"))).toBe(
       "I AM A RELEASE!"
     );
-    expect(getFileContents(path.join(__dirname, "./out/webpack4/entrypoint2.js"))).not.toContain(
-      "I AM A RELEASE!"
-    );
+    expect(
+      getFileContents(path.join(__dirname, "out", "webpack4", "entrypoint2.js"))
+    ).not.toContain("I AM A RELEASE!");
   });
 
   test("webpack 5 bundle", () => {
-    expect(getBundleOutput(path.join(__dirname, "./out/webpack5/entrypoint1.js"))).toBe(
+    expect(getBundleOutput(path.join(__dirname, "out", "webpack5", "entrypoint1.js"))).toBe(
       "I AM A RELEASE!"
     );
-    expect(getBundleOutput(path.join(__dirname, "./out/webpack5/entrypoint2.js"))).toBe("");
-    expect(getBundleOutput(path.join(__dirname, "./out/webpack5/entrypoint3.js"))).toBe(
+    expect(getBundleOutput(path.join(__dirname, "out", "webpack5", "entrypoint2.js"))).toBe("");
+    expect(getBundleOutput(path.join(__dirname, "out", "webpack5", "entrypoint3.js"))).toBe(
       "I AM A RELEASE!"
     );
-    expect(getFileContents(path.join(__dirname, "./out/webpack5/entrypoint2.js"))).not.toContain(
-      "I AM A RELEASE!"
-    );
+    expect(
+      getFileContents(path.join(__dirname, "out", "webpack5", "entrypoint2.js"))
+    ).not.toContain("I AM A RELEASE!");
   });
 });

--- a/packages/integration-tests/fixtures/function-entries-option/function-entries-option.test.ts
+++ b/packages/integration-tests/fixtures/function-entries-option/function-entries-option.test.ts
@@ -1,10 +1,7 @@
 import childProcess from "child_process";
 import path from "path";
 import fs from "fs";
-import {
-  testIfNodeMajorVersionIsGreaterOrEqual14,
-  testIfNodeMajorVersionIsLessThan18,
-} from "../../utils/testIf";
+import { testIfNodeMajorVersionIsLessThan18 } from "../../utils/testIf";
 
 function getBundleOutput(bundlePath: string): string {
   return childProcess.execSync(`node ${bundlePath}`, { encoding: "utf-8" });
@@ -41,18 +38,14 @@ describe("`releaseInjectionTargets` option should work as expected when given a 
     );
   });
 
-  testIfNodeMajorVersionIsGreaterOrEqual14("vite bundle", () => {
-    // eslint-disable-next-line jest/no-standalone-expect
+  test("vite bundle", () => {
     expect(getBundleOutput(path.join(__dirname, "out", "vite", "entrypoint1.js"))).toBe(
       "I AM A RELEASE!"
     );
-    // eslint-disable-next-line jest/no-standalone-expect
     expect(getBundleOutput(path.join(__dirname, "out", "vite", "entrypoint2.js"))).toBe("");
-    // eslint-disable-next-line jest/no-standalone-expect
     expect(getBundleOutput(path.join(__dirname, "out", "vite", "entrypoint3.js"))).toBe(
       "I AM A RELEASE!"
     );
-    // eslint-disable-next-line jest/no-standalone-expect
     expect(getFileContents(path.join(__dirname, "out", "vite", "entrypoint2.js"))).not.toContain(
       "I AM A RELEASE!"
     );

--- a/packages/integration-tests/fixtures/function-entries-option/setup.ts
+++ b/packages/integration-tests/fixtures/function-entries-option/setup.ts
@@ -2,10 +2,10 @@ import { Options } from "@sentry/bundler-plugin-core";
 import * as path from "path";
 import { createCjsBundles } from "../../utils/create-cjs-bundles";
 
-const entryPoint1Path = path.resolve(__dirname, "./input/entrypoint1.js");
-const entryPoint2Path = path.resolve(__dirname, "./input/entrypoint2.js");
-const entryPoint3Path = path.resolve(__dirname, "./input/entrypoint3.js");
-const outputDir = path.resolve(__dirname, "./out");
+const entryPoint1Path = path.resolve(__dirname, "input", "entrypoint1.js");
+const entryPoint2Path = path.resolve(__dirname, "input", "entrypoint2.js");
+const entryPoint3Path = path.resolve(__dirname, "input", "entrypoint3.js");
+const outputDir = path.resolve(__dirname, "out");
 
 createCjsBundles(
   { entrypoint1: entryPoint1Path, entrypoint2: entryPoint2Path, entrypoint3: entryPoint3Path },

--- a/packages/integration-tests/fixtures/regex-entries-option/setup.ts
+++ b/packages/integration-tests/fixtures/regex-entries-option/setup.ts
@@ -2,9 +2,9 @@ import { Options } from "@sentry/bundler-plugin-core";
 import * as path from "path";
 import { createCjsBundles } from "../../utils/create-cjs-bundles";
 
-const entryPoint1Path = path.resolve(__dirname, "./input/entrypoint1.js");
-const entryPoint2Path = path.resolve(__dirname, "./input/entrypoint2.js");
-const outputDir = path.resolve(__dirname, "./out");
+const entryPoint1Path = path.resolve(__dirname, "input", "entrypoint1.js");
+const entryPoint2Path = path.resolve(__dirname, "input", "entrypoint2.js");
+const outputDir = path.resolve(__dirname, "out");
 
 createCjsBundles({ entrypoint1: entryPoint1Path, entrypoint2: entryPoint2Path }, outputDir, {
   release: "I AM A RELEASE!",

--- a/packages/integration-tests/fixtures/regex-entries-option/string-entries-option.test.ts
+++ b/packages/integration-tests/fixtures/regex-entries-option/string-entries-option.test.ts
@@ -1,10 +1,7 @@
 import childProcess from "child_process";
 import path from "path";
 import fs from "fs";
-import {
-  testIfNodeMajorVersionIsGreaterOrEqual14,
-  testIfNodeMajorVersionIsLessThan18,
-} from "../../utils/testIf";
+import { testIfNodeMajorVersionIsLessThan18 } from "../../utils/testIf";
 
 function getBundleOutput(bundlePath: string): string {
   return childProcess.execSync(`node ${bundlePath}`, { encoding: "utf-8" });
@@ -35,14 +32,11 @@ describe("`releaseInjectionTargets` option should work as expected when given a 
     );
   });
 
-  testIfNodeMajorVersionIsGreaterOrEqual14("vite bundle", () => {
-    // eslint-disable-next-line jest/no-standalone-expect
+  test("vite bundle", () => {
     expect(getBundleOutput(path.join(__dirname, "out", "vite", "entrypoint1.js"))).toBe(
       "I AM A RELEASE!"
     );
-    // eslint-disable-next-line jest/no-standalone-expect
     expect(getBundleOutput(path.join(__dirname, "out", "vite", "entrypoint2.js"))).toBe("");
-    // eslint-disable-next-line jest/no-standalone-expect
     expect(getFileContents(path.join(__dirname, "out", "vite", "entrypoint2.js"))).not.toContain(
       "I AM A RELEASE!"
     );

--- a/packages/integration-tests/fixtures/regex-entries-option/string-entries-option.test.ts
+++ b/packages/integration-tests/fixtures/regex-entries-option/string-entries-option.test.ts
@@ -1,7 +1,10 @@
 import childProcess from "child_process";
 import path from "path";
 import fs from "fs";
-import { testIfNodeMajorVersionIsLessThan18 } from "../../utils/testIf";
+import {
+  testIfNodeMajorVersionIsGreaterOrEqual14,
+  testIfNodeMajorVersionIsLessThan18,
+} from "../../utils/testIf";
 
 function getBundleOutput(bundlePath: string): string {
   return childProcess.execSync(`node ${bundlePath}`, { encoding: "utf-8" });
@@ -32,11 +35,14 @@ describe("`releaseInjectionTargets` option should work as expected when given a 
     );
   });
 
-  test("vite bundle", () => {
+  testIfNodeMajorVersionIsGreaterOrEqual14("vite bundle", () => {
+    // eslint-disable-next-line jest/no-standalone-expect
     expect(getBundleOutput(path.join(__dirname, "out", "vite", "entrypoint1.js"))).toBe(
       "I AM A RELEASE!"
     );
+    // eslint-disable-next-line jest/no-standalone-expect
     expect(getBundleOutput(path.join(__dirname, "out", "vite", "entrypoint2.js"))).toBe("");
+    // eslint-disable-next-line jest/no-standalone-expect
     expect(getFileContents(path.join(__dirname, "out", "vite", "entrypoint2.js"))).not.toContain(
       "I AM A RELEASE!"
     );

--- a/packages/integration-tests/fixtures/regex-entries-option/string-entries-option.test.ts
+++ b/packages/integration-tests/fixtures/regex-entries-option/string-entries-option.test.ts
@@ -12,52 +12,52 @@ function getFileContents(bundlePath: string): string {
 
 describe("`releaseInjectionTargets` option should work as expected when given a regular expression", () => {
   test("esbuild bundle", () => {
-    expect(getBundleOutput(path.join(__dirname, "./out/esbuild/entrypoint1.js"))).toBe(
+    expect(getBundleOutput(path.join(__dirname, "out", "esbuild", "entrypoint1.js"))).toBe(
       "I AM A RELEASE!"
     );
-    expect(getBundleOutput(path.join(__dirname, "./out/esbuild/entrypoint2.js"))).toBe("");
-    expect(getFileContents(path.join(__dirname, "./out/esbuild/entrypoint2.js"))).not.toContain(
+    expect(getBundleOutput(path.join(__dirname, "out", "esbuild", "entrypoint2.js"))).toBe("");
+    expect(getFileContents(path.join(__dirname, "out", "esbuild", "entrypoint2.js"))).not.toContain(
       "I AM A RELEASE!"
     );
   });
 
   test("rollup bundle", () => {
-    expect(getBundleOutput(path.join(__dirname, "./out/rollup/entrypoint1.js"))).toBe(
+    expect(getBundleOutput(path.join(__dirname, "out", "rollup", "entrypoint1.js"))).toBe(
       "I AM A RELEASE!"
     );
-    expect(getBundleOutput(path.join(__dirname, "./out/rollup/entrypoint2.js"))).toBe("");
-    expect(getFileContents(path.join(__dirname, "./out/rollup/entrypoint2.js"))).not.toContain(
+    expect(getBundleOutput(path.join(__dirname, "out", "rollup", "entrypoint2.js"))).toBe("");
+    expect(getFileContents(path.join(__dirname, "out", "rollup", "entrypoint2.js"))).not.toContain(
       "I AM A RELEASE!"
     );
   });
 
   test("vite bundle", () => {
-    expect(getBundleOutput(path.join(__dirname, "./out/vite/entrypoint1.js"))).toBe(
+    expect(getBundleOutput(path.join(__dirname, "out", "vite", "entrypoint1.js"))).toBe(
       "I AM A RELEASE!"
     );
-    expect(getBundleOutput(path.join(__dirname, "./out/vite/entrypoint2.js"))).toBe("");
-    expect(getFileContents(path.join(__dirname, "./out/vite/entrypoint2.js"))).not.toContain(
+    expect(getBundleOutput(path.join(__dirname, "out", "vite", "entrypoint2.js"))).toBe("");
+    expect(getFileContents(path.join(__dirname, "out", "vite", "entrypoint2.js"))).not.toContain(
       "I AM A RELEASE!"
     );
   });
 
   test("webpack 4 bundle", () => {
-    expect(getBundleOutput(path.join(__dirname, "./out/webpack4/entrypoint1.js"))).toBe(
+    expect(getBundleOutput(path.join(__dirname, "out", "webpack4", "entrypoint1.js"))).toBe(
       "I AM A RELEASE!"
     );
-    expect(getBundleOutput(path.join(__dirname, "./out/webpack4/entrypoint2.js"))).toBe("");
-    expect(getFileContents(path.join(__dirname, "./out/webpack4/entrypoint2.js"))).not.toContain(
-      "I AM A RELEASE!"
-    );
+    expect(getBundleOutput(path.join(__dirname, "out", "webpack4", "entrypoint2.js"))).toBe("");
+    expect(
+      getFileContents(path.join(__dirname, "out", "webpack4", "entrypoint2.js"))
+    ).not.toContain("I AM A RELEASE!");
   });
 
   test("webpack 5 bundle", () => {
-    expect(getBundleOutput(path.join(__dirname, "./out/webpack5/entrypoint1.js"))).toBe(
+    expect(getBundleOutput(path.join(__dirname, "out", "webpack5", "entrypoint1.js"))).toBe(
       "I AM A RELEASE!"
     );
-    expect(getBundleOutput(path.join(__dirname, "./out/webpack5/entrypoint2.js"))).toBe("");
-    expect(getFileContents(path.join(__dirname, "./out/webpack5/entrypoint2.js"))).not.toContain(
-      "I AM A RELEASE!"
-    );
+    expect(getBundleOutput(path.join(__dirname, "out", "webpack5", "entrypoint2.js"))).toBe("");
+    expect(
+      getFileContents(path.join(__dirname, "out", "webpack5", "entrypoint2.js"))
+    ).not.toContain("I AM A RELEASE!");
   });
 });

--- a/packages/integration-tests/fixtures/regex-entries-option/string-entries-option.test.ts
+++ b/packages/integration-tests/fixtures/regex-entries-option/string-entries-option.test.ts
@@ -1,6 +1,7 @@
 import childProcess from "child_process";
 import path from "path";
 import fs from "fs";
+import { testIfNodeMajorVersionIsLessThan18 } from "../../utils/testIf";
 
 function getBundleOutput(bundlePath: string): string {
   return childProcess.execSync(`node ${bundlePath}`, { encoding: "utf-8" });
@@ -41,11 +42,14 @@ describe("`releaseInjectionTargets` option should work as expected when given a 
     );
   });
 
-  test("webpack 4 bundle", () => {
+  testIfNodeMajorVersionIsLessThan18("webpack 4 bundle", () => {
+    // eslint-disable-next-line jest/no-standalone-expect
     expect(getBundleOutput(path.join(__dirname, "out", "webpack4", "entrypoint1.js"))).toBe(
       "I AM A RELEASE!"
     );
+    // eslint-disable-next-line jest/no-standalone-expect
     expect(getBundleOutput(path.join(__dirname, "out", "webpack4", "entrypoint2.js"))).toBe("");
+    // eslint-disable-next-line jest/no-standalone-expect
     expect(
       getFileContents(path.join(__dirname, "out", "webpack4", "entrypoint2.js"))
     ).not.toContain("I AM A RELEASE!");

--- a/packages/integration-tests/fixtures/releases-injection/releases-injection.test.ts
+++ b/packages/integration-tests/fixtures/releases-injection/releases-injection.test.ts
@@ -1,5 +1,6 @@
 import childProcess from "child_process";
 import path from "path";
+import { testIfNodeMajorVersionIsLessThan18 } from "../../utils/testIf";
 
 /**
  * Runs a node file in a seprate process.
@@ -27,7 +28,7 @@ test("vite bundle", () => {
   checkBundle(path.join(__dirname, "out", "vite", "index.js"));
 });
 
-test("webpack 4 bundle", () => {
+testIfNodeMajorVersionIsLessThan18("webpack 4 bundle", () => {
   expect.assertions(1);
   checkBundle(path.join(__dirname, "out", "webpack4", "index.js"));
 });

--- a/packages/integration-tests/fixtures/releases-injection/releases-injection.test.ts
+++ b/packages/integration-tests/fixtures/releases-injection/releases-injection.test.ts
@@ -14,25 +14,25 @@ function checkBundle(bundlePath: string): void {
 
 test("esbuild bundle", () => {
   expect.assertions(1);
-  checkBundle(path.join(__dirname, "./out/esbuild/index.js"));
+  checkBundle(path.join(__dirname, "out", "esbuild", "index.js"));
 });
 
 test("rollup bundle", () => {
   expect.assertions(1);
-  checkBundle(path.join(__dirname, "./out/rollup/index.js"));
+  checkBundle(path.join(__dirname, "out", "rollup", "index.js"));
 });
 
 test("vite bundle", () => {
   expect.assertions(1);
-  checkBundle(path.join(__dirname, "./out/vite/index.js"));
+  checkBundle(path.join(__dirname, "out", "vite", "index.js"));
 });
 
 test("webpack 4 bundle", () => {
   expect.assertions(1);
-  checkBundle(path.join(__dirname, "./out/webpack4/index.js"));
+  checkBundle(path.join(__dirname, "out", "webpack4", "index.js"));
 });
 
 test("webpack 5 bundle", () => {
   expect.assertions(1);
-  checkBundle(path.join(__dirname, "./out/webpack5/index.js"));
+  checkBundle(path.join(__dirname, "out", "webpack5", "index.js"));
 });

--- a/packages/integration-tests/fixtures/releases-injection/releases-injection.test.ts
+++ b/packages/integration-tests/fixtures/releases-injection/releases-injection.test.ts
@@ -1,9 +1,6 @@
 import childProcess from "child_process";
 import path from "path";
-import {
-  testIfNodeMajorVersionIsGreaterOrEqual14,
-  testIfNodeMajorVersionIsLessThan18,
-} from "../../utils/testIf";
+import { testIfNodeMajorVersionIsLessThan18 } from "../../utils/testIf";
 
 /**
  * Runs a node file in a seprate process.
@@ -26,7 +23,7 @@ test("rollup bundle", () => {
   checkBundle(path.join(__dirname, "out", "rollup", "index.js"));
 });
 
-testIfNodeMajorVersionIsGreaterOrEqual14("vite bundle", () => {
+test("vite bundle", () => {
   expect.assertions(1);
   checkBundle(path.join(__dirname, "out", "vite", "index.js"));
 });

--- a/packages/integration-tests/fixtures/releases-injection/releases-injection.test.ts
+++ b/packages/integration-tests/fixtures/releases-injection/releases-injection.test.ts
@@ -1,6 +1,9 @@
 import childProcess from "child_process";
 import path from "path";
-import { testIfNodeMajorVersionIsLessThan18 } from "../../utils/testIf";
+import {
+  testIfNodeMajorVersionIsGreaterOrEqual14,
+  testIfNodeMajorVersionIsLessThan18,
+} from "../../utils/testIf";
 
 /**
  * Runs a node file in a seprate process.
@@ -23,7 +26,7 @@ test("rollup bundle", () => {
   checkBundle(path.join(__dirname, "out", "rollup", "index.js"));
 });
 
-test("vite bundle", () => {
+testIfNodeMajorVersionIsGreaterOrEqual14("vite bundle", () => {
   expect.assertions(1);
   checkBundle(path.join(__dirname, "out", "vite", "index.js"));
 });

--- a/packages/integration-tests/fixtures/releases-injection/setup.ts
+++ b/packages/integration-tests/fixtures/releases-injection/setup.ts
@@ -2,8 +2,8 @@ import { Options } from "@sentry/bundler-plugin-core";
 import * as path from "path";
 import { createCjsBundles } from "../../utils/create-cjs-bundles";
 
-const entryPointPath = path.resolve(__dirname, "./input/entrypoint.js");
-const outputDir = path.resolve(__dirname, "./out");
+const entryPointPath = path.resolve(__dirname, "input", "entrypoint.js");
+const outputDir = path.resolve(__dirname, "out");
 
 createCjsBundles({ index: entryPointPath }, outputDir, {
   release: "I AM A RELEASE!",

--- a/packages/integration-tests/fixtures/string-entries-option/setup.ts
+++ b/packages/integration-tests/fixtures/string-entries-option/setup.ts
@@ -2,9 +2,9 @@ import { Options } from "@sentry/bundler-plugin-core";
 import * as path from "path";
 import { createCjsBundles } from "../../utils/create-cjs-bundles";
 
-const entryPoint1Path = path.resolve(__dirname, "./input/entrypoint1.js");
-const entryPoint2Path = path.resolve(__dirname, "./input/entrypoint2.js");
-const outputDir = path.resolve(__dirname, "./out");
+const entryPoint1Path = path.resolve(__dirname, "input", "entrypoint1.js");
+const entryPoint2Path = path.resolve(__dirname, "input", "entrypoint2.js");
+const outputDir = path.resolve(__dirname, "out");
 
 createCjsBundles({ entrypoint1: entryPoint1Path, entrypoint2: entryPoint2Path }, outputDir, {
   release: "I AM A RELEASE!",

--- a/packages/integration-tests/fixtures/string-entries-option/string-entries-option.test.ts
+++ b/packages/integration-tests/fixtures/string-entries-option/string-entries-option.test.ts
@@ -1,10 +1,7 @@
 import childProcess from "child_process";
 import path from "path";
 import fs from "fs";
-import {
-  testIfNodeMajorVersionIsGreaterOrEqual14,
-  testIfNodeMajorVersionIsLessThan18,
-} from "../../utils/testIf";
+import { testIfNodeMajorVersionIsLessThan18 } from "../../utils/testIf";
 
 function getBundleOutput(bundlePath: string): string {
   return childProcess.execSync(`node ${bundlePath}`, { encoding: "utf-8" });
@@ -35,14 +32,11 @@ describe("`releaseInjectionTargets` option should work as expected when given a 
     );
   });
 
-  testIfNodeMajorVersionIsGreaterOrEqual14("vite bundle", () => {
-    // eslint-disable-next-line jest/no-standalone-expect
+  test("vite bundle", () => {
     expect(getBundleOutput(path.join(__dirname, "out", "vite", "entrypoint1.js"))).toBe(
       "I AM A RELEASE!"
     );
-    // eslint-disable-next-line jest/no-standalone-expect
     expect(getBundleOutput(path.join(__dirname, "out", "vite", "entrypoint2.js"))).toBe("");
-    // eslint-disable-next-line jest/no-standalone-expect
     expect(getFileContents(path.join(__dirname, "out", "vite", "entrypoint2.js"))).not.toContain(
       "I AM A RELEASE!"
     );

--- a/packages/integration-tests/fixtures/string-entries-option/string-entries-option.test.ts
+++ b/packages/integration-tests/fixtures/string-entries-option/string-entries-option.test.ts
@@ -1,7 +1,10 @@
 import childProcess from "child_process";
 import path from "path";
 import fs from "fs";
-import { testIfNodeMajorVersionIsLessThan18 } from "../../utils/testIf";
+import {
+  testIfNodeMajorVersionIsGreaterOrEqual14,
+  testIfNodeMajorVersionIsLessThan18,
+} from "../../utils/testIf";
 
 function getBundleOutput(bundlePath: string): string {
   return childProcess.execSync(`node ${bundlePath}`, { encoding: "utf-8" });
@@ -32,11 +35,14 @@ describe("`releaseInjectionTargets` option should work as expected when given a 
     );
   });
 
-  test("vite bundle", () => {
+  testIfNodeMajorVersionIsGreaterOrEqual14("vite bundle", () => {
+    // eslint-disable-next-line jest/no-standalone-expect
     expect(getBundleOutput(path.join(__dirname, "out", "vite", "entrypoint1.js"))).toBe(
       "I AM A RELEASE!"
     );
+    // eslint-disable-next-line jest/no-standalone-expect
     expect(getBundleOutput(path.join(__dirname, "out", "vite", "entrypoint2.js"))).toBe("");
+    // eslint-disable-next-line jest/no-standalone-expect
     expect(getFileContents(path.join(__dirname, "out", "vite", "entrypoint2.js"))).not.toContain(
       "I AM A RELEASE!"
     );

--- a/packages/integration-tests/fixtures/string-entries-option/string-entries-option.test.ts
+++ b/packages/integration-tests/fixtures/string-entries-option/string-entries-option.test.ts
@@ -12,52 +12,52 @@ function getFileContents(bundlePath: string): string {
 
 describe("`releaseInjectionTargets` option should work as expected when given a string", () => {
   test("esbuild bundle", () => {
-    expect(getBundleOutput(path.join(__dirname, "./out/esbuild/entrypoint1.js"))).toBe(
+    expect(getBundleOutput(path.join(__dirname, "out", "esbuild", "entrypoint1.js"))).toBe(
       "I AM A RELEASE!"
     );
-    expect(getBundleOutput(path.join(__dirname, "./out/esbuild/entrypoint2.js"))).toBe("");
-    expect(getFileContents(path.join(__dirname, "./out/esbuild/entrypoint2.js"))).not.toContain(
+    expect(getBundleOutput(path.join(__dirname, "out", "esbuild", "entrypoint2.js"))).toBe("");
+    expect(getFileContents(path.join(__dirname, "out", "esbuild", "entrypoint2.js"))).not.toContain(
       "I AM A RELEASE!"
     );
   });
 
   test("rollup bundle", () => {
-    expect(getBundleOutput(path.join(__dirname, "./out/rollup/entrypoint1.js"))).toBe(
+    expect(getBundleOutput(path.join(__dirname, "out", "rollup", "entrypoint1.js"))).toBe(
       "I AM A RELEASE!"
     );
-    expect(getBundleOutput(path.join(__dirname, "./out/rollup/entrypoint2.js"))).toBe("");
-    expect(getFileContents(path.join(__dirname, "./out/rollup/entrypoint2.js"))).not.toContain(
+    expect(getBundleOutput(path.join(__dirname, "out", "rollup", "entrypoint2.js"))).toBe("");
+    expect(getFileContents(path.join(__dirname, "out", "rollup", "entrypoint2.js"))).not.toContain(
       "I AM A RELEASE!"
     );
   });
 
   test("vite bundle", () => {
-    expect(getBundleOutput(path.join(__dirname, "./out/vite/entrypoint1.js"))).toBe(
+    expect(getBundleOutput(path.join(__dirname, "out", "vite", "entrypoint1.js"))).toBe(
       "I AM A RELEASE!"
     );
-    expect(getBundleOutput(path.join(__dirname, "./out/vite/entrypoint2.js"))).toBe("");
-    expect(getFileContents(path.join(__dirname, "./out/vite/entrypoint2.js"))).not.toContain(
+    expect(getBundleOutput(path.join(__dirname, "out", "vite", "entrypoint2.js"))).toBe("");
+    expect(getFileContents(path.join(__dirname, "out", "vite", "entrypoint2.js"))).not.toContain(
       "I AM A RELEASE!"
     );
   });
 
   test("webpack 4 bundle", () => {
-    expect(getBundleOutput(path.join(__dirname, "./out/webpack4/entrypoint1.js"))).toBe(
+    expect(getBundleOutput(path.join(__dirname, "out", "webpack4", "entrypoint1.js"))).toBe(
       "I AM A RELEASE!"
     );
-    expect(getBundleOutput(path.join(__dirname, "./out/webpack4/entrypoint2.js"))).toBe("");
-    expect(getFileContents(path.join(__dirname, "./out/webpack4/entrypoint2.js"))).not.toContain(
-      "I AM A RELEASE!"
-    );
+    expect(getBundleOutput(path.join(__dirname, "out", "webpack4", "entrypoint2.js"))).toBe("");
+    expect(
+      getFileContents(path.join(__dirname, "out", "webpack4", "entrypoint2.js"))
+    ).not.toContain("I AM A RELEASE!");
   });
 
   test("webpack 5 bundle", () => {
-    expect(getBundleOutput(path.join(__dirname, "./out/webpack5/entrypoint1.js"))).toBe(
+    expect(getBundleOutput(path.join(__dirname, "out", "webpack5", "entrypoint1.js"))).toBe(
       "I AM A RELEASE!"
     );
-    expect(getBundleOutput(path.join(__dirname, "./out/webpack5/entrypoint2.js"))).toBe("");
-    expect(getFileContents(path.join(__dirname, "./out/webpack5/entrypoint2.js"))).not.toContain(
-      "I AM A RELEASE!"
-    );
+    expect(getBundleOutput(path.join(__dirname, "out", "webpack5", "entrypoint2.js"))).toBe("");
+    expect(
+      getFileContents(path.join(__dirname, "out", "webpack5", "entrypoint2.js"))
+    ).not.toContain("I AM A RELEASE!");
   });
 });

--- a/packages/integration-tests/fixtures/string-entries-option/string-entries-option.test.ts
+++ b/packages/integration-tests/fixtures/string-entries-option/string-entries-option.test.ts
@@ -1,6 +1,7 @@
 import childProcess from "child_process";
 import path from "path";
 import fs from "fs";
+import { testIfNodeMajorVersionIsLessThan18 } from "../../utils/testIf";
 
 function getBundleOutput(bundlePath: string): string {
   return childProcess.execSync(`node ${bundlePath}`, { encoding: "utf-8" });
@@ -41,11 +42,14 @@ describe("`releaseInjectionTargets` option should work as expected when given a 
     );
   });
 
-  test("webpack 4 bundle", () => {
+  testIfNodeMajorVersionIsLessThan18("webpack 4 bundle", () => {
+    // eslint-disable-next-line jest/no-standalone-expect
     expect(getBundleOutput(path.join(__dirname, "out", "webpack4", "entrypoint1.js"))).toBe(
       "I AM A RELEASE!"
     );
+    // eslint-disable-next-line jest/no-standalone-expect
     expect(getBundleOutput(path.join(__dirname, "out", "webpack4", "entrypoint2.js"))).toBe("");
+    // eslint-disable-next-line jest/no-standalone-expect
     expect(
       getFileContents(path.join(__dirname, "out", "webpack4", "entrypoint2.js"))
     ).not.toContain("I AM A RELEASE!");

--- a/packages/integration-tests/scripts/run-fixture-setups.ts
+++ b/packages/integration-tests/scripts/run-fixture-setups.ts
@@ -2,8 +2,8 @@ import fs from "fs";
 import path from "path";
 
 const fixturePaths = fs
-  .readdirSync(path.join(__dirname, "../fixtures"))
-  .map((fixtureDir) => path.join(__dirname, "../fixtures", fixtureDir));
+  .readdirSync(path.join(__dirname, "..", "fixtures"))
+  .map((fixtureDir) => path.join(__dirname, "..", "fixtures", fixtureDir));
 
 fixturePaths.forEach((fixturePath) => {
   require(path.join(fixturePath, "setup.ts"));

--- a/packages/integration-tests/utils/create-cjs-bundles.ts
+++ b/packages/integration-tests/utils/create-cjs-bundles.ts
@@ -54,24 +54,27 @@ export function createCjsBundles(
     format: "cjs",
   });
 
-  webpack4(
-    {
-      mode: "production",
-      entry: entrypoints,
-      cache: false,
-      output: {
-        path: path.join(outFolder, "webpack4"),
-        libraryTarget: "commonjs",
+  const nodejsMajorversion = process.version.split(".")[0];
+  if (!nodejsMajorversion || parseInt(nodejsMajorversion) < 18) {
+    webpack4(
+      {
+        mode: "production",
+        entry: entrypoints,
+        cache: false,
+        output: {
+          path: path.join(outFolder, "webpack4"),
+          libraryTarget: "commonjs",
+        },
+        target: "node", // needed for webpack 4 so we can access node api
+        plugins: [sentryWebpackPlugin(sentryUnpluginOptions)],
       },
-      target: "node", // needed for webpack 4 so we can access node api
-      plugins: [sentryWebpackPlugin(sentryUnpluginOptions)],
-    },
-    (err) => {
-      if (err) {
-        throw err;
+      (err) => {
+        if (err) {
+          throw err;
+        }
       }
-    }
-  );
+    );
+  }
 
   webpack5(
     {

--- a/packages/integration-tests/utils/create-cjs-bundles.ts
+++ b/packages/integration-tests/utils/create-cjs-bundles.ts
@@ -12,25 +12,30 @@ import {
   Options,
 } from "@sentry/bundler-plugin-core";
 
+const nodejsMajorversion = process.version.split(".")[0];
+
 export function createCjsBundles(
   entrypoints: { [name: string]: string },
   outFolder: string,
   sentryUnpluginOptions: Options
 ): void {
-  void vite.build({
-    clearScreen: false,
-    build: {
-      outDir: path.join(outFolder, "vite"),
-      rollupOptions: {
-        input: entrypoints,
-        output: {
-          format: "cjs",
-          entryFileNames: "[name].js",
+  // Vite doesn't work on Node.js versions <= 12
+  if (!nodejsMajorversion || parseInt(nodejsMajorversion) >= 14) {
+    void vite.build({
+      clearScreen: false,
+      build: {
+        outDir: path.join(outFolder, "vite"),
+        rollupOptions: {
+          input: entrypoints,
+          output: {
+            format: "cjs",
+            entryFileNames: "[name].js",
+          },
         },
       },
-    },
-    plugins: [sentryVitePlugin(sentryUnpluginOptions)],
-  });
+      plugins: [sentryVitePlugin(sentryUnpluginOptions)],
+    });
+  }
 
   void rollup
     .rollup({
@@ -54,7 +59,7 @@ export function createCjsBundles(
     format: "cjs",
   });
 
-  const nodejsMajorversion = process.version.split(".")[0];
+  // Webpack 4 doesn't work on Node.js versions >= 18
   if (!nodejsMajorversion || parseInt(nodejsMajorversion) < 18) {
     webpack4(
       {

--- a/packages/integration-tests/utils/create-cjs-bundles.ts
+++ b/packages/integration-tests/utils/create-cjs-bundles.ts
@@ -19,23 +19,20 @@ export function createCjsBundles(
   outFolder: string,
   sentryUnpluginOptions: Options
 ): void {
-  // Vite doesn't work on Node.js versions <= 12
-  if (!nodejsMajorversion || parseInt(nodejsMajorversion) >= 14) {
-    void vite.build({
-      clearScreen: false,
-      build: {
-        outDir: path.join(outFolder, "vite"),
-        rollupOptions: {
-          input: entrypoints,
-          output: {
-            format: "cjs",
-            entryFileNames: "[name].js",
-          },
+  void vite.build({
+    clearScreen: false,
+    build: {
+      outDir: path.join(outFolder, "vite"),
+      rollupOptions: {
+        input: entrypoints,
+        output: {
+          format: "cjs",
+          entryFileNames: "[name].js",
         },
       },
-      plugins: [sentryVitePlugin(sentryUnpluginOptions)],
-    });
-  }
+    },
+    plugins: [sentryVitePlugin(sentryUnpluginOptions)],
+  });
 
   void rollup
     .rollup({

--- a/packages/integration-tests/utils/testIf.ts
+++ b/packages/integration-tests/utils/testIf.ts
@@ -19,14 +19,3 @@ export const testIfNodeMajorVersionIsLessThan18: jest.It = function () {
   return testIf(!nodejsMajorversion || parseInt(nodejsMajorversion) < 18);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 } as any;
-
-/**
- * Vite doesn't work for Node.js versions < 14.
- * We can use this function to skip tests on vite.
- */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any, no-undef, @typescript-eslint/no-unsafe-assignment
-export const testIfNodeMajorVersionIsGreaterOrEqual14: jest.It = function () {
-  const nodejsMajorversion = process.version.split(".")[0];
-  return testIf(!nodejsMajorversion || parseInt(nodejsMajorversion) >= 14);
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-} as any;

--- a/packages/integration-tests/utils/testIf.ts
+++ b/packages/integration-tests/utils/testIf.ts
@@ -1,0 +1,18 @@
+// eslint-disable-next-line no-undef
+export function testIf(condition: boolean): jest.It {
+  if (condition) {
+    // eslint-disable-next-line no-undef
+    return test;
+  } else {
+    // eslint-disable-next-line no-undef
+    return test.skip;
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any, no-undef, @typescript-eslint/no-unsafe-assignment
+export const testIfNodeMajorVersionIsLessThan18: jest.It =
+  function testIfNodeMajorVersionIsLessThan18() {
+    const nodejsMajorversion = process.version.split(".")[0];
+    return testIf(!nodejsMajorversion || parseInt(nodejsMajorversion) < 18);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;

--- a/packages/integration-tests/utils/testIf.ts
+++ b/packages/integration-tests/utils/testIf.ts
@@ -9,10 +9,24 @@ export function testIf(condition: boolean): jest.It {
   }
 }
 
+/**
+ * Webpack 4 doesn't work for Node.js versions >= 18.
+ * We can use this function to skip tests on Webpack 4.
+ */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any, no-undef, @typescript-eslint/no-unsafe-assignment
-export const testIfNodeMajorVersionIsLessThan18: jest.It =
-  function testIfNodeMajorVersionIsLessThan18() {
-    const nodejsMajorversion = process.version.split(".")[0];
-    return testIf(!nodejsMajorversion || parseInt(nodejsMajorversion) < 18);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  } as any;
+export const testIfNodeMajorVersionIsLessThan18: jest.It = function () {
+  const nodejsMajorversion = process.version.split(".")[0];
+  return testIf(!nodejsMajorversion || parseInt(nodejsMajorversion) < 18);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+} as any;
+
+/**
+ * Vite doesn't work for Node.js versions < 14.
+ * We can use this function to skip tests on vite.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any, no-undef, @typescript-eslint/no-unsafe-assignment
+export const testIfNodeMajorVersionIsGreaterOrEqual14: jest.It = function () {
+  const nodejsMajorversion = process.version.split(".")[0];
+  return testIf(!nodejsMajorversion || parseInt(nodejsMajorversion) >= 14);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+} as any;

--- a/packages/playground/build-webpack4.js
+++ b/packages/playground/build-webpack4.js
@@ -11,7 +11,7 @@ webpack4(
     entry: "./src/entrypoint1.js",
     cache: false,
     output: {
-      path: path.resolve(__dirname, `./out/webpack4`),
+      path: path.resolve(__dirname, "out", "webpack4"),
       filename: "index.js",
       library: "ExampleBundle",
       libraryTarget: "commonjs",

--- a/packages/playground/build-webpack5.js
+++ b/packages/playground/build-webpack5.js
@@ -11,7 +11,7 @@ webpack5(
     entry: "./src/entrypoint1.js",
     output: {
       filename: "index.js",
-      path: path.resolve(__dirname, `./out/webpack5`),
+      path: path.resolve(__dirname, "out", "webpack5"),
       library: {
         type: "commonjs",
         name: "ExampleBundle",

--- a/packages/playground/scripts/request-logger-proxy.ts
+++ b/packages/playground/scripts/request-logger-proxy.ts
@@ -47,7 +47,7 @@ app.use(function (req, res, next) {
     )}\nResponse body:\n${Buffer.concat(resBody).toString()}`;
 
     fs.appendFileSync(
-      path.join(__dirname, `request-logger-logs/${now}.txt`),
+      path.join(__dirname, "request-logger-logs", `${now}.txt`),
       `>>>>>>>>>\n\n${reqLog}\n\n-----------\n\n${resLog}\n\n<<<<<<<<<\n\n`,
       {
         encoding: "utf-8",

--- a/packages/playground/vite.config.js
+++ b/packages/playground/vite.config.js
@@ -8,7 +8,7 @@ export default defineConfig({
   build: {
     outDir: "./out/vite",
     lib: {
-      entry: path.resolve(__dirname, "./src/entrypoint1.js"),
+      entry: path.resolve(__dirname, "src", "entrypoint1.js"),
       name: "ExampleBundle",
       fileName: "index",
       formats: ["cjs"],

--- a/packages/playground/vite.config.smallNodeApp.js
+++ b/packages/playground/vite.config.smallNodeApp.js
@@ -7,7 +7,7 @@ export default defineConfig({
   build: {
     outDir: "./out/vite-smallNodeApp",
     lib: {
-      entry: path.resolve(__dirname, "./src/smallNodeApp.js"),
+      entry: path.resolve(__dirname, "src", "smallNodeApp.js"),
       name: "ExampleBundle",
       fileName: "index",
       formats: ["cjs"],


### PR DESCRIPTION
Adds a test matrix in our integration test CI for Node.js versions and Linux + Windows. We currently skip versions 10 and 12 because they cause issues with our dev-dependencies - which I believe covers the 80% use-case.