### PR TITLE
fix(core): Fix vite complaining about CJS import of `webpack-sources`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - "You know what they say ‘Fool me once, strike one, but fool me twice… strike three.’" — Michael Scott
 
+## 0.7.1
+
+- fix(core): Fix vite complaining about CJS import of webpack-sources (#210)
+
 ## 0.7.0
 
 This release introduces the `sourcemaps` option. This option switches to a new system of handling source maps in Sentry.

--- a/packages/bundler-plugin-core/src/index.ts
+++ b/packages/bundler-plugin-core/src/index.ts
@@ -30,7 +30,7 @@ import { promisify } from "util";
 import { getDependencies, getPackageJson, parseMajorVersion, stringToUUID } from "./utils";
 import { glob } from "glob";
 import { injectDebugIdSnippetIntoChunk, prepareBundleForDebugIdUpload } from "./debug-id";
-import { SourceMapSource } from "webpack-sources";
+import webpackSources from "webpack-sources";
 import type { sources } from "webpack";
 
 const ALLOWED_TRANSFORMATION_FILE_ENDINGS = [".js", ".ts", ".jsx", ".tsx", ".mjs"];
@@ -465,7 +465,7 @@ const unplugin = createUnplugin<Options, true>((userOptions, unpluginMetaContext
                   // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
                   newSourceMap.sourcesContent = originalSourceMap.sourcesContent as string[];
 
-                  const newSource = new SourceMapSource(
+                  const newSource = new webpackSources.SourceMapSource(
                     newCode,
                     fileName,
                     // eslint-disable-next-line @typescript-eslint/no-unsafe-argument


### PR DESCRIPTION
fixes #209