### PR TITLE
build: Clean up rollup configs

### DIFF
--- a/packages/bundler-plugin-core/package.json
+++ b/packages/bundler-plugin-core/package.json
@@ -53,8 +53,7 @@
   },
   "dependencies": {
     "@sentry/cli": "^2.17.0",
-    "@sentry/node": "^7.19.0",
-    "@sentry/tracing": "^7.19.0",
+    "@sentry/node": "7.50.0",
     "find-up": "5.0.0",
     "glob": "9.3.2",
     "magic-string": "0.27.0",
@@ -66,7 +65,6 @@
     "@babel/preset-env": "7.18.2",
     "@babel/preset-typescript": "7.17.12",
     "@rollup/plugin-babel": "5.3.1",
-    "@rollup/plugin-commonjs": "22.0.1",
     "@rollup/plugin-json": "4.1.0",
     "@rollup/plugin-node-resolve": "13.3.0",
     "@rollup/plugin-replace": "^4.0.0",

--- a/packages/bundler-plugin-core/rollup.config.js
+++ b/packages/bundler-plugin-core/rollup.config.js
@@ -1,14 +1,12 @@
-import commonjs from "@rollup/plugin-commonjs";
+import babel from "@rollup/plugin-babel";
+import json from "@rollup/plugin-json";
 import resolve from "@rollup/plugin-node-resolve";
 import replace from "@rollup/plugin-replace";
-import babel from "@rollup/plugin-babel";
-import packageJson from "./package.json";
-import json from "@rollup/plugin-json";
 import modulePackage from "module";
+import packageJson from "./package.json";
 
 const input = ["src/index.ts"];
-
-const extensions = [".js", ".ts"];
+const extensions = [".ts"];
 
 export default {
   input,
@@ -17,8 +15,11 @@ export default {
     throw new Error(warning.message); // Warnings are usually high-consequence for us so let's throw to catch them
   },
   plugins: [
-    resolve({ extensions, preferBuiltins: true }),
-    commonjs(),
+    resolve({
+      extensions,
+      rootDir: "./src",
+      preferBuiltins: true,
+    }),
     json(),
     replace({
       preventAssignment: true,

--- a/packages/bundler-plugin-core/src/index.ts
+++ b/packages/bundler-plugin-core/src/index.ts
@@ -10,7 +10,6 @@ import {
   uploadSourceMaps,
   uploadDebugIdSourcemaps,
 } from "./sentry/releasePipeline";
-import "@sentry/tracing";
 import SentryCli from "@sentry/cli";
 import {
   addPluginOptionInformationToHub,

--- a/packages/bundler-plugin-core/src/sentry/releasePipeline.ts
+++ b/packages/bundler-plugin-core/src/sentry/releasePipeline.ts
@@ -6,7 +6,6 @@
 //           - huge download
 //           - unnecessary functionality
 
-import { logger } from "@sentry/utils";
 import { NormalizedOptions } from "../options-mapping";
 import { BuildContext } from "../types";
 import { addSpanToTransaction } from "./telemetry";
@@ -37,7 +36,7 @@ export async function cleanArtifacts(
   releaseName: string
 ): Promise<void> {
   if (!options.cleanArtifacts) {
-    logger.debug("Skipping artifact cleanup.");
+    ctx.logger.debug("Skipping artifact cleanup.");
     return;
   }
 
@@ -62,7 +61,7 @@ export async function uploadSourceMaps(
   releaseName: string
 ): Promise<void> {
   if (!options.uploadSourceMaps) {
-    logger.debug("Skipping source maps upload.");
+    ctx.logger.debug("Skipping source maps upload.");
     return;
   }
 
@@ -126,7 +125,7 @@ export async function setCommits(
   releaseName: string
 ): Promise<void> {
   if (!options.setCommits) {
-    logger.debug("Skipping setting commits to release.");
+    ctx.logger.debug("Skipping setting commits to release.");
     return;
   }
 
@@ -160,7 +159,7 @@ export async function finalizeRelease(
 ): Promise<void> {
   if (!options.finalize) {
     ctx.hub.addBreadcrumb({ level: "info", message: "Skipping release finalization." });
-    logger.debug("Skipping release finalization.");
+    ctx.logger.debug("Skipping release finalization.");
     return;
   }
 
@@ -186,7 +185,7 @@ export async function addDeploy(
 ): Promise<void> {
   if (!options.deploy) {
     ctx.hub.addBreadcrumb({ level: "info", message: "Skipping adding deploy info to release." });
-    logger.debug("Skipping adding deploy info to release.");
+    ctx.logger.debug("Skipping adding deploy info to release.");
     return;
   }
 

--- a/packages/bundler-plugin-core/src/types.ts
+++ b/packages/bundler-plugin-core/src/types.ts
@@ -1,5 +1,4 @@
-import { Hub } from "@sentry/core";
-import { Span } from "@sentry/tracing";
+import { Hub, Span } from "@sentry/node";
 import { SentryCLILike } from "./sentry/cli";
 import { createLogger } from "./sentry/logger";
 

--- a/packages/esbuild-plugin/package.json
+++ b/packages/esbuild-plugin/package.json
@@ -54,8 +54,6 @@
     "@babel/preset-env": "7.18.2",
     "@babel/preset-typescript": "7.17.12",
     "@rollup/plugin-babel": "5.3.1",
-    "@rollup/plugin-commonjs": "22.0.1",
-    "@rollup/plugin-json": "4.1.0",
     "@rollup/plugin-node-resolve": "13.3.0",
     "@sentry-internal/eslint-config": "0.7.2",
     "@sentry-internal/sentry-bundler-plugin-tsconfig": "0.7.2",

--- a/packages/esbuild-plugin/rollup.config.js
+++ b/packages/esbuild-plugin/rollup.config.js
@@ -10,8 +10,15 @@ const extensions = [".ts"];
 export default {
   input,
   external: [...Object.keys(packageJson.dependencies), ...modulePackage.builtinModules],
+  onwarn: (warning) => {
+    throw new Error(warning.message); // Warnings are usually high-consequence for us so let's throw to catch them
+  },
   plugins: [
-    resolve({ extensions, preferBuiltins: true }),
+    resolve({
+      extensions,
+      rootDir: "./src",
+      preferBuiltins: true,
+    }),
     babel({
       extensions,
       babelHelpers: "bundled",

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -19,8 +19,8 @@
   },
   "dependencies": {
     "@sentry/bundler-plugin-core": "0.7.2",
-    "@sentry/integrations": "^7.19.0",
-    "@sentry/node": "^7.19.0",
+    "@sentry/integrations": "7.50",
+    "@sentry/node": "7.50",
     "@types/express": "^4.17.13",
     "@types/http-proxy": "^1.17.9",
     "esbuild": "0.14.49",

--- a/packages/rollup-plugin/package.json
+++ b/packages/rollup-plugin/package.json
@@ -55,8 +55,6 @@
     "@babel/preset-env": "7.18.2",
     "@babel/preset-typescript": "7.17.12",
     "@rollup/plugin-babel": "5.3.1",
-    "@rollup/plugin-commonjs": "22.0.1",
-    "@rollup/plugin-json": "4.1.0",
     "@rollup/plugin-node-resolve": "13.3.0",
     "@sentry-internal/eslint-config": "0.7.2",
     "@sentry-internal/sentry-bundler-plugin-tsconfig": "0.7.2",

--- a/packages/rollup-plugin/rollup.config.js
+++ b/packages/rollup-plugin/rollup.config.js
@@ -10,8 +10,15 @@ const extensions = [".ts"];
 export default {
   input,
   external: [...Object.keys(packageJson.dependencies), ...modulePackage.builtinModules],
+  onwarn: (warning) => {
+    throw new Error(warning.message); // Warnings are usually high-consequence for us so let's throw to catch them
+  },
   plugins: [
-    resolve({ extensions, preferBuiltins: true }),
+    resolve({
+      extensions,
+      rootDir: "./src",
+      preferBuiltins: true,
+    }),
     babel({
       extensions,
       babelHelpers: "bundled",

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -54,8 +54,6 @@
     "@babel/preset-env": "7.18.2",
     "@babel/preset-typescript": "7.17.12",
     "@rollup/plugin-babel": "5.3.1",
-    "@rollup/plugin-commonjs": "22.0.1",
-    "@rollup/plugin-json": "4.1.0",
     "@rollup/plugin-node-resolve": "13.3.0",
     "@sentry-internal/eslint-config": "0.7.2",
     "@sentry-internal/sentry-bundler-plugin-tsconfig": "0.7.2",

--- a/packages/vite-plugin/rollup.config.js
+++ b/packages/vite-plugin/rollup.config.js
@@ -10,8 +10,15 @@ const extensions = [".ts"];
 export default {
   input,
   external: [...Object.keys(packageJson.dependencies), ...modulePackage.builtinModules],
+  onwarn: (warning) => {
+    throw new Error(warning.message); // Warnings are usually high-consequence for us so let's throw to catch them
+  },
   plugins: [
-    resolve({ extensions, preferBuiltins: true }),
+    resolve({
+      extensions,
+      rootDir: "./src",
+      preferBuiltins: true,
+    }),
     babel({
       extensions,
       babelHelpers: "bundled",

--- a/packages/webpack-plugin/package.json
+++ b/packages/webpack-plugin/package.json
@@ -55,8 +55,6 @@
     "@babel/preset-typescript": "7.17.12",
     "@rollup/plugin-babel": "5.3.1",
     "@rollup/plugin-commonjs": "22.0.1",
-    "@rollup/plugin-json": "4.1.0",
-    "@rollup/plugin-node-resolve": "13.3.0",
     "@sentry-internal/eslint-config": "0.7.2",
     "@sentry-internal/sentry-bundler-plugin-tsconfig": "0.7.2",
     "@swc/core": "^1.2.205",

--- a/packages/webpack-plugin/rollup.config.js
+++ b/packages/webpack-plugin/rollup.config.js
@@ -10,8 +10,15 @@ const extensions = [".ts"];
 export default {
   input,
   external: [...Object.keys(packageJson.dependencies), ...modulePackage.builtinModules],
+  onwarn: (warning) => {
+    throw new Error(warning.message); // Warnings are usually high-consequence for us so let's throw to catch them
+  },
   plugins: [
-    resolve({ extensions, preferBuiltins: true }),
+    resolve({
+      extensions,
+      rootDir: "./src",
+      preferBuiltins: true,
+    }),
     babel({
       extensions,
       babelHelpers: "bundled",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2564,6 +2564,16 @@
     estree-walker "^1.0.1"
     picomatch "^2.2.2"
 
+"@sentry-internal/tracing@7.50.0":
+  version "7.50.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/tracing/-/tracing-7.50.0.tgz#74454af99a03d81762993835d2687c881e14f41e"
+  integrity sha512-4TQ4vN0aMBWsUXfJWk2xbe4x7fKfwCXgXKTtHC/ocwwKM+0EefV5Iw9YFG8IrIQN4vMtuRzktqcs9q0/Sbv7tg==
+  dependencies:
+    "@sentry/core" "7.50.0"
+    "@sentry/types" "7.50.0"
+    "@sentry/utils" "7.50.0"
+    tslib "^1.9.3"
+
 "@sentry/cli@^2.17.0":
   version "2.17.0"
   resolved "https://registry.yarnpkg.com/@sentry/cli/-/cli-2.17.0.tgz#fc809ecd721eb5323502625fa904b786af28ad89"
@@ -2575,59 +2585,50 @@
     proxy-from-env "^1.1.0"
     which "^2.0.2"
 
-"@sentry/core@7.19.0":
-  version "7.19.0"
-  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.19.0.tgz#74e0eaf4b9f42bb0290f4b3f3b0ea3e272dd693e"
-  integrity sha512-YF9cTBcAnO4R44092BJi5Wa2/EO02xn2ziCtmNgAVTN2LD31a/YVGxGBt/FDr4Y6yeuVehaqijVVvtpSmXrGJw==
+"@sentry/core@7.50.0":
+  version "7.50.0"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.50.0.tgz#88bc9cbfc0cb429a28489ece6f0be7a7006436c4"
+  integrity sha512-6oD1a3fYs4aiNK7tuJSd88LHjYJAetd7ZK/AfJniU7zWKj4jxIYfO8nhm0qdnhEDs81RcweVDmPhWm3Kwrzzsg==
   dependencies:
-    "@sentry/types" "7.19.0"
-    "@sentry/utils" "7.19.0"
+    "@sentry/types" "7.50.0"
+    "@sentry/utils" "7.50.0"
     tslib "^1.9.3"
 
-"@sentry/integrations@^7.19.0":
-  version "7.19.0"
-  resolved "https://registry.yarnpkg.com/@sentry/integrations/-/integrations-7.19.0.tgz#570b7ced7ef9de43a6a56f99f324936148adf6b9"
-  integrity sha512-0x5AGU7EBIzOTSqD7TFvD4S5eX6hbqbvb4YCzJt3SIZC3bO4FiBu2t0y+PIZUSsupnqafBIIWsCcGWeKrNHAyA==
+"@sentry/integrations@7.50":
+  version "7.50.0"
+  resolved "https://registry.yarnpkg.com/@sentry/integrations/-/integrations-7.50.0.tgz#82616f34ddba3c1f3e17b54900dfa7d8e0a0c537"
+  integrity sha512-HUmPN2sHNx37m+lOWIoCILHimILdI0Df9nGmWA13fIhny8mxJ6Dbazyis11AW4/lrZ1a6F1SQ2epLEq7ZesiRw==
   dependencies:
-    "@sentry/types" "7.19.0"
-    "@sentry/utils" "7.19.0"
+    "@sentry/types" "7.50.0"
+    "@sentry/utils" "7.50.0"
     localforage "^1.8.1"
     tslib "^1.9.3"
 
-"@sentry/node@^7.19.0":
-  version "7.19.0"
-  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-7.19.0.tgz#4c9494d6aaa15d7f22fe4e6c31d0358a365adb2f"
-  integrity sha512-yG7Tx32WqOkEHVotFLrumCcT9qlaSDTkFNZ+yLSvZXx74ifsE781DzBA9W7K7bBdYO3op+p2YdsOKzf3nPpAyQ==
+"@sentry/node@7.50", "@sentry/node@7.50.0":
+  version "7.50.0"
+  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-7.50.0.tgz#d6adab136d87f7dca614ea0d77944f902fa45626"
+  integrity sha512-11UJBKoQFMp7f8sbzeO2gENsKIUkVCNBTzuPRib7l2K1HMjSfacXmwwma7ZEs0mc3ofIZ1UYuyONAXmI1lK9cQ==
   dependencies:
-    "@sentry/core" "7.19.0"
-    "@sentry/types" "7.19.0"
-    "@sentry/utils" "7.19.0"
+    "@sentry-internal/tracing" "7.50.0"
+    "@sentry/core" "7.50.0"
+    "@sentry/types" "7.50.0"
+    "@sentry/utils" "7.50.0"
     cookie "^0.4.1"
     https-proxy-agent "^5.0.0"
     lru_map "^0.3.3"
     tslib "^1.9.3"
 
-"@sentry/tracing@^7.19.0":
-  version "7.19.0"
-  resolved "https://registry.yarnpkg.com/@sentry/tracing/-/tracing-7.19.0.tgz#d69ecea2c0b53d113c5100fc52d0a0acc5c8a129"
-  integrity sha512-SWY17M3TsgBePaGowUcSqBwaT0TJQzuNexVnLojuU0k6F57L9hubvP9zaoosoCfARXQ/3NypAFWnlJyf570rFQ==
-  dependencies:
-    "@sentry/core" "7.19.0"
-    "@sentry/types" "7.19.0"
-    "@sentry/utils" "7.19.0"
-    tslib "^1.9.3"
+"@sentry/types@7.50.0":
+  version "7.50.0"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.50.0.tgz#52a035cad83a80ca26fa53c09eb1241250c3df3e"
+  integrity sha512-Zo9vyI98QNeYT0K0y57Rb4JRWDaPEgmp+QkQ4CRQZFUTWetO5fvPZ4Gb/R7TW16LajuHZlbJBHmvmNj2pkL2kw==
 
-"@sentry/types@7.19.0":
-  version "7.19.0"
-  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.19.0.tgz#3ebb96670399b637a945fa499fa7436f7b930147"
-  integrity sha512-oGRAT6lfzoKrxO1mvxiSj0XHxWPd6Gd1wpPGuu6iJo03xgWDS+MIlD1h2unqL4N5fAzLjzmbC2D2lUw50Kn2pA==
-
-"@sentry/utils@7.19.0":
-  version "7.19.0"
-  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-7.19.0.tgz#0e039fe57056074c3a5e47bd50d9cb4ac9a6e909"
-  integrity sha512-2L6lq+c9Ol2uiRxQDdcgoapmHJp24MhMN0gIkn2alSfMJ+ls6bGXzQHx6JAIdoOiwFQXRZHKL9ecfAc8O+vItA==
+"@sentry/utils@7.50.0":
+  version "7.50.0"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-7.50.0.tgz#2b93a48024651436e95b7c8e2066aee7c2234d57"
+  integrity sha512-iyPwwC6fwJsiPhH27ZbIiSsY5RaccHBqADS2zEjgKYhmP4P9WGgHRDrvLEnkOjqQyKNb6c0yfmv83n0uxYnolw==
   dependencies:
-    "@sentry/types" "7.19.0"
+    "@sentry/types" "7.50.0"
     tslib "^1.9.3"
 
 "@sinclair/typebox@^0.24.1":
@@ -6979,9 +6980,9 @@ is-buffer@^1.1.5:
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
 
 is-builtin-module@^3.1.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/is-builtin-module/-/is-builtin-module-3.2.0.tgz#bb0310dfe881f144ca83f30100ceb10cf58835e0"
-  integrity sha512-phDA4oSGt7vl1n5tJvTWooWWAsXLY+2xCnxNqvKhGEzujg+A43wPlPOyDg3C8XQHN+6k/JTQWJ/j0dQh/qr+Hw==
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/is-builtin-module/-/is-builtin-module-3.2.1.tgz#f03271717d8654cfcaf07ab0463faa3571581169"
+  integrity sha512-BSLE3HnV2syZ0FK0iMA/yUGplUeMmNz4AW5fnTunbCIqZi4vG3WjJT9FHMy5D69xmAYBHXQhJdALdpwVxV501A==
   dependencies:
     builtin-modules "^3.3.0"
 
@@ -6996,6 +6997,13 @@ is-ci@^2.0.0:
   integrity sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==
   dependencies:
     ci-info "^2.0.0"
+
+is-core-module@^2.11.0:
+  version "2.12.0"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.12.0.tgz#36ad62f6f73c8253fd6472517a12483cf03e7ec4"
+  integrity sha512-RECHCBCd/viahWmwj6enj19sKbHfJrddi/6cBDsNTKbNq0f7VeaUkBo60BqzvPqo/W54ChS62Z5qyun7cfOMqQ==
+  dependencies:
+    has "^1.0.3"
 
 is-core-module@^2.5.0, is-core-module@^2.8.1:
   version "2.11.0"
@@ -10306,12 +10314,21 @@ resolve.exports@1.1.0, resolve.exports@^1.1.0:
   resolved "https://registry.yarnpkg.com/resolve.exports/-/resolve.exports-1.1.0.tgz#5ce842b94b05146c0e03076985d1d0e7e48c90c9"
   integrity sha512-J1l+Zxxp4XK3LUDZ9m60LRJF/mAe4z6a4xyabPHk7pvK5t35dACV32iIjJDFeWZFfZlO29w6SZ67knR0tHzJtQ==
 
-resolve@^1.10.0, resolve@^1.14.2, resolve@^1.17.0, resolve@^1.19.0, resolve@^1.20.0, resolve@^1.22.1:
+resolve@^1.10.0, resolve@^1.14.2, resolve@^1.17.0, resolve@^1.20.0, resolve@^1.22.1:
   version "1.22.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.1.tgz#27cb2ebb53f91abb49470a928bba7558066ac177"
   integrity sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==
   dependencies:
     is-core-module "^2.9.0"
+    path-parse "^1.0.7"
+    supports-preserve-symlinks-flag "^1.0.0"
+
+resolve@^1.19.0:
+  version "1.22.2"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.2.tgz#0ed0943d4e301867955766c9f3e1ae6d01c6845f"
+  integrity sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==
+  dependencies:
+    is-core-module "^2.11.0"
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
 
@@ -10380,6 +10397,13 @@ rollup@2.77.0:
   version "2.77.0"
   resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.77.0.tgz#749eaa5ac09b6baa52acc076bc46613eddfd53f4"
   integrity sha512-vL8xjY4yOQEw79DvyXLijhnhh+R/O9zpF/LEgkCebZFtb6ELeN9H3/2T0r8+mp+fFTBHZ5qGpOpW2ela2zRt3g==
+  optionalDependencies:
+    fsevents "~2.3.2"
+
+rollup@3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-3.2.0.tgz#a6f44074418e55217967c8eca622f9638d396388"
+  integrity sha512-0ZkFPyBNvx717KvC700NoxUD31aEEX675u6INJVAmBgKtQuCL8jmmJCj1b9B/qDSnILAvASVKa7UpGS+FLN6AQ==
   optionalDependencies:
     fsevents "~2.3.2"
 


### PR DESCRIPTION
Clean up rollup configs, bump Sentry SDK, and don't bundle parts of the SDK anymore.