### PR TITLE
docs: Fix anchor tags in READMEs

### DIFF
--- a/packages/dev-utils/src/generate-documentation-table.ts
+++ b/packages/dev-utils/src/generate-documentation-table.ts
@@ -375,9 +375,7 @@ function generateDescriptions(
     .map((node) => {
       const name = parentName === undefined ? node.name : `${parentName}.${node.name}`;
       const id = `${parentId}-${node.name.toLowerCase()}`;
-      let output = `### \`${name}\`
-
-<a name="${id}"></a>
+      let output = `### <a name="${id}"></a>\`${name}\`
 
 ${node.type === undefined ? "" : `Type: \`${node.type}\``}
 


### PR DESCRIPTION
Npm transforms anchor tags in a way that destroys the links if you don't put them inside a heading like this.