### PR TITLE
ci: Fix faulty image type for CodeQL

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,7 +29,7 @@ concurrency:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-20-latest
+    runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
Attempt to fix CI failing/being queued forever for CodeQL.

Ref: https://github.com/getsentry/sentry-javascript-bundler-plugins/pull/152#issuecomment-1346449182