### PR TITLE
fix: Add typing exports to packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ plugin({
 - feat(esbuild): Add debug ID injection for esbuild (#202)
 - feat: Promote debug ID uploading to stable via `sourcemaps` option (#204)
 - fix(core): Also do debug ID injection for `.cjs` files (#203)
+- fix: Add typing exports to packages (#208)
 
 ## 0.6.0
 

--- a/packages/bundler-plugin-core/package.json
+++ b/packages/bundler-plugin-core/package.json
@@ -20,8 +20,14 @@
       "require": "./dist/cjs/index.js",
       "types": "./dist/types/index.d.ts"
     },
-    "./sentry-release-injection-file": "./sentry-release-injection-file.js",
-    "./sentry-esbuild-debugid-injection-file": "./sentry-esbuild-debugid-injection-file.js"
+    "./sentry-release-injection-file": {
+      "import": "./sentry-release-injection-file.js",
+      "require": "./sentry-release-injection-file.js"
+    },
+    "./sentry-esbuild-debugid-injection-file": {
+      "import": "./sentry-esbuild-debugid-injection-file.js",
+      "require": "./sentry-esbuild-debugid-injection-file.js"
+    }
   },
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.mjs",

--- a/packages/bundler-plugin-core/package.json
+++ b/packages/bundler-plugin-core/package.json
@@ -20,14 +20,8 @@
       "require": "./dist/cjs/index.js",
       "types": "./dist/types/index.d.ts"
     },
-    "./sentry-release-injection-file.js": {
-      "import": "./sentry-release-injection-file.js",
-      "require": "./sentry-release-injection-file.js"
-    },
-    "./sentry-esbuild-debugid-injection-file.js": {
-      "import": "./sentry-esbuild-debugid-injection-file.js",
-      "require": "./sentry-esbuild-debugid-injection-file.js"
-    }
+    "./sentry-release-injection-file": "./sentry-release-injection-file.js",
+    "./sentry-esbuild-debugid-injection-file": "./sentry-esbuild-debugid-injection-file.js"
   },
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.mjs",

--- a/packages/bundler-plugin-core/package.json
+++ b/packages/bundler-plugin-core/package.json
@@ -20,8 +20,14 @@
       "require": "./dist/cjs/index.js",
       "types": "./dist/types/index.d.ts"
     },
-    "./sentry-release-injection-file.js": "./sentry-release-injection-file.js",
-    "./sentry-esbuild-debugid-injection-file.js": "./sentry-esbuild-debugid-injection-file.js"
+    "./sentry-release-injection-file.js": {
+      "import": "./sentry-release-injection-file.js",
+      "require": "./sentry-release-injection-file.js"
+    },
+    "./sentry-esbuild-debugid-injection-file.js": {
+      "import": "./sentry-esbuild-debugid-injection-file.js",
+      "require": "./sentry-esbuild-debugid-injection-file.js"
+    }
   },
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.mjs",

--- a/packages/bundler-plugin-core/package.json
+++ b/packages/bundler-plugin-core/package.json
@@ -19,7 +19,9 @@
       "import": "./dist/esm/index.mjs",
       "require": "./dist/cjs/index.js",
       "types": "./dist/types/index.d.ts"
-    }
+    },
+    "./sentry-release-injection-file.js": "./sentry-release-injection-file.js",
+    "./sentry-esbuild-debugid-injection-file.js": "./sentry-esbuild-debugid-injection-file.js"
   },
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.mjs",

--- a/packages/bundler-plugin-core/package.json
+++ b/packages/bundler-plugin-core/package.json
@@ -14,6 +14,13 @@
     "sentry-release-injection-file.js",
     "sentry-esbuild-debugid-injection-file.js"
   ],
+  "exports": {
+    ".": {
+      "import": "./dist/esm/index.mjs",
+      "require": "./dist/cjs/index.js",
+      "types": "./dist/types/index.d.ts"
+    }
+  },
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.mjs",
   "types": "dist/types/index.d.ts",

--- a/packages/esbuild-plugin/package.json
+++ b/packages/esbuild-plugin/package.json
@@ -21,7 +21,8 @@
   "exports": {
     ".": {
       "import": "./dist/esm/index.mjs",
-      "require": "./dist/cjs/index.js"
+      "require": "./dist/cjs/index.js",
+      "types": "./dist/types/index.d.ts"
     }
   },
   "main": "dist/cjs/index.js",

--- a/packages/rollup-plugin/package.json
+++ b/packages/rollup-plugin/package.json
@@ -22,7 +22,8 @@
   "exports": {
     ".": {
       "import": "./dist/esm/index.mjs",
-      "require": "./dist/cjs/index.js"
+      "require": "./dist/cjs/index.js",
+      "types": "./dist/types/index.d.ts"
     }
   },
   "main": "dist/cjs/index.js",

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -21,7 +21,8 @@
   "exports": {
     ".": {
       "import": "./dist/esm/index.mjs",
-      "require": "./dist/cjs/index.js"
+      "require": "./dist/cjs/index.js",
+      "types": "./dist/types/index.d.ts"
     }
   },
   "main": "dist/cjs/index.js",

--- a/packages/webpack-plugin/package.json
+++ b/packages/webpack-plugin/package.json
@@ -22,7 +22,8 @@
   "exports": {
     ".": {
       "import": "./dist/esm/index.mjs",
-      "require": "./dist/cjs/index.js"
+      "require": "./dist/cjs/index.js",
+      "types": "./dist/types/index.d.ts"
     }
   },
   "main": "dist/cjs/index.js",


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript-bundler-plugins/issues/183