### PR TITLE
feat(core): Implements rewrite sources for debug ID upload

### DIFF
--- a/packages/bundler-plugin-core/src/index.ts
+++ b/packages/bundler-plugin-core/src/index.ts
@@ -205,6 +205,7 @@ export function sentryUnpluginFactory({
             releaseName: options.release.name,
             logger: logger,
             handleRecoverableError: handleRecoverableError,
+            rewriteSourcesHook: options.sourcemaps.rewriteSources,
             sentryHub,
             sentryClient,
             sentryCliOptions: {

--- a/packages/bundler-plugin-core/src/plugins/debug-id-upload.ts
+++ b/packages/bundler-plugin-core/src/plugins/debug-id-upload.ts
@@ -9,12 +9,17 @@ import { promisify } from "util";
 import { Hub, NodeClient } from "@sentry/node";
 import SentryCli from "@sentry/cli";
 
+interface RewriteSourcesHook {
+  (source: string, map: any): string;
+}
+
 interface DebugIdUploadPluginOptions {
   logger: Logger;
   assets: string | string[];
   ignore?: string | string[];
   releaseName?: string;
   dist?: string;
+  rewriteSourcesHook?: RewriteSourcesHook;
   handleRecoverableError: (error: unknown) => void;
   sentryHub: Hub;
   sentryClient: NodeClient;
@@ -39,6 +44,7 @@ export function debugIdUploadPlugin({
   sentryHub,
   sentryClient,
   sentryCliOptions,
+  rewriteSourcesHook,
 }: DebugIdUploadPluginOptions): UnpluginOptions {
   return {
     name: "sentry-debug-id-upload-plugin",
@@ -73,7 +79,8 @@ export function debugIdUploadPlugin({
               chunkFilePath,
               tmpUploadFolder,
               String(chunkIndex),
-              logger
+              logger,
+              rewriteSourcesHook ?? defaultRewriteSourcesHook
             );
           })
         );
@@ -105,7 +112,8 @@ export async function prepareBundleForDebugIdUpload(
   bundleFilePath: string,
   uploadFolder: string,
   uniqueUploadName: string,
-  logger: Logger
+  logger: Logger,
+  rewriteSourcesHook: RewriteSourcesHook
 ) {
   let bundleContent;
   try {
@@ -143,6 +151,7 @@ export async function prepareBundleForDebugIdUpload(
         sourceMapPath,
         path.join(uploadFolder, `${uniqueUploadName}.js.map`),
         debugId,
+        rewriteSourcesHook,
         logger
       );
     }
@@ -210,6 +219,7 @@ async function prepareSourceMapForDebugIdUpload(
   sourceMapPath: string,
   targetPath: string,
   debugId: string,
+  rewriteSourcesHook: RewriteSourcesHook,
   logger: Logger
 ): Promise<void> {
   let sourceMapFileContent: string;
@@ -222,15 +232,19 @@ async function prepareSourceMapForDebugIdUpload(
     return;
   }
 
-  let map: Record<string, string>;
+  let map: Record<string, unknown>;
   try {
-    map = JSON.parse(sourceMapFileContent) as Record<string, string>;
+    map = JSON.parse(sourceMapFileContent) as { sources: unknown; [key: string]: unknown };
     // For now we write both fields until we know what will become the standard - if ever.
     map["debug_id"] = debugId;
     map["debugId"] = debugId;
   } catch (e) {
     logger.error(`Failed to parse source map for debug ID upload: ${sourceMapPath}`);
     return;
+  }
+
+  if (map["sources"] && Array.isArray(map["sources"])) {
+    map["sources"].map((source: string) => rewriteSourcesHook(source, map));
   }
 
   try {
@@ -240,5 +254,14 @@ async function prepareSourceMapForDebugIdUpload(
   } catch (e) {
     logger.error(`Failed to prepare source map for debug ID upload: ${sourceMapPath}`, e);
     return;
+  }
+}
+
+const PROTOCOL_REGEX = /^[a-zA-Z][a-zA-Z0-9+\-.]*:\/\//;
+function defaultRewriteSourcesHook(source: string): string {
+  if (source.match(PROTOCOL_REGEX)) {
+    return source.replace(PROTOCOL_REGEX, "");
+  } else {
+    return path.relative(process.cwd(), path.normalize(source));
   }
 }

--- a/packages/bundler-plugin-core/src/types.ts
+++ b/packages/bundler-plugin-core/src/types.ts
@@ -114,8 +114,6 @@ export interface Options {
      * Hook to rewrite the `sources` field inside the source map before being uploaded to Sentry. Does not modify the actual source map.
      *
      * Defaults to making all sources relative to `process.cwd()` while building.
-     *
-     * @hidden Not yet implemented.
      */
     rewriteSources?: (source: string, map: any) => string;
 


### PR DESCRIPTION
Adds the `rewriteSources` hook to the plugin which allows to modify the names of files inside the stacktrace on Sentry.

The hook is called for each individual source file and also passed the entire source map object for convenience.

The default logic if not otherwise defined is to make all the sources relative to `process.cwd()` or to strip away a protocol if there is one (this is mainly for webpack).