### PR TITLE
feat: Add `filesToDeleteAfterUpload` alias for `deleteFilesAfterUpload`

### DIFF
--- a/packages/bundler-plugin-core/src/debug-id-upload.ts
+++ b/packages/bundler-plugin-core/src/debug-id-upload.ts
@@ -23,7 +23,7 @@ interface DebugIdUploadPluginOptions {
   handleRecoverableError: (error: unknown) => void;
   sentryHub: Hub;
   sentryClient: NodeClient;
-  deleteFilesAfterUpload?: string | string[];
+  filesToDeleteAfterUpload?: string | string[];
   sentryCliOptions: {
     url: string;
     authToken: string;
@@ -46,7 +46,7 @@ export function createDebugIdUploadFunction({
   sentryClient,
   sentryCliOptions,
   rewriteSourcesHook,
-  deleteFilesAfterUpload,
+  filesToDeleteAfterUpload,
 }: DebugIdUploadPluginOptions) {
   return async (buildArtifactPaths: string[]) => {
     const artifactBundleUploadTransaction = sentryHub.startTransaction({
@@ -157,11 +157,11 @@ export function createDebugIdUploadFunction({
         uploadSpan.finish();
       }
 
-      if (deleteFilesAfterUpload) {
+      if (filesToDeleteAfterUpload) {
         const deleteGlobSpan = artifactBundleUploadTransaction.startChild({
           description: "delete-glob",
         });
-        const filePathsToDelete = await glob(deleteFilesAfterUpload, {
+        const filePathsToDelete = await glob(filesToDeleteAfterUpload, {
           absolute: true,
           nodir: true,
         });

--- a/packages/bundler-plugin-core/src/index.ts
+++ b/packages/bundler-plugin-core/src/index.ts
@@ -222,7 +222,9 @@ export function sentryUnpluginFactory({
           createDebugIdUploadFunction({
             assets: options.sourcemaps?.assets,
             ignore: options.sourcemaps?.ignore,
-            deleteFilesAfterUpload: options.sourcemaps?.deleteFilesAfterUpload,
+            filesToDeleteAfterUpload:
+              options.sourcemaps?.filesToDeleteAfterUpload ??
+              options.sourcemaps?.deleteFilesAfterUpload,
             dist: options.release.dist,
             releaseName: options.release.name,
             logger: logger,

--- a/packages/bundler-plugin-core/src/sentry/telemetry.ts
+++ b/packages/bundler-plugin-core/src/sentry/telemetry.ts
@@ -83,7 +83,10 @@ export function setTelemetryDataOnHub(options: NormalizedOptions, hub: Hub, bund
   // Miscelaneous options
   hub.setTag("custom-error-handler", !!errorHandler);
   hub.setTag("sourcemaps-assets", !!sourcemaps?.assets);
-  hub.setTag("delete-after-upload", !!sourcemaps?.deleteFilesAfterUpload);
+  hub.setTag(
+    "delete-after-upload",
+    !!sourcemaps?.deleteFilesAfterUpload || !!sourcemaps?.filesToDeleteAfterUpload
+  );
 
   hub.setTag("node", process.version);
   hub.setTag("platform", process.platform);

--- a/packages/bundler-plugin-core/src/types.ts
+++ b/packages/bundler-plugin-core/src/types.ts
@@ -125,8 +125,20 @@ export interface Options {
      * The globbing patterns follow the implementation of the `glob` package. (https://www.npmjs.com/package/glob)
      *
      * Use the `debug` option to print information about which files end up being deleted.
+     *
+     * @deprecated Use `filesToDeleteAfterUpload` instead.
      */
+    // TODO(v3): Remove this option.
     deleteFilesAfterUpload?: string | string[];
+
+    /**
+     * A glob or an array of globs that specifies the build artifacts that should be deleted after the artifact upload to Sentry has been completed.
+     *
+     * The globbing patterns follow the implementation of the `glob` package. (https://www.npmjs.com/package/glob)
+     *
+     * Use the `debug` option to print information about which files end up being deleted.
+     */
+    filesToDeleteAfterUpload?: string | string[];
   };
 
   /**

--- a/packages/dev-utils/src/generate-documentation-table.ts
+++ b/packages/dev-utils/src/generate-documentation-table.ts
@@ -94,7 +94,7 @@ errorHandler: (err) => {
           "Hook to rewrite the `sources` field inside the source map before being uploaded to Sentry. Does not modify the actual source map. Effectively, this modifies how files inside the stacktrace will show up in Sentry.\n\nDefaults to making all sources relative to `process.cwd()` while building.",
       },
       {
-        name: "deleteFilesAfterUpload",
+        name: "filesToDeleteAfterUpload",
         type: "string | string[]",
         fullDescription:
           "A glob or an array of globs that specifies the build artifacts that should be deleted after the artifact upload to Sentry has been completed.\n\nThe globbing patterns follow the implementation of the `glob` package. (https://www.npmjs.com/package/glob)\n\nUse the `debug` option to print information about which files end up being deleted.",


### PR DESCRIPTION
Based on https://github.com/getsentry/sentry-javascript-bundler-plugins/issues/293 and in particular https://github.com/getsentry/sentry-javascript-bundler-plugins/issues/293#issuecomment-1583441017 the option name to delete files after the upload is really ambiguous and sounds like it takes a boolean.

This PR adds an alias `filesToDeleteAfterUpload` for `deleteFilesAfterUpload ` based on https://github.com/getsentry/sentry-javascript-bundler-plugins/issues/293#issuecomment-1586827514 that better reflects what this option is about.