### PR TITLE
fix: Use automatic release name detection for release injection

### DIFF
--- a/packages/bundler-plugin-core/src/index.ts
+++ b/packages/bundler-plugin-core/src/index.ts
@@ -10,7 +10,6 @@ import { createLogger } from "./sentry/logger";
 import { allowedToSendTelemetry, createSentryInstance } from "./sentry/telemetry";
 import { Options } from "./types";
 import {
-  determineReleaseName,
   generateGlobalInjectorCode,
   getDependencies,
   getPackageJson,
@@ -135,8 +134,7 @@ export function sentryUnpluginFactory({
       plugins.push(releaseInjectionPlugin(injectionCode));
     }
 
-    const releaseManagementPluginReleaseName = options.release.name ?? determineReleaseName();
-    if (!releaseManagementPluginReleaseName) {
+    if (!options.release.name) {
       logger.warn(
         "No release name provided. Will not create release. Please set the `release.name` option to identifiy your release."
       );
@@ -156,7 +154,7 @@ export function sentryUnpluginFactory({
       plugins.push(
         releaseManagementPlugin({
           logger,
-          releaseName: releaseManagementPluginReleaseName,
+          releaseName: options.release.name,
           shouldCreateRelease: options.release.create,
           shouldCleanArtifacts: options.release.cleanArtifacts,
           shouldFinalizeRelease: options.release.finalize,

--- a/packages/bundler-plugin-core/src/options-mapping.ts
+++ b/packages/bundler-plugin-core/src/options-mapping.ts
@@ -1,5 +1,6 @@
 import { Logger } from "./sentry/logger";
 import { Options as UserOptions } from "./types";
+import { determineReleaseName } from "./utils";
 
 export type NormalizedOptions = ReturnType<typeof normalizeUserOptions>;
 
@@ -20,6 +21,7 @@ export function normalizeUserOptions(userOptions: UserOptions) {
     sourcemaps: userOptions.sourcemaps,
     release: {
       ...userOptions.release,
+      name: userOptions.release?.name ?? determineReleaseName(),
       inject: userOptions.release?.inject ?? true,
       create: userOptions.release?.create ?? true,
       finalize: userOptions.release?.finalize ?? true,


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript-bundler-plugins/issues/264