### PR TITLE
fix(core): Use `createRequire` to not use built-in `require` in ESM

### DIFF
--- a/packages/bundler-plugin-core/rollup.config.js
+++ b/packages/bundler-plugin-core/rollup.config.js
@@ -13,6 +13,9 @@ const extensions = [".js", ".ts"];
 export default {
   input,
   external: [...Object.keys(packageJson.dependencies), ...modulePackage.builtinModules],
+  onwarn: (warning) => {
+    throw new Error(warning.message); // Warnings are usually high-consequence for us so let's throw to catch them
+  },
   plugins: [
     resolve({ extensions, preferBuiltins: true }),
     commonjs(),

--- a/packages/bundler-plugin-core/src/index.ts
+++ b/packages/bundler-plugin-core/src/index.ts
@@ -26,6 +26,7 @@ import { makeMain } from "@sentry/node";
 import os from "os";
 import path from "path";
 import fs from "fs";
+import { createRequire } from "module";
 import { promisify } from "util";
 import { getDependencies, getPackageJson, parseMajorVersion, stringToUUID } from "./utils";
 import { glob } from "glob";
@@ -34,6 +35,9 @@ import webpackSources from "webpack-sources";
 import type { sources } from "webpack";
 
 const ALLOWED_TRANSFORMATION_FILE_ENDINGS = [".js", ".ts", ".jsx", ".tsx", ".mjs"];
+
+// Use createRequire because esm doesn't like built-in require.resolve
+const require = createRequire(import.meta.url);
 
 const releaseInjectionFilePath = require.resolve(
   "@sentry/bundler-plugin-core/sentry-release-injection-file"

--- a/packages/bundler-plugin-core/src/tsconfig.json
+++ b/packages/bundler-plugin-core/src/tsconfig.json
@@ -7,6 +7,7 @@
     "resolveJsonModule": true, // needed to import package.json
     "types": ["node"],
     "target": "ES6", // needed for some iterator features
+    "module": "es2020",
     "lib": ["ES2020", "DOM"] // es2020 needed for "new Set()", DOM needed for various bundler types
   }
 }


### PR DESCRIPTION
fixes https://github.com/getsentry/sentry-javascript-bundler-plugins/issues/211

Rollup takes care of correctly transpiling the import meta stuff