### PR TITLE
docs: Fix anchor tags in READMEs

### DIFF
--- a/packages/dev-utils/src/generate-documentation-table.ts
+++ b/packages/dev-utils/src/generate-documentation-table.ts
@@ -356,7 +356,9 @@ function generateTableOfContents(
   return nodes
     .map((node) => {
       const id = `${parentId}-${node.name.toLowerCase()}`;
-      let output = `${"    ".repeat(depth)}-   [\`${node.name}\`](#${id})`;
+      let output = `${"    ".repeat(depth)}-   [\`${node.name}\`](#${id
+        .replace(/\./g, "")
+        .toLowerCase()})`;
       if (node.children && depth <= 0) {
         output += "\n";
         output += generateTableOfContents(depth + 1, id, node.children);
@@ -375,7 +377,7 @@ function generateDescriptions(
     .map((node) => {
       const name = parentName === undefined ? node.name : `${parentName}.${node.name}`;
       const id = `${parentId}-${node.name.toLowerCase()}`;
-      let output = `### <a name="${id}"></a>\`${name}\`
+      let output = `### \`${name}\`
 
 ${node.type === undefined ? "" : `Type: \`${node.type}\``}
 

--- a/packages/esbuild-plugin/src/index.ts
+++ b/packages/esbuild-plugin/src/index.ts
@@ -51,8 +51,6 @@ function esbuildDebugIdInjectionPlugin(): UnpluginOptions {
           } else {
             return {
               pluginName,
-              // needs to be an abs path, otherwise esbuild will complain
-              path: path.isAbsolute(args.path) ? args.path : path.join(args.resolveDir, args.path),
               pluginData: {
                 isProxyResolver: true,
                 originalPath: args.path,


### PR DESCRIPTION
Npm normalizes the anchors by removing all dots and lowercasing everything.