### PR TITLE
feat: Auto detect build artifacts

### DIFF
--- a/packages/bundler-plugin-core/src/debug-id-upload.ts
+++ b/packages/bundler-plugin-core/src/debug-id-upload.ts
@@ -64,7 +64,7 @@ export function createDebugIdUploadFunction({
         globAssets = assets;
       } else {
         logger.debug(
-          "Not `sourcemaps.assets` option provided, falling back to uploading detected build artifacts."
+          "No `sourcemaps.assets` option provided, falling back to uploading detected build artifacts."
         );
         globAssets = buildArtifactPaths;
       }

--- a/packages/bundler-plugin-core/src/debug-id-upload.ts
+++ b/packages/bundler-plugin-core/src/debug-id-upload.ts
@@ -59,8 +59,18 @@ export function createDebugIdUploadFunction({
 
       folderToCleanUp = tmpUploadFolder;
 
+      let globAssets;
+      if (assets) {
+        globAssets = assets;
+      } else {
+        logger.debug(
+          "Not `sourcemaps.assets` option provided, falling back to uploading detected build artifacts."
+        );
+        globAssets = buildArtifactPaths;
+      }
+
       const debugIdChunkFilePaths = (
-        await glob(assets ?? buildArtifactPaths, {
+        await glob(globAssets, {
           absolute: true,
           nodir: true,
           ignore: ignore,

--- a/packages/bundler-plugin-core/src/types.ts
+++ b/packages/bundler-plugin-core/src/types.ts
@@ -93,11 +93,13 @@ export interface Options {
     /**
      * A glob or an array of globs that specifies the build artifacts that should be uploaded to Sentry.
      *
+     * If this option is not specified, the plugin will try to upload all JavaScript files and source map files that are created during build.
+     *
      * The globbing patterns follow the implementation of the `glob` package. (https://www.npmjs.com/package/glob)
      *
      * Use the `debug` option to print information about which files end up being uploaded.
      */
-    assets: string | string[];
+    assets?: string | string[];
 
     /**
      * A glob or an array of globs that specifies which build artifacts should not be uploaded to Sentry.

--- a/packages/dev-utils/src/generate-documentation-table.ts
+++ b/packages/dev-utils/src/generate-documentation-table.ts
@@ -79,7 +79,7 @@ errorHandler: (err) => {
         name: "assets",
         type: "string | string[]",
         fullDescription:
-          "A glob or an array of globs that specifies the build artifacts that should be uploaded to Sentry.\n\nThe globbing patterns follow the implementation of the `glob` package. (https://www.npmjs.com/package/glob)\n\nUse the `debug` option to print information about which files end up being uploaded.",
+          "A glob or an array of globs that specifies the build artifacts that should be uploaded to Sentry.\n\nIf this option is not specified, the plugin will try to upload all JavaScript files and source map files that are created during build.\n\nThe globbing patterns follow the implementation of the `glob` package. (https://www.npmjs.com/package/glob)\n\nUse the `debug` option to print information about which files end up being uploaded.",
       },
       {
         name: "ignore",

--- a/packages/esbuild-plugin/README_TEMPLATE.md
+++ b/packages/esbuild-plugin/README_TEMPLATE.md
@@ -49,27 +49,6 @@ require("esbuild").build({
       // Auth tokens can be obtained from https://sentry.io/settings/account/api/auth-tokens/
       // and need `project:releases` and `org:read` scopes
       authToken: process.env.SENTRY_AUTH_TOKEN,
-
-      sourcemaps: {
-        // Specify the directory containing build artifacts
-        assets: "./**",
-        // Don't upload the source maps of dependencies
-        ignore: ["./node_modules/**"],
-      },
-
-      // Helps troubleshooting - set to false to make plugin less noisy
-      debug: true,
-
-      // Use the following option if you're on an SDK version lower than 7.47.0:
-      // release: {
-      //   uploadLegacySourcemaps: {
-      //     include: ".",
-      //     ignore: ["node_modules"],
-      //   },
-      // },
-
-      // Optionally uncomment the line below to override automatic release name detection
-      // release: process.env.RELEASE,
     }),
   ],
 });

--- a/packages/esbuild-plugin/src/index.ts
+++ b/packages/esbuild-plugin/src/index.ts
@@ -63,9 +63,27 @@ function esbuildDebugIdInjectionPlugin(): UnpluginOptions {
   };
 }
 
+function esbuildDebugIdUploadPlugin(
+  upload: (buildArtifacts: string[]) => Promise<void>
+): UnpluginOptions {
+  return {
+    name: "sentry-esbuild-debug-id-upload-plugin",
+    esbuild: {
+      setup({ initialOptions, onEnd }) {
+        initialOptions.metafile = true;
+        onEnd(async (result) => {
+          const buildArtifacts = result.metafile ? Object.keys(result.metafile.outputs) : [];
+          await upload(buildArtifacts);
+        });
+      },
+    },
+  };
+}
+
 const sentryUnplugin = sentryUnpluginFactory({
   releaseInjectionPlugin: esbuildReleaseInjectionPlugin,
   debugIdInjectionPlugin: esbuildDebugIdInjectionPlugin,
+  debugIdUploadPlugin: esbuildDebugIdUploadPlugin,
 });
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/playground/build-esbuild.js
+++ b/packages/playground/build-esbuild.js
@@ -6,10 +6,7 @@ build({
   outdir: "./out/esbuild",
   plugins: [
     sentryEsbuildPlugin({
-      sourcemaps: {
-        assets: "./out/esbuild/**",
-        deleteFilesAfterUpload: "./out/esbuild/**/*.map",
-      },
+      debug: true,
     }),
   ],
   minify: true,

--- a/packages/playground/build-webpack4.js
+++ b/packages/playground/build-webpack4.js
@@ -16,10 +16,7 @@ webpack4(
     },
     plugins: [
       sentryWebpackPlugin({
-        sourcemaps: {
-          assets: "./out/webpack4/**",
-          deleteFilesAfterUpload: "./out/webpack4/**/*.map",
-        },
+        debug: true,
       }),
     ],
     devtool: "source-map",

--- a/packages/playground/build-webpack5.js
+++ b/packages/playground/build-webpack5.js
@@ -18,10 +18,7 @@ webpack5(
     mode: "production",
     plugins: [
       sentryWebpackPlugin({
-        sourcemaps: {
-          assets: "./out/webpack5/**",
-          deleteFilesAfterUpload: "./out/webpack5/**/*.map",
-        },
+        debug: true,
       }),
     ],
     devtool: "source-map",

--- a/packages/playground/rollup.config.mjs
+++ b/packages/playground/rollup.config.mjs
@@ -8,10 +8,7 @@ export default {
   input,
   plugins: [
     sentryRollupPlugin({
-      sourcemaps: {
-        assets: "./out/rollup/**",
-        deleteFilesAfterUpload: "./out/rollup/**/*.map",
-      },
+      debug: true,
     }),
   ],
   output: {

--- a/packages/playground/vite.config.js
+++ b/packages/playground/vite.config.js
@@ -16,10 +16,7 @@ export default defineConfig({
   },
   plugins: [
     sentryVitePlugin({
-      sourcemaps: {
-        assets: "./out/vite/**",
-        deleteFilesAfterUpload: "./out/vite/**/*.map",
-      },
+      debug: true,
     }),
   ],
 });

--- a/packages/rollup-plugin/README_TEMPLATE.md
+++ b/packages/rollup-plugin/README_TEMPLATE.md
@@ -42,33 +42,12 @@ export default {
   plugins: [
     // Put the Sentry rollup plugin after all other plugins
     sentryRollupPlugin({
-      org: "___ORG_SLUG___",
-      project: "___PROJECT_SLUG___",
+      org: process.env.SENTRY_ORG,
+      project: process.env.SENTRY_PROJECT,
 
       // Auth tokens can be obtained from https://sentry.io/settings/account/api/auth-tokens/
       // and need `project:releases` and `org:read` scopes
-      authToken: env.SENTRY_AUTH_TOKEN,
-
-      sourcemaps: {
-        // Specify the directory containing build artifacts
-        assets: "./**",
-        // Don't upload the source maps of dependencies
-        ignore: ["./node_modules/**"],
-      },
-
-      // Helps troubleshooting - set to false to make plugin less noisy
-      debug: true,
-
-      // Use the following option if you're on an SDK version lower than 7.47.0:
-      // release: {
-      //   uploadLegacySourcemaps: {
-      //     include: ".",
-      //     ignore: ["node_modules"],
-      //   },
-      // },
-
-      // Optionally uncomment the line below to override automatic release name detection
-      // release: env.RELEASE,
+      authToken: process.env.SENTRY_AUTH_TOKEN,
     }),
   ],
   output: {

--- a/packages/rollup-plugin/src/index.ts
+++ b/packages/rollup-plugin/src/index.ts
@@ -3,6 +3,7 @@ import {
   Options,
   createRollupReleaseInjectionHooks,
   createRollupDebugIdInjectionHooks,
+  createRollupDebugIdUploadHooks,
 } from "@sentry/bundler-plugin-core";
 import type { UnpluginOptions } from "unplugin";
 
@@ -20,9 +21,19 @@ function rollupDebugIdInjectionPlugin(): UnpluginOptions {
   };
 }
 
+function rollupDebugIdUploadPlugin(
+  upload: (buildArtifacts: string[]) => Promise<void>
+): UnpluginOptions {
+  return {
+    name: "sentry-rollup-debug-id-upload-plugin",
+    rollup: createRollupDebugIdUploadHooks(upload),
+  };
+}
+
 const sentryUnplugin = sentryUnpluginFactory({
   releaseInjectionPlugin: rollupReleaseInjectionPlugin,
   debugIdInjectionPlugin: rollupDebugIdInjectionPlugin,
+  debugIdUploadPlugin: rollupDebugIdUploadPlugin,
 });
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/vite-plugin/README_TEMPLATE.md
+++ b/packages/vite-plugin/README_TEMPLATE.md
@@ -56,27 +56,6 @@ export default defineConfig({
       // Auth tokens can be obtained from https://sentry.io/settings/account/api/auth-tokens/
       // and need `project:releases` and `org:read` scopes
       authToken: process.env.SENTRY_AUTH_TOKEN,
-
-      sourcemaps: {
-        // Specify the directory containing build artifacts
-        assets: "./**",
-        // Don't upload the source maps of dependencies
-        ignore: ["./node_modules/**"],
-      },
-
-      // Helps troubleshooting - set to false to make plugin less noisy
-      debug: true,
-
-      // Use the following option if you're on an SDK version lower than 7.47.0:
-      // release: {
-      //   uploadLegacySourcemaps: {
-      //     include: ".",
-      //     ignore: ["node_modules"],
-      //   },
-      // },
-
-      // Optionally uncomment the line below to override automatic release name detection
-      // release: env.RELEASE,
     }),
   ],
 });

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -3,6 +3,7 @@ import {
   Options,
   createRollupReleaseInjectionHooks,
   createRollupDebugIdInjectionHooks,
+  createRollupDebugIdUploadHooks,
 } from "@sentry/bundler-plugin-core";
 import { UnpluginOptions } from "unplugin";
 
@@ -21,9 +22,19 @@ function viteDebugIdInjectionPlugin(): UnpluginOptions {
   };
 }
 
+function viteDebugIdUploadPlugin(
+  upload: (buildArtifacts: string[]) => Promise<void>
+): UnpluginOptions {
+  return {
+    name: "sentry-vite-debug-id-upload-plugin",
+    vite: createRollupDebugIdUploadHooks(upload),
+  };
+}
+
 const sentryUnplugin = sentryUnpluginFactory({
   releaseInjectionPlugin: viteReleaseInjectionPlugin,
   debugIdInjectionPlugin: viteDebugIdInjectionPlugin,
+  debugIdUploadPlugin: viteDebugIdUploadPlugin,
 });
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/webpack-plugin/README_TEMPLATE.md
+++ b/packages/webpack-plugin/README_TEMPLATE.md
@@ -50,27 +50,6 @@ module.exports = {
       // Auth tokens can be obtained from https://sentry.io/settings/account/api/auth-tokens/
       // and need `project:releases` and `org:read` scopes
       authToken: process.env.SENTRY_AUTH_TOKEN,
-
-      sourcemaps: {
-        // Specify the directory containing build artifacts
-        assets: "./**",
-        // Don't upload the source maps of dependencies
-        ignore: ["./node_modules/**"],
-      },
-
-      // Helps troubleshooting - set to false to make plugin less noisy
-      debug: true,
-
-      // Use the following option if you're on an SDK version lower than 7.47.0:
-      // release: {
-      //   uploadLegacySourcemaps: {
-      //     include: ".",
-      //     ignore: ["node_modules"],
-      //   },
-      // },
-
-      // Optionally uncomment the line below to override automatic release name detection
-      // release: env.RELEASE,
     }),
   ],
 };


### PR DESCRIPTION
Will auto detect build artifacts based on the information bundlers provide in the build end hooks - making the `assets` option optional.

Risky change incoming.