### PR TITLE
docs: Fix documentation to use named exports

### DIFF
--- a/packages/vite-plugin/README.md
+++ b/packages/vite-plugin/README.md
@@ -105,7 +105,7 @@ Example:
 
 ```ts
 // vite.config.ts
-import sentryVitePlugin from "@sentry/vite-plugin";
+import { sentryVitePlugin } from "@sentry/vite-plugin";
 
 export default {
   plugins: [


### PR DESCRIPTION
see changelog from 0.3.0 to 0.4.0