### PR TITLE
test: Disable E2E tests

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -78,7 +78,7 @@ jobs:
     if:
       (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) &&
       github.actor != 'dependabot[bot]' &&
-      ${{ false }} # Debug ID backend changes broke the E2E tests, we need to revisit them
+      false # Debug ID backend changes broke the E2E tests, we need to revisit them
     needs: build
     name: E2E Tests
     runs-on: ubuntu-latest

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -77,7 +77,8 @@ jobs:
     # Dependabot PRs sadly also don't have access to secrets, so we skip them as well
     if:
       (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) &&
-      github.actor != 'dependabot[bot]'
+      github.actor != 'dependabot[bot]' &&
+      ${{ false }} # Debug ID backend changes broke the E2E tests, we need to revisit them
     needs: build
     name: E2E Tests
     runs-on: ubuntu-latest


### PR DESCRIPTION
The switch to the newer artifact bundle upload has rendered our e2e tests faulty because the endpoint we ping to check for uploaded source maps doesn't return them anymore.

For now we disable them so we can have green CI again.