### PR TITLE
feat(core): Set custom user agent when interacting with Sentry

### DIFF
--- a/packages/bundler-plugin-core/src/index.ts
+++ b/packages/bundler-plugin-core/src/index.ts
@@ -92,6 +92,11 @@ export function sentryUnpluginFactory({
       debug: options.debug,
     });
 
+    // Set the User-Agent that Sentry CLI will use when interacting with Sentry
+    process.env[
+      "SENTRY_PIPELINE"
+    ] = `${unpluginMetaContext.framework}-plugin/${__PACKAGE_VERSION__}`;
+
     function handleRecoverableError(unknownError: unknown) {
       sentrySession.status = "abnormal";
       try {


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript-bundler-plugins/issues/288

Like we did in the old webpack plugin: https://github.com/getsentry/sentry-webpack-plugin/blob/3628137a10c93e0bf8f8362abc19c0b4c46218ca/src/index.js#L12