### PR TITLE
ref: Improve log message when sourcemap cannot be found

### DIFF
--- a/packages/bundler-plugin-core/src/debug-id-upload.ts
+++ b/packages/bundler-plugin-core/src/debug-id-upload.ts
@@ -249,7 +249,9 @@ async function determineSourceMapPathFromBundle(
   }
 
   // This is just a debug message because it can be quite spammy for some frameworks
-  logger.debug(`Could not determine source map path for bundle: ${bundlePath}`);
+  logger.debug(
+    `Could not determine source map path for bundle: ${bundlePath} - Did you turn on source map generation in your bundler?`
+  );
   return undefined;
 }
 


### PR DESCRIPTION
Will help people understand a potential cause for sources not being found.

A better approach for the futre is to detect whether they have enabled it via the options.