### PR TITLE
feat: Add `sentryCliBinaryExists` function

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -43,6 +43,10 @@ The purpose of this option is to support module-federated projects or micro fron
 The `customHeader` was used to attach an additional header to outgoing requests to Sentry when uploading source maps.
 This option has been removed in favor of the `headers` option which allows for attaching multiple headers.
 
+### Renaming of `cliBinaryExists` to `sentryCliBinaryExists`
+
+The `cliBinaryExists` function was renamed to `sentryCliBinaryExists`.
+
 ## Upgrading from 0.3.x to 0.4.x
 
 ### Replacing default exports with named exports

--- a/packages/bundler-plugin-core/src/index.ts
+++ b/packages/bundler-plugin-core/src/index.ts
@@ -10,6 +10,7 @@ import {
   uploadSourceMaps,
 } from "./sentry/releasePipeline";
 import "@sentry/tracing";
+import SentryCli from "@sentry/cli";
 import {
   addPluginOptionInformationToHub,
   addSpanToTransaction,
@@ -22,6 +23,7 @@ import { InternalOptions, normalizeUserOptions, validateOptions } from "./option
 import { getSentryCli } from "./sentry/cli";
 import { makeMain } from "@sentry/node";
 import path from "path";
+import fs from "fs";
 
 const ALLOWED_TRANSFORMATION_FILE_ENDINGS = [".js", ".ts", ".jsx", ".tsx", ".mjs"];
 
@@ -362,6 +364,15 @@ function generateGlobalInjectorCode({
   }
 
   return code;
+}
+
+/**
+ * Determines whether the Sentry CLI binary is in its expected location.
+ * This function is useful since `@sentry/cli` installs the binary via a post-install
+ * script and post-install scripts may not always run. E.g. with `npm i --ignore-scripts`.
+ */
+export function sentryCliBinaryExists(): boolean {
+  return fs.existsSync(SentryCli.getPath());
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/esbuild-plugin/src/index.ts
+++ b/packages/esbuild-plugin/src/index.ts
@@ -1,2 +1,2 @@
-export { sentryEsbuildPlugin } from "@sentry/bundler-plugin-core";
+export { sentryEsbuildPlugin, sentryCliBinaryExists } from "@sentry/bundler-plugin-core";
 export type { Options as SentryEsbuildPluginOptions } from "@sentry/bundler-plugin-core";

--- a/packages/rollup-plugin/src/index.ts
+++ b/packages/rollup-plugin/src/index.ts
@@ -1,2 +1,2 @@
-export { sentryRollupPlugin } from "@sentry/bundler-plugin-core";
+export { sentryRollupPlugin, sentryCliBinaryExists } from "@sentry/bundler-plugin-core";
 export type { Options as SentryRollupPluginOptions } from "@sentry/bundler-plugin-core";

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -1,2 +1,2 @@
-export { sentryVitePlugin } from "@sentry/bundler-plugin-core";
+export { sentryVitePlugin, sentryCliBinaryExists } from "@sentry/bundler-plugin-core";
 export type { Options as SentryVitePluginOptions } from "@sentry/bundler-plugin-core";

--- a/packages/webpack-plugin/src/index.ts
+++ b/packages/webpack-plugin/src/index.ts
@@ -1,2 +1,2 @@
-export { sentryWebpackPlugin } from "@sentry/bundler-plugin-core";
+export { sentryWebpackPlugin, sentryCliBinaryExists } from "@sentry/bundler-plugin-core";
 export type { Options as SentryWebpackPluginOptions } from "@sentry/bundler-plugin-core";


### PR DESCRIPTION
This PR adds a function which exists in the current implementation of the webpack plugin to check for the existence of the sentry cli in node modules.

We need this for the Next.js SDK.