### PR TITLE
ref(core): Decouple breadcrumb usage from logger

### DIFF
--- a/packages/bundler-plugin-core/src/index.ts
+++ b/packages/bundler-plugin-core/src/index.ts
@@ -78,7 +78,6 @@ const unplugin = createUnplugin<Options>((options, unpluginMetaContext) => {
   makeMain(sentryHub);
 
   const logger = createLogger({
-    hub: sentryHub,
     prefix: `[sentry-${unpluginMetaContext.framework}-plugin]`,
     silent: internalOptions.silent,
     debug: internalOptions.debug,
@@ -119,6 +118,12 @@ const unplugin = createUnplugin<Options>((options, unpluginMetaContext) => {
       if (isAllowedToSendToSendTelemetry) {
         logger.info("Sending error and performance telemetry data to Sentry.");
         logger.info("To disable telemetry, set `options.telemetry` to `false`.");
+        sentryHub.addBreadcrumb({ level: "info", message: "Telemetry enabled." });
+      } else {
+        sentryHub.addBreadcrumb({
+          level: "info",
+          message: "Telemetry disabled. This should never show up in a Sentry event.",
+        });
       }
 
       const releaseName = await releaseNamePromise;

--- a/packages/bundler-plugin-core/src/index.ts
+++ b/packages/bundler-plugin-core/src/index.ts
@@ -311,18 +311,23 @@ const unplugin = createUnplugin<Options>((options, unpluginMetaContext) => {
         transaction?.setStatus("ok");
       } catch (e: unknown) {
         transaction?.setStatus("cancelled");
+        sentryHub.addBreadcrumb({
+          level: "error",
+          message: "Error during writeBundle",
+        });
         handleError(e, logger, internalOptions.errorHandler, sentryHub);
       } finally {
-        sentryHub.addBreadcrumb({
-          category: "writeBundle:finish",
-          level: "info",
-        });
         releasePipelineSpan?.finish();
         transaction?.finish();
         await sentryClient.flush().then(null, () => {
           logger.warn("Sending of telemetry failed");
         });
       }
+
+      sentryHub.addBreadcrumb({
+        category: "writeBundle:finish",
+        level: "info",
+      });
     },
   };
 });

--- a/packages/bundler-plugin-core/src/sentry/logger.ts
+++ b/packages/bundler-plugin-core/src/sentry/logger.ts
@@ -1,9 +1,6 @@
-import { SeverityLevel, Hub } from "@sentry/node";
-
 interface LoggerOptions {
   silent: boolean;
   debug: boolean;
-  hub: Hub;
   prefix: string;
 }
 
@@ -15,44 +12,29 @@ export type Logger = {
 };
 
 export function createLogger(options: LoggerOptions): Logger {
-  function addBreadcrumb(level: SeverityLevel, message: string) {
-    options.hub.addBreadcrumb({
-      category: "logger",
-      level,
-      message,
-    });
-  }
-
   return {
     info(message: string, ...params: unknown[]) {
       if (!options.silent) {
         // eslint-disable-next-line no-console
         console.log(`${options.prefix} Info: ${message}`, ...params);
       }
-
-      addBreadcrumb("info", message);
     },
     warn(message: string, ...params: unknown[]) {
       if (!options.silent) {
         // eslint-disable-next-line no-console
         console.log(`${options.prefix} Warning: ${message}`, ...params);
       }
-
-      addBreadcrumb("warning", message);
     },
     error(message: string, ...params: unknown[]) {
       if (!options.silent) {
         // eslint-disable-next-line no-console
         console.log(`${options.prefix} Error: ${message}`, ...params);
       }
-
-      addBreadcrumb("error", message);
     },
     debug(message: string, ...params: unknown[]) {
       if (!options.silent && options.debug) {
         // eslint-disable-next-line no-console
         console.log(`${options.prefix} Debug: ${message}`, ...params);
-        // We're not creating breadcrumbs for debug logs because it is super spammy
       }
     },
   };

--- a/packages/bundler-plugin-core/src/sentry/releasePipeline.ts
+++ b/packages/bundler-plugin-core/src/sentry/releasePipeline.ts
@@ -24,6 +24,7 @@ export async function createNewRelease(
     span?.finish();
   }
 
+  ctx.hub.addBreadcrumb({ level: "info", message: "Successfully created release." });
   ctx.logger.info("Successfully created release.");
 }
 
@@ -45,6 +46,7 @@ export async function cleanArtifacts(
     span?.finish();
   }
 
+  ctx.hub.addBreadcrumb({ level: "info", message: "Successfully cleaned previous artifacts." });
   ctx.logger.info("Successfully cleaned previous artifacts.");
 }
 
@@ -64,7 +66,8 @@ export async function uploadSourceMaps(
     span?.finish();
   }
 
-  ctx.logger.info("Successfully uploaded Sourcemaps.");
+  ctx.hub.addBreadcrumb({ level: "info", message: "Successfully uploaded source maps." });
+  ctx.logger.info("Successfully uploaded source maps.");
 }
 
 export async function setCommits(
@@ -103,6 +106,7 @@ export async function finalizeRelease(
   releaseName: string
 ): Promise<void> {
   if (!options.finalize) {
+    ctx.hub.addBreadcrumb({ level: "info", message: "Skipping release finalization." });
     logger.debug("Skipping release finalization.");
     return;
   }
@@ -115,6 +119,7 @@ export async function finalizeRelease(
     span?.finish();
   }
 
+  ctx.hub.addBreadcrumb({ level: "info", message: "Successfully finalized release." });
   ctx.logger.info("Successfully finalized release.");
 }
 
@@ -124,6 +129,7 @@ export async function addDeploy(
   releaseName: string
 ): Promise<void> {
   if (!options.deploy) {
+    ctx.hub.addBreadcrumb({ level: "info", message: "Skipping adding deploy info to release." });
     logger.debug("Skipping adding deploy info to release.");
     return;
   }
@@ -145,5 +151,6 @@ export async function addDeploy(
     span?.finish();
   }
 
+  ctx.hub.addBreadcrumb({ level: "info", message: "Successfully added deploy." });
   ctx.logger.info("Successfully added deploy.");
 }

--- a/packages/bundler-plugin-core/test/sentry/logger.test.ts
+++ b/packages/bundler-plugin-core/test/sentry/logger.test.ts
@@ -1,22 +1,10 @@
-import { Hub } from "@sentry/node";
 import { createLogger } from "../../src/sentry/logger";
 
 describe("Logger", () => {
   const consoleLogSpy = jest.spyOn(console, "log").mockImplementation(() => undefined);
 
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
-  const hub: Hub = {
-    addBreadcrumb: () => {
-      return;
-    },
-  };
-
-  const mockedAddBreadcrumb = jest.spyOn(hub, "addBreadcrumb");
-
   afterEach(() => {
     consoleLogSpy.mockReset();
-    mockedAddBreadcrumb.mockReset();
   });
 
   it.each([
@@ -25,16 +13,11 @@ describe("Logger", () => {
     ["error", "Error"],
   ] as const)(".%s() should log correctly", (loggerMethod, logLevel) => {
     const prefix = "[some-prefix]";
-    const logger = createLogger({ hub, prefix, silent: false, debug: true });
+    const logger = createLogger({ prefix, silent: false, debug: true });
 
     logger[loggerMethod]("Hey!");
 
     expect(consoleLogSpy).toHaveBeenCalledWith(`[some-prefix] ${logLevel}: Hey!`);
-    expect(mockedAddBreadcrumb).toHaveBeenCalledWith({
-      category: "logger",
-      level: logLevel.toLowerCase(),
-      message: "Hey!",
-    });
   });
 
   it.each([
@@ -43,7 +26,7 @@ describe("Logger", () => {
     ["error", "Error"],
   ] as const)(".%s() should log multiple params correctly", (loggerMethod, logLevel) => {
     const prefix = "[some-prefix]";
-    const logger = createLogger({ hub, prefix, silent: false, debug: true });
+    const logger = createLogger({ prefix, silent: false, debug: true });
 
     logger[loggerMethod]("Hey!", "this", "is", "a test with", 5, "params");
 
@@ -55,26 +38,20 @@ describe("Logger", () => {
       5,
       "params"
     );
-    expect(mockedAddBreadcrumb).toHaveBeenCalledWith({
-      category: "logger",
-      level: logLevel.toLowerCase(),
-      message: "Hey!",
-    });
   });
 
   it(".debug() should log correctly", () => {
     const prefix = "[some-prefix]";
-    const logger = createLogger({ hub, prefix, silent: false, debug: true });
+    const logger = createLogger({ prefix, silent: false, debug: true });
 
     logger.debug("Hey!");
 
     expect(consoleLogSpy).toHaveBeenCalledWith(`[some-prefix] Debug: Hey!`);
-    expect(mockedAddBreadcrumb).not.toHaveBeenCalled();
   });
 
   it(".debug() should log multiple params correctly", () => {
     const prefix = "[some-prefix]";
-    const logger = createLogger({ hub, prefix, silent: false, debug: true });
+    const logger = createLogger({ prefix, silent: false, debug: true });
 
     logger.debug("Hey!", "this", "is", "a test with", 5, "params");
 
@@ -86,33 +63,25 @@ describe("Logger", () => {
       5,
       "params"
     );
-    expect(mockedAddBreadcrumb).not.toHaveBeenCalled();
   });
 
   describe("doesn't log when `silent` option is `true`", () => {
     it.each(["info", "warn", "error"] as const)(".%s()", (loggerMethod) => {
       const prefix = "[some-prefix]";
-      const logger = createLogger({ hub, prefix, silent: true, debug: true });
+      const logger = createLogger({ prefix, silent: true, debug: true });
 
       logger[loggerMethod]("Hey!");
 
       expect(consoleLogSpy).not.toHaveBeenCalled();
-
-      expect(mockedAddBreadcrumb).toHaveBeenCalledWith({
-        category: "logger",
-        level: expect.stringMatching(/.*/) as string,
-        message: "Hey!",
-      });
     });
   });
 
   it(".debug() doesn't log when `silent` option is `true`", () => {
     const prefix = "[some-prefix]";
-    const logger = createLogger({ hub, prefix, silent: true, debug: true });
+    const logger = createLogger({ prefix, silent: true, debug: true });
 
     logger.debug("Hey!");
 
     expect(consoleLogSpy).not.toHaveBeenCalled();
-    expect(mockedAddBreadcrumb).not.toHaveBeenCalled();
   });
 });

--- a/packages/bundler-plugin-core/test/sentry/releasePipeline.test.ts
+++ b/packages/bundler-plugin-core/test/sentry/releasePipeline.test.ts
@@ -33,6 +33,10 @@ describe("Release Pipeline", () => {
     error: jest.fn(),
   };
 
+  const mockedHub = {
+    addBreadcrumb: jest.fn(),
+  };
+
   const mockedCLI = {
     releases: {
       new: jest.fn(),
@@ -47,7 +51,7 @@ describe("Release Pipeline", () => {
   const mockedChildSpan = { finish: jest.fn() };
   mockedAddSpanToTxn.mockImplementation(() => mockedChildSpan);
 
-  const ctx = { cli: mockedCLI, logger: mockedLogger };
+  const ctx = { cli: mockedCLI, logger: mockedLogger, hub: mockedHub };
 
   beforeEach(() => {
     jest.clearAllMocks();


### PR DESCRIPTION
Breadcrumbs can potentially leak PII so we make their usage explicit.