### PR TITLE
fix: Use magic-string `appendLeft` instead of `replace`

### DIFF
--- a/packages/bundler-plugin-core/src/index.ts
+++ b/packages/bundler-plugin-core/src/index.ts
@@ -346,9 +346,11 @@ export function createRollupDebugIdInjectionHooks() {
           // Note: CodeQL complains that this regex potentially has n^2 runtime. This likely won't affect realistic files.
           /^(?:\s*|\/\*(?:.|\r|\n)*\*\/|\/\/.*[\n\r])*(?:"[^"]*";|'[^']*';)?/;
 
-        if (code.match(commentUseStrictRegex)?.[0]) {
+        const match = code.match(commentUseStrictRegex)?.[0];
+
+        if (match) {
           // Add injected code after any comments or "use strict" at the beginning of the bundle.
-          ms.replace(commentUseStrictRegex, (match) => `${match}${codeToInject}`);
+          ms.appendLeft(match.length, codeToInject);
         } else {
           // ms.replace() doesn't work when there is an empty string match (which happens if
           // there is neither, a comment, nor a "use strict" at the top of the chunk) so we


### PR DESCRIPTION
This is an experimental fix that might resolve https://github.com/getsentry/sentry-javascript-bundler-plugins/issues/298

I tried a bunch of things with our RegExp to understand whether it is wrong but couldn't reproduce the examined outcome.

This led me to believe that there is something going on inside the `magic-string` library that might cause the issue. This is an experimental fix that should be equivalent in behaviour but will hopefully resolve the issue.