### PR TITLE
fix(core): Account for undefined release name values

### DIFF
--- a/packages/bundler-plugin-core/src/index.ts
+++ b/packages/bundler-plugin-core/src/index.ts
@@ -10,6 +10,7 @@ import { createLogger } from "./sentry/logger";
 import { allowedToSendTelemetry, createSentryInstance } from "./sentry/telemetry";
 import { Options } from "./types";
 import {
+  determineReleaseName,
   generateGlobalInjectorCode,
   getDependencies,
   getPackageJson,
@@ -134,7 +135,8 @@ export function sentryUnpluginFactory({
       plugins.push(releaseInjectionPlugin(injectionCode));
     }
 
-    if (!options.release.name) {
+    const releaseManagementPluginReleaseName = options.release.name ?? determineReleaseName();
+    if (!releaseManagementPluginReleaseName) {
       logger.warn(
         "No release name provided. Will not create release. Please set the `release.name` option to identifiy your release."
       );
@@ -154,7 +156,7 @@ export function sentryUnpluginFactory({
       plugins.push(
         releaseManagementPlugin({
           logger,
-          releaseName: options.release.name,
+          releaseName: releaseManagementPluginReleaseName,
           shouldCreateRelease: options.release.create,
           shouldCleanArtifacts: options.release.cleanArtifacts,
           shouldFinalizeRelease: options.release.finalize,

--- a/packages/bundler-plugin-core/src/options-mapping.ts
+++ b/packages/bundler-plugin-core/src/options-mapping.ts
@@ -20,13 +20,12 @@ export function normalizeUserOptions(userOptions: UserOptions) {
     disable: userOptions.disable ?? false,
     sourcemaps: userOptions.sourcemaps,
     release: {
-      name: determineReleaseName(),
-      inject: true,
-      create: true,
-      finalize: true,
-      vcsRemote: process.env["SENTRY_VSC_REMOTE"] ?? "origin",
-      cleanArtifacts: false,
       ...userOptions.release,
+      inject: userOptions.release?.inject ?? true,
+      create: userOptions.release?.create ?? true,
+      finalize: userOptions.release?.finalize ?? true,
+      vcsRemote: userOptions.release?.vcsRemote ?? process.env["SENTRY_VSC_REMOTE"] ?? "origin",
+      cleanArtifacts: userOptions.release?.cleanArtifacts ?? false,
     },
     _experiments: userOptions._experiments ?? {},
   };

--- a/packages/bundler-plugin-core/src/options-mapping.ts
+++ b/packages/bundler-plugin-core/src/options-mapping.ts
@@ -1,6 +1,5 @@
 import { Logger } from "./sentry/logger";
 import { Options as UserOptions } from "./types";
-import { determineReleaseName } from "./utils";
 
 export type NormalizedOptions = ReturnType<typeof normalizeUserOptions>;
 

--- a/packages/bundler-plugin-core/src/plugins/debug-id-upload.ts
+++ b/packages/bundler-plugin-core/src/plugins/debug-id-upload.ts
@@ -87,16 +87,19 @@ export function debugIdUploadPlugin({
           })
         );
 
-        await cliInstance.releases.uploadSourceMaps(releaseName ?? "", {
-          include: [
-            {
-              paths: [tmpUploadFolder],
-              rewrite: false,
-              dist: dist,
-            },
-          ],
-          useArtifactBundle: true,
-        });
+        await cliInstance.releases.uploadSourceMaps(
+          releaseName ?? "undefined", // unfortunetly this needs a value for now but it will not matter since debug IDs overpower releases anyhow
+          {
+            include: [
+              {
+                paths: [tmpUploadFolder],
+                rewrite: false,
+                dist: dist,
+              },
+            ],
+            useArtifactBundle: true,
+          }
+        );
 
         if (deleteFilesAfterUpload) {
           const filePathsToDelete = await glob(deleteFilesAfterUpload, {

--- a/packages/integration-tests/fixtures/build-information-injection/setup.ts
+++ b/packages/integration-tests/fixtures/build-information-injection/setup.ts
@@ -5,5 +5,8 @@ const entryPointPath = path.resolve(__dirname, "input", "entrypoint.js");
 const outputDir = path.resolve(__dirname, "out");
 
 createCjsBundles({ index: entryPointPath }, outputDir, {
+  release: {
+    name: "build-information-injection-test",
+  },
   _experiments: { injectBuildInformation: true },
 });

--- a/packages/playground/build-esbuild.js
+++ b/packages/playground/build-esbuild.js
@@ -1,13 +1,15 @@
 const { sentryEsbuildPlugin } = require("@sentry/esbuild-plugin");
 const { build } = require("esbuild");
-const placeHolderOptions = require("./config.json");
 
 build({
   entryPoints: ["./src/entrypoint1.js"],
   outdir: "./out/esbuild",
   plugins: [
     sentryEsbuildPlugin({
-      ...placeHolderOptions,
+      sourcemaps: {
+        assets: "./out/esbuild/**",
+        deleteFilesAfterUpload: "./out/esbuild/**/*.map",
+      },
     }),
   ],
   minify: true,

--- a/packages/playground/build-webpack4.js
+++ b/packages/playground/build-webpack4.js
@@ -3,8 +3,6 @@ const path = require("path");
 const webpack4 = require("webpack4");
 const { sentryWebpackPlugin } = require("@sentry/webpack-plugin");
 
-const placeHolderOptions = require("./config.json");
-
 webpack4(
   {
     mode: "production",
@@ -16,7 +14,14 @@ webpack4(
       library: "ExampleBundle",
       libraryTarget: "commonjs",
     },
-    plugins: [sentryWebpackPlugin({ ...placeHolderOptions })],
+    plugins: [
+      sentryWebpackPlugin({
+        sourcemaps: {
+          assets: "./out/webpack4/**",
+          deleteFilesAfterUpload: "./out/webpack4/**/*.map",
+        },
+      }),
+    ],
     devtool: "source-map",
   },
   (err) => {

--- a/packages/playground/build-webpack5.js
+++ b/packages/playground/build-webpack5.js
@@ -3,8 +3,6 @@ const path = require("path");
 const webpack5 = require("webpack");
 const { sentryWebpackPlugin } = require("@sentry/webpack-plugin");
 
-const placeHolderOptions = require("./config.json");
-
 webpack5(
   {
     cache: false,
@@ -18,7 +16,14 @@ webpack5(
       },
     },
     mode: "production",
-    plugins: [sentryWebpackPlugin({ ...placeHolderOptions })],
+    plugins: [
+      sentryWebpackPlugin({
+        sourcemaps: {
+          assets: "./out/webpack5/**",
+          deleteFilesAfterUpload: "./out/webpack5/**/*.map",
+        },
+      }),
+    ],
     devtool: "source-map",
   },
   (err) => {

--- a/packages/playground/config.json
+++ b/packages/playground/config.json
@@ -1,8 +1,0 @@
-{
-  "release": "0.0.1",
-  "org": "some-org",
-  "project": "some-proj",
-  "authToken": "some-auth-token",
-  "include": "/dist",
-  "debug": true
-}

--- a/packages/playground/rollup.config.mjs
+++ b/packages/playground/rollup.config.mjs
@@ -8,7 +8,10 @@ export default {
   input,
   plugins: [
     sentryRollupPlugin({
-      ...JSON.parse(fs.readFileSync("./config.json", "utf-8")),
+      sourcemaps: {
+        assets: "./out/rollup/**",
+        deleteFilesAfterUpload: "./out/rollup/**/*.map",
+      },
     }),
   ],
   output: {

--- a/packages/playground/vite.config.js
+++ b/packages/playground/vite.config.js
@@ -2,7 +2,6 @@
 import { sentryVitePlugin } from "@sentry/vite-plugin";
 import { defineConfig } from "vite";
 import * as path from "path";
-import placeHolderOptions from "./config.json";
 
 export default defineConfig({
   build: {
@@ -17,7 +16,10 @@ export default defineConfig({
   },
   plugins: [
     sentryVitePlugin({
-      ...placeHolderOptions,
+      sourcemaps: {
+        assets: "./out/vite/**",
+        deleteFilesAfterUpload: "./out/vite/**/*.map",
+      },
     }),
   ],
 });


### PR DESCRIPTION
Fixes a bug where Sentry CLI throws if we only pass an empty string as a release value for debug ID upload.