### PR TITLE
fix(esbuild): Don't use namespace for esbuild proxy resolving

### DIFF
--- a/packages/playground/build-esbuild.js
+++ b/packages/playground/build-esbuild.js
@@ -2,7 +2,7 @@ const { sentryEsbuildPlugin } = require("@sentry/esbuild-plugin");
 const { build } = require("esbuild");
 
 build({
-  entryPoints: ["./src/entrypoint1.js"],
+  entryPoints: ["./src/get-global.js", "./src/hello-world.js"],
   outdir: "./out/esbuild",
   plugins: [
     sentryEsbuildPlugin({


### PR DESCRIPTION
Potentially fixes https://github.com/getsentry/sentry-javascript-bundler-plugins/issues/310