### PR TITLE
fix: Use intro hook for debug ID injection in rollup and vite

### DIFF
--- a/packages/rollup-plugin/package.json
+++ b/packages/rollup-plugin/package.json
@@ -50,7 +50,8 @@
   },
   "dependencies": {
     "@sentry/bundler-plugin-core": "2.2.0",
-    "unplugin": "1.0.1"
+    "unplugin": "1.0.1",
+    "uuid": "^9.0.0"
   },
   "peerDependencies": {
     "rollup": ">=3.2.0"

--- a/packages/rollup-plugin/src/index.ts
+++ b/packages/rollup-plugin/src/index.ts
@@ -2,10 +2,11 @@ import {
   sentryUnpluginFactory,
   Options,
   createRollupReleaseInjectionHooks,
-  createRollupDebugIdInjectionHooks,
   createRollupDebugIdUploadHooks,
+  getDebugIdSnippet,
 } from "@sentry/bundler-plugin-core";
 import type { UnpluginOptions } from "unplugin";
+import { v4 as uuidv4 } from "uuid";
 
 function rollupReleaseInjectionPlugin(injectionCode: string): UnpluginOptions {
   return {
@@ -17,7 +18,13 @@ function rollupReleaseInjectionPlugin(injectionCode: string): UnpluginOptions {
 function rollupDebugIdInjectionPlugin(): UnpluginOptions {
   return {
     name: "sentry-rollup-debug-id-injection-plugin",
-    rollup: createRollupDebugIdInjectionHooks(),
+    rollup: {
+      intro() {
+        const debugId = uuidv4();
+        const codeToInject = getDebugIdSnippet(debugId);
+        return codeToInject;
+      },
+    },
   };
 }
 

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -49,7 +49,8 @@
   },
   "dependencies": {
     "@sentry/bundler-plugin-core": "2.2.0",
-    "unplugin": "1.0.1"
+    "unplugin": "1.0.1",
+    "uuid": "^9.0.0"
   },
   "devDependencies": {
     "@babel/core": "7.18.5",

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -2,10 +2,11 @@ import {
   sentryUnpluginFactory,
   Options,
   createRollupReleaseInjectionHooks,
-  createRollupDebugIdInjectionHooks,
   createRollupDebugIdUploadHooks,
+  getDebugIdSnippet,
 } from "@sentry/bundler-plugin-core";
 import { UnpluginOptions } from "unplugin";
+import { v4 as uuidv4 } from "uuid";
 
 function viteReleaseInjectionPlugin(injectionCode: string): UnpluginOptions {
   return {
@@ -18,7 +19,13 @@ function viteReleaseInjectionPlugin(injectionCode: string): UnpluginOptions {
 function viteDebugIdInjectionPlugin(): UnpluginOptions {
   return {
     name: "sentry-vite-debug-id-injection-plugin",
-    vite: createRollupDebugIdInjectionHooks(),
+    vite: {
+      intro() {
+        const debugId = uuidv4();
+        const codeToInject = getDebugIdSnippet(debugId);
+        return codeToInject;
+      },
+    },
   };
 }
 


### PR DESCRIPTION
Implicitly fixes https://github.com/getsentry/sentry-javascript-bundler-plugins/issues/298

I realized we were using an overkill approach of injecting something into each bundle. Rollup and vite have a `intro` hook that allows to inject code into bundles, similar to `banner` and `footer` except for inside any format-specific wrappers (and also below any JS directives). I was previously only looking at banner and footer which had the problem of being injected before JS directives - so I opted for the solution which we're getting rid of in this PR instead.