### PR TITLE
ref(core): Send project as `dist` in telemetry

### DIFF
--- a/packages/bundler-plugin-core/src/index.ts
+++ b/packages/bundler-plugin-core/src/index.ts
@@ -64,7 +64,8 @@ const unplugin = createUnplugin<Options>((options, unpluginMetaContext) => {
 
   const { sentryHub, sentryClient } = makeSentryClient(
     "https://4c2bae7d9fbc413e8f7385f55c515d51@o1.ingest.sentry.io/6690737",
-    allowedToSendTelemetryPromise
+    allowedToSendTelemetryPromise,
+    internalOptions.project
   );
 
   addPluginOptionInformationToHub(internalOptions, sentryHub, unpluginMetaContext.framework);

--- a/packages/bundler-plugin-core/src/sentry/telemetry.ts
+++ b/packages/bundler-plugin-core/src/sentry/telemetry.ts
@@ -7,13 +7,19 @@ const SENTRY_SAAS_HOSTNAME = "sentry.io";
 
 export function makeSentryClient(
   dsn: string,
-  allowedToSendTelemetryPromise: Promise<boolean>
+  allowedToSendTelemetryPromise: Promise<boolean>,
+  userProject: string | undefined
 ): { sentryHub: Hub; sentryClient: NodeClient } {
   const client = new NodeClient({
     dsn,
 
     tracesSampleRate: 1,
     sampleRate: 1,
+
+    // We're also sending the user project in dist because it is an indexed fieldso we can use this data effectively in
+    // a dashboard.
+    // Yes, this is slightly abusing the purpose of this field.
+    dist: userProject,
 
     release: __PACKAGE_VERSION__,
     integrations: [],


### PR DESCRIPTION
Sends the user project as `dist` in telemetry so we can query for it efficiently in dashboards since `dist` is an indexed parameter.