### PR TITLE
fix: Use `SENTRY_RELEASE` environment variable to set `release.name` option

### DIFF
--- a/packages/bundler-plugin-core/src/options-mapping.ts
+++ b/packages/bundler-plugin-core/src/options-mapping.ts
@@ -21,7 +21,7 @@ export function normalizeUserOptions(userOptions: UserOptions) {
     sourcemaps: userOptions.sourcemaps,
     release: {
       ...userOptions.release,
-      name: userOptions.release?.name ?? determineReleaseName(),
+      name: userOptions.release?.name ?? process.env["SENTRY_RELEASE"] ?? determineReleaseName(),
       inject: userOptions.release?.inject ?? true,
       create: userOptions.release?.create ?? true,
       finalize: userOptions.release?.finalize ?? true,


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry-javascript-bundler-plugins/issues/316

I think we accidentally removed this functionality.