### PR TITLE
ref(core): Don't record stack traces for telemetry

### DIFF
--- a/packages/bundler-plugin-core/src/index.ts
+++ b/packages/bundler-plugin-core/src/index.ts
@@ -13,7 +13,6 @@ import "@sentry/tracing";
 import {
   addPluginOptionInformationToHub,
   addSpanToTransaction,
-  captureMinimalError,
   makeSentryClient,
   shouldSendTelemetry,
 } from "./sentry/telemetry";
@@ -21,7 +20,7 @@ import { Span, Transaction } from "@sentry/types";
 import { createLogger, Logger } from "./sentry/logger";
 import { InternalOptions, normalizeUserOptions, validateOptions } from "./options-mapping";
 import { getSentryCli } from "./sentry/cli";
-import { Hub, makeMain } from "@sentry/node";
+import { makeMain } from "@sentry/node";
 import path from "path";
 
 // We prefix the polyfill id with \0 to tell other plugins not to try to load or transform it.
@@ -130,8 +129,7 @@ const unplugin = createUnplugin<Options>((options, unpluginMetaContext) => {
             "Unable to determine a release name. Make sure to set the `release` option or use an environment that supports auto-detection https://docs.sentry.io/cli/releases/#creating-releases`"
           ),
           logger,
-          internalOptions.errorHandler,
-          sentryHub
+          internalOptions.errorHandler
         );
       }
 
@@ -306,7 +304,7 @@ const unplugin = createUnplugin<Options>((options, unpluginMetaContext) => {
         transaction?.setStatus("ok");
       } catch (e: unknown) {
         transaction?.setStatus("cancelled");
-        handleError(e, logger, internalOptions.errorHandler, sentryHub);
+        handleError(e, logger, internalOptions.errorHandler);
       } finally {
         sentryHub.addBreadcrumb({
           category: "writeBundle:finish",
@@ -325,17 +323,12 @@ const unplugin = createUnplugin<Options>((options, unpluginMetaContext) => {
 function handleError(
   unknownError: unknown,
   logger: Logger,
-  errorHandler: InternalOptions["errorHandler"],
-  sentryHub?: Hub
+  errorHandler: InternalOptions["errorHandler"]
 ) {
   if (unknownError instanceof Error) {
     logger.error(unknownError.message);
   } else {
     logger.error(String(unknownError));
-  }
-
-  if (sentryHub) {
-    captureMinimalError(unknownError, sentryHub);
   }
 
   if (errorHandler) {

--- a/packages/bundler-plugin-core/src/sentry/releasePipeline.ts
+++ b/packages/bundler-plugin-core/src/sentry/releasePipeline.ts
@@ -20,6 +20,9 @@ export async function createNewRelease(
 
   try {
     await ctx.cli.releases.new(releaseName);
+  } catch (e) {
+    ctx.hub.captureException(new Error("CLI Error: Creating new release failed"));
+    throw e;
   } finally {
     span?.finish();
   }
@@ -41,6 +44,9 @@ export async function cleanArtifacts(
 
   try {
     await ctx.cli.releases.execute(["releases", "files", releaseName, "delete", "--all"], true);
+  } catch (e) {
+    ctx.hub.captureException(new Error("CLI Error: Deleting release files failed"));
+    throw e;
   } finally {
     span?.finish();
   }
@@ -60,6 +66,9 @@ export async function uploadSourceMaps(
   // we only need to pass the include option here.
   try {
     await ctx.cli.releases.uploadSourceMaps(releaseName, { include: options.include });
+  } catch (e) {
+    ctx.hub.captureException(new Error("CLI Error: Uploading source maps failed"));
+    throw e;
   } finally {
     span?.finish();
   }
@@ -90,6 +99,9 @@ export async function setCommits(
       ignoreMissing,
       ignoreEmpty,
     });
+  } catch (e) {
+    ctx.hub.captureException(new Error("CLI Error: Setting commits failed"));
+    throw e;
   } finally {
     span?.finish();
   }
@@ -111,6 +123,9 @@ export async function finalizeRelease(
 
   try {
     await ctx.cli.releases.finalize(releaseName);
+  } catch (e) {
+    ctx.hub.captureException(new Error("CLI Error: Finalizing release failed"));
+    throw e;
   } finally {
     span?.finish();
   }
@@ -141,6 +156,9 @@ export async function addDeploy(
       name,
       url,
     });
+  } catch (e) {
+    ctx.hub.captureException(new Error("CLI Error: Adding deploy info failed"));
+    throw e;
   } finally {
     span?.finish();
   }

--- a/packages/bundler-plugin-core/src/sentry/telemetry.ts
+++ b/packages/bundler-plugin-core/src/sentry/telemetry.ts
@@ -22,6 +22,10 @@ export function makeSentryClient(
     stackParser: defaultStackParser,
 
     beforeSend: (event) => {
+      event.exception?.values?.forEach((exception) => {
+        delete exception.stacktrace;
+      });
+
       delete event.server_name; // Server name might contain PII
       return event;
     },
@@ -68,27 +72,6 @@ export function addSpanToTransaction(
   hub.configureScope((scope) => scope.setSpan(span));
 
   return span;
-}
-
-export function captureMinimalError(error: unknown | Error, hub: Hub) {
-  let sentryError;
-
-  if (error && typeof error === "object") {
-    const e = error as { name?: string; message?: string; stack?: string };
-    sentryError = {
-      name: e.name,
-      message: e.message,
-      stack: e.stack,
-    };
-  } else {
-    sentryError = {
-      name: "Error",
-      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-      message: `${error}`,
-    };
-  }
-
-  hub.captureException(sentryError);
 }
 
 export function addPluginOptionInformationToHub(

--- a/packages/bundler-plugin-core/test/sentry/telemetry.test.ts
+++ b/packages/bundler-plugin-core/test/sentry/telemetry.test.ts
@@ -1,10 +1,6 @@
 import { Hub } from "@sentry/node";
 import { InternalOptions } from "../../src/options-mapping";
-import {
-  addPluginOptionInformationToHub,
-  captureMinimalError,
-  shouldSendTelemetry,
-} from "../../src/sentry/telemetry";
+import { addPluginOptionInformationToHub, shouldSendTelemetry } from "../../src/sentry/telemetry";
 
 const mockCliExecute = jest.fn();
 jest.mock(
@@ -32,63 +28,6 @@ describe("shouldSendTelemetry", () => {
       () => "Sentry Server: https://sentry.io  \nsomeotherstuff\netc"
     );
     expect(await shouldSendTelemetry({} as InternalOptions)).toBe(true);
-  });
-});
-
-describe("captureMinimalError", () => {
-  const mockedHub = {
-    captureException: jest.fn(),
-  };
-
-  beforeEach(() => {
-    jest.resetAllMocks();
-  });
-
-  it("Should capture a normal error", () => {
-    captureMinimalError(new Error("test"), mockedHub as unknown as Hub);
-    expect(mockedHub.captureException).toHaveBeenCalledWith({
-      name: "Error",
-      message: "test",
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      stack: expect.any(String),
-    });
-  });
-
-  it("Shouldn't capture an error with additional data", () => {
-    const error = new Error("test");
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    (error as any).additionalContext = { foo: "bar" };
-
-    captureMinimalError(error, mockedHub as unknown as Hub);
-
-    expect(mockedHub.captureException).toHaveBeenCalledWith({
-      name: "Error",
-      message: "test",
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      stack: expect.any(String),
-    });
-  });
-
-  it("Should handle string messages gracefully", () => {
-    const error = "Property x is missing!";
-
-    captureMinimalError(error, mockedHub as unknown as Hub);
-
-    expect(mockedHub.captureException).toHaveBeenCalledWith({
-      name: "Error",
-      message: error,
-    });
-  });
-
-  it("Should even handle undefined gracefully", () => {
-    const error = undefined;
-
-    captureMinimalError(error, mockedHub as unknown as Hub);
-
-    expect(mockedHub.captureException).toHaveBeenCalledWith({
-      name: "Error",
-      message: "undefined",
-    });
   });
 });
 


### PR DESCRIPTION
Stack traces might contain PII. We can just remove the entire stack trace instead of renaming the frames because once we get rid of the frames the stack trace becomes useless anyways.