### PR TITLE
fix(core): Skip all transformations for 3rd party modules

### DIFF
--- a/packages/bundler-plugin-core/src/index.ts
+++ b/packages/bundler-plugin-core/src/index.ts
@@ -133,6 +133,12 @@ const unplugin = createUnplugin<Options>((options, unpluginMetaContext) => {
         });
       }
 
+      if (process.cwd().match(/\\node_modules\\|\/node_modules\//)) {
+        logger.warn(
+          "Running Sentry plugin from within a `node_modules` folder. Some features may not work."
+        );
+      }
+
       const releaseName = await releaseNamePromise;
 
       // At this point, we either have determined a release or we have to bail
@@ -184,6 +190,10 @@ const unplugin = createUnplugin<Options>((options, unpluginMetaContext) => {
      */
     transformInclude(id) {
       logger.debug('Called "transformInclude":', { id });
+
+      if (id.match(/\\node_modules\\|\/node_modules\//)) {
+        return false; // never transform 3rd party modules
+      }
 
       // We normalize the id because vite always passes `id` as a unix style path which causes problems when a user passes
       // a windows style path to `releaseInjectionTargets`


### PR DESCRIPTION
Hopefully fixes https://github.com/getsentry/sentry-javascript-bundler-plugins/issues/194

It seems like injecting into 3rd party modules may cause them to be bundled/resolved differently and this will fail some builds.

It could be that this is just an incompatibility with another plugin but I say it is worth just making this exemption.