### PR TITLE
ref: Turn default exports into named exports

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -37,3 +37,46 @@ Matching behaviour stays the same.
 Previously, the webpack plugin always injected a `SENTRY_RELEASES` variable into the global object which would map from `project@org` to the `release` value. In version 2, we made this behaviour opt-in by setting the `injectReleasesMap` option in the plugin options to `true`.
 
 The purpose of this option is to support module-federated projects or micro frontend setups where multiple projects would want to access the global release variable. However, Sentry SDKs by default never accessed this variable so it would require manual user-intervention to make use of it. Making this behaviour opt-in decreases the bundle size impact of our plugin for the majority of users.
+
+## Upgrading from 0.3.x to 0.4.x
+
+### Replacing default exports with named exports
+
+Previously all the plugins were exported as default exports.
+Moving forward, with version `0.4.x` of the plugins, all exports become named exports:
+
+```ts
+import sentryVitePlugin from "@sentry/vite-plugin";
+// becomes
+import { sentryVitePlugin } from "@sentry/vite-plugin";
+
+import sentryEsbuildPlugin from "@sentry/esbuild-plugin";
+// becomes
+import { sentryEsbuildPlugin } from "@sentry/esbuild-plugin";
+
+import sentryRollupPlugin from "@sentry/rollup-plugin";
+// becomes
+import { sentryRollupPlugin } from "@sentry/rollup-plugin";
+```
+
+### Renaming of `Options` type export
+
+The `Options` type was a bit too generic for our taste so we renamed it:
+
+```ts
+import type { Options } from "@sentry/vite-plugin";
+// becomes
+import type { SentryVitePluginOptions } from "@sentry/vite-plugin";
+
+import type { Options } from "@sentry/esbuild-plugin";
+// becomes
+import type { SentryEsbuildPluginOptions } from "@sentry/esbuild-plugin";
+
+import type { Options } from "@sentry/rollup-plugin";
+// becomes
+import type { SentryRollupPluginOptions } from "@sentry/rollup-plugin";
+```
+
+### Removal of `customHeader` option
+
+We removed the `customHeader` option in favor of the `headers` option.

--- a/packages/e2e-tests/utils/create-cjs-bundles.ts
+++ b/packages/e2e-tests/utils/create-cjs-bundles.ts
@@ -5,10 +5,11 @@ import { default as webpack4 } from "webpack4";
 import { webpack as webpack5 } from "webpack";
 import * as esbuild from "esbuild";
 
-import sentryVitePlugin, { Options } from "@sentry/vite-plugin";
-import sentryWebpackPlugin from "@sentry/webpack-plugin";
-import sentryEsbuildPlugin from "@sentry/esbuild-plugin";
-import sentryRollupPlugin from "@sentry/rollup-plugin";
+import type { Options } from "@sentry/bundler-plugin-core";
+import { sentryVitePlugin } from "@sentry/vite-plugin";
+import { sentryWebpackPlugin } from "@sentry/webpack-plugin";
+import { sentryEsbuildPlugin } from "@sentry/esbuild-plugin";
+import { sentryRollupPlugin } from "@sentry/rollup-plugin";
 
 export function createCjsBundles(
   entrypoints: { [name: string]: string },

--- a/packages/esbuild-plugin/README.md
+++ b/packages/esbuild-plugin/README.md
@@ -31,7 +31,7 @@ $ yarn add @sentry/esbuild-plugin --dev
 
 ```js
 // esbuild.config.js
-const sentryEsbuildPlugin = require("@sentry/esbuild-plugin");
+const { sentryEsbuildPlugin } = require("@sentry/esbuild-plugin");
 
 require("esbuild").build({
   plugins: [

--- a/packages/esbuild-plugin/src/index.ts
+++ b/packages/esbuild-plugin/src/index.ts
@@ -1,2 +1,2 @@
-export { sentryEsbuildPlugin as default } from "@sentry/bundler-plugin-core";
-export type { Options } from "@sentry/bundler-plugin-core";
+export { sentryEsbuildPlugin } from "@sentry/bundler-plugin-core";
+export type { Options as SentryEsbuildPluginOptions } from "@sentry/bundler-plugin-core";

--- a/packages/esbuild-plugin/test/public-api.test.ts
+++ b/packages/esbuild-plugin/test/public-api.test.ts
@@ -1,4 +1,4 @@
-import sentryEsbuildPlugin from "../src";
+import { sentryEsbuildPlugin } from "../src";
 
 test("Esbuild plugin should exist", () => {
   expect(sentryEsbuildPlugin).toBeDefined();

--- a/packages/rollup-plugin/README.md
+++ b/packages/rollup-plugin/README.md
@@ -31,7 +31,7 @@ $ yarn add @sentry/rollup-plugin --dev
 
 ```js
 // rollup.config.js
-import sentryRollupPlugin from "@sentry/rollup-plugin";
+import { sentryRollupPlugin } from "@sentry/rollup-plugin";
 
 export default {
   plugins: [

--- a/packages/rollup-plugin/src/index.ts
+++ b/packages/rollup-plugin/src/index.ts
@@ -1,2 +1,2 @@
-export { sentryRollupPlugin as default } from "@sentry/bundler-plugin-core";
-export type { Options } from "@sentry/bundler-plugin-core";
+export { sentryRollupPlugin } from "@sentry/bundler-plugin-core";
+export type { Options as SentryRollupPluginOptions } from "@sentry/bundler-plugin-core";

--- a/packages/rollup-plugin/test/public-api.test.ts
+++ b/packages/rollup-plugin/test/public-api.test.ts
@@ -1,4 +1,4 @@
-import sentryRollupPlugin from "../src";
+import { sentryRollupPlugin } from "../src";
 
 test("Rollup plugin should exist", () => {
   expect(sentryRollupPlugin).toBeDefined();

--- a/packages/vite-plugin/README.md
+++ b/packages/vite-plugin/README.md
@@ -31,7 +31,7 @@ $ yarn add @sentry/vite-plugin --dev
 
 ```ts
 // vite.config.ts
-import sentryVitePlugin from "@sentry/vite-plugin";
+import { sentryVitePlugin } from "@sentry/vite-plugin";
 
 export default {
   plugins: [

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -1,2 +1,2 @@
-export { sentryVitePlugin as default } from "@sentry/bundler-plugin-core";
-export type { Options } from "@sentry/bundler-plugin-core";
+export { sentryVitePlugin } from "@sentry/bundler-plugin-core";
+export type { Options as SentryVitePluginOptions } from "@sentry/bundler-plugin-core";

--- a/packages/vite-plugin/test/public-api.test.ts
+++ b/packages/vite-plugin/test/public-api.test.ts
@@ -1,4 +1,4 @@
-import sentryVitePlugin from "../src";
+import { sentryVitePlugin } from "../src";
 
 test("Vite plugin should exist", () => {
   expect(sentryVitePlugin).toBeDefined();

--- a/packages/webpack-plugin/README.md
+++ b/packages/webpack-plugin/README.md
@@ -31,7 +31,7 @@ $ yarn add @sentry/webpack-plugin --dev
 
 ```js
 // webpack.config.js
-const sentryWebpackPlugin = require("@sentry/webpack-plugin");
+const { sentryWebpackPlugin } = require("@sentry/webpack-plugin");
 
 module.exports = {
   plugins: [

--- a/packages/webpack-plugin/src/index.ts
+++ b/packages/webpack-plugin/src/index.ts
@@ -1,2 +1,2 @@
-export { sentryWebpackPlugin as default } from "@sentry/bundler-plugin-core";
-export type { Options } from "@sentry/bundler-plugin-core";
+export { sentryWebpackPlugin } from "@sentry/bundler-plugin-core";
+export type { Options as SentryWebpackPluginOptions } from "@sentry/bundler-plugin-core";

--- a/packages/webpack-plugin/test/public-api.test.ts
+++ b/packages/webpack-plugin/test/public-api.test.ts
@@ -1,4 +1,4 @@
-import sentryWebpackPlugin from "../src";
+import { sentryWebpackPlugin } from "../src";
 
 test("Webpack plugin should exist", () => {
   expect(sentryWebpackPlugin).toBeDefined();


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript-bundler-plugins/issues/161

Turns all the default exports of the plugins into named exports. This is just way more future proof in case we want to export more stuff and properly support CJS at the same time.