### PR TITLE
meta: Disable TypeScript `noUnused` rules

### DIFF
--- a/packages/tsconfigs/base-config.json
+++ b/packages/tsconfigs/base-config.json
@@ -12,6 +12,8 @@
     "noPropertyAccessFromIndexSignature": true,
     "noUncheckedIndexedAccess": true,
     "noImplicitOverride": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
     "exactOptionalPropertyTypes": false
   }
 }


### PR DESCRIPTION
ESlint will complain anyways