### PR TITLE
feat: Sort globbed files to ensure deterministic bundle IDs

### DIFF
--- a/packages/bundler-plugin-core/src/debug-id-upload.ts
+++ b/packages/bundler-plugin-core/src/debug-id-upload.ts
@@ -89,7 +89,9 @@ export function createDebugIdUploadFunction({
           debugIdChunkFilePath.endsWith(".cjs")
       );
 
-      debugIdChunkFilePaths.sort(); // ensure order; glob() does not
+      // The order of the files output by glob() is not deterministic
+      // Ensure order within the files so that {debug-id}-{chunkIndex} coupling is consistent
+      debugIdChunkFilePaths.sort();
 
       if (Array.isArray(assets) && assets.length === 0) {
         logger.debug(

--- a/packages/bundler-plugin-core/src/debug-id-upload.ts
+++ b/packages/bundler-plugin-core/src/debug-id-upload.ts
@@ -89,6 +89,8 @@ export function createDebugIdUploadFunction({
           debugIdChunkFilePath.endsWith(".cjs")
       );
 
+      debugIdChunkFilePaths.sort(); // ensure order; glob() does not
+
       if (Array.isArray(assets) && assets.length === 0) {
         logger.debug(
           "Empty `sourcemaps.assets` option provided. Will not upload sourcemaps with debug ID."


### PR DESCRIPTION
The results from `glob()` are not guarenteed to be ordered, and prevent deterministic output.

This manifests in the assignment of artefeact names, as well as the bundle-id.