### PR TITLE
fix: Add definitions in `package.json` for ESM resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## 0.2.2
 
 - feat(core): Remove `server_name` from telemetry events (#135)
+- fix: Add definitions in package.json for ESM resolution (#141)
 - fix(core): Finish spans when CLI commands fail (#136)
 - ref(core): Decouple breadcrumb usage from logger (#138)
 - ref(core): Don't record stack traces for telemetry (#137)

--- a/packages/bundler-plugin-core/package.json
+++ b/packages/bundler-plugin-core/package.json
@@ -12,8 +12,14 @@
   "files": [
     "dist"
   ],
+  "exports": {
+    ".": {
+      "import": "./dist/esm/index.mjs",
+      "require": "./dist/cjs/index.js"
+    }
+  },
   "main": "dist/cjs/index.js",
-  "module": "dist/esm/index.js",
+  "module": "dist/esm/index.mjs",
   "types": "dist/types/index.d.ts",
   "scripts": {
     "build": "rimraf ./out && run-p build:rollup build:types",

--- a/packages/esbuild-plugin/package.json
+++ b/packages/esbuild-plugin/package.json
@@ -18,8 +18,14 @@
   "files": [
     "dist"
   ],
+  "exports": {
+    ".": {
+      "import": "./dist/esm/index.mjs",
+      "require": "./dist/cjs/index.js"
+    }
+  },
   "main": "dist/cjs/index.js",
-  "module": "dist/esm/index.js",
+  "module": "dist/esm/index.mjs",
   "types": "dist/types/index.d.ts",
   "scripts": {
     "build": "rimraf ./out && run-p build:rollup build:types",

--- a/packages/rollup-plugin/package.json
+++ b/packages/rollup-plugin/package.json
@@ -19,8 +19,14 @@
   "files": [
     "dist"
   ],
+  "exports": {
+    ".": {
+      "import": "./dist/esm/index.mjs",
+      "require": "./dist/cjs/index.js"
+    }
+  },
   "main": "dist/cjs/index.js",
-  "module": "dist/esm/index.js",
+  "module": "dist/esm/index.mjs",
   "types": "dist/types/index.d.ts",
   "scripts": {
     "build": "rimraf ./out && run-p build:rollup build:types",

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -18,8 +18,14 @@
   "files": [
     "dist"
   ],
+  "exports": {
+    ".": {
+      "import": "./dist/esm/index.mjs",
+      "require": "./dist/cjs/index.js"
+    }
+  },
   "main": "dist/cjs/index.js",
-  "module": "dist/esm/index.js",
+  "module": "dist/esm/index.mjs",
   "types": "dist/types/index.d.ts",
   "scripts": {
     "build": "rimraf ./out && run-p build:rollup build:types",

--- a/packages/webpack-plugin/package.json
+++ b/packages/webpack-plugin/package.json
@@ -19,8 +19,14 @@
   "files": [
     "dist"
   ],
+  "exports": {
+    ".": {
+      "import": "./dist/esm/index.mjs",
+      "require": "./dist/cjs/index.js"
+    }
+  },
   "main": "dist/cjs/index.js",
-  "module": "dist/esm/index.js",
+  "module": "dist/esm/index.mjs",
   "types": "dist/types/index.d.ts",
   "scripts": {
     "build": "rimraf ./out && run-p build:rollup build:types",


### PR DESCRIPTION
Fixes #140

This PR adds definitions to the `package.json`s of published packages and changes the file extension of the ESM bundle to `.mjs` which should fix importing the bundler plugins when using `"type": "module"` or `--experimental-modules`.