### PR TITLE
fix: Fix esbuild debug ID generation

### DIFF
--- a/packages/bundler-plugin-core/src/utils.ts
+++ b/packages/bundler-plugin-core/src/utils.ts
@@ -175,6 +175,7 @@ export function stringToUUID(str: string): string {
   const md5sum = crypto.createHash("md5");
   md5sum.update(str);
   const md5Hash = md5sum.digest("hex");
+  const variant = ["8", "9", "a", "b"][md5Hash.substring(16, 17).charCodeAt(0) % 4] as string;
   return (
     md5Hash.substring(0, 8) +
     "-" +
@@ -182,7 +183,8 @@ export function stringToUUID(str: string): string {
     "-4" +
     md5Hash.substring(13, 16) +
     "-" +
-    md5Hash.substring(16, 20) +
+    variant +
+    md5Hash.substring(17, 20) +
     "-" +
     md5Hash.substring(20)
   ).toLowerCase();

--- a/packages/bundler-plugin-core/src/utils.ts
+++ b/packages/bundler-plugin-core/src/utils.ts
@@ -175,7 +175,11 @@ export function stringToUUID(str: string): string {
   const md5sum = crypto.createHash("md5");
   md5sum.update(str);
   const md5Hash = md5sum.digest("hex");
-  const variant = ["8", "9", "a", "b"][md5Hash.substring(16, 17).charCodeAt(0) % 4] as string;
+
+  // Position 16 is fixed to either 8, 9, a, or b in the uuid v4 spec (10xx in binary)
+  // RFC 4122 section 4.4
+  const v4variant = ["8", "9", "a", "b"][md5Hash.substring(16, 17).charCodeAt(0) % 4] as string;
+
   return (
     md5Hash.substring(0, 8) +
     "-" +
@@ -183,7 +187,7 @@ export function stringToUUID(str: string): string {
     "-4" +
     md5Hash.substring(13, 16) +
     "-" +
-    variant +
+    v4variant +
     md5Hash.substring(17, 20) +
     "-" +
     md5Hash.substring(20)

--- a/packages/bundler-plugin-core/test/utils.test.ts
+++ b/packages/bundler-plugin-core/test/utils.test.ts
@@ -172,6 +172,6 @@ describe("getDependencies", () => {
 
 describe("stringToUUID", () => {
   test("should return a deterministic UUID", () => {
-    expect(stringToUUID("Nothing personnel kid")).toBe("52c7a762-5ddf-49a7-6f16-6874a8cb2512");
+    expect(stringToUUID("Nothing personnel kid")).toBe("52c7a762-5ddf-49a7-af16-6874a8cb2512");
   });
 });

--- a/packages/esbuild-plugin/src/index.ts
+++ b/packages/esbuild-plugin/src/index.ts
@@ -51,6 +51,8 @@ function esbuildDebugIdInjectionPlugin(): UnpluginOptions {
           } else {
             return {
               pluginName,
+              // needs to be an abs path, otherwise esbuild will complain
+              path: path.isAbsolute(args.path) ? args.path : path.join(args.resolveDir, args.path),
               pluginData: {
                 isProxyResolver: true,
                 originalPath: args.path,

--- a/packages/esbuild-plugin/src/index.ts
+++ b/packages/esbuild-plugin/src/index.ts
@@ -85,9 +85,9 @@ function esbuildDebugIdInjectionPlugin(): UnpluginOptions {
             pluginName,
             contents: `
               import "_sentry-debug-id-injection-stub";
-              import * as OriginalModule from "${originalPath}";
+              import * as OriginalModule from ${JSON.stringify(originalPath)};
               export default OriginalModule.default;
-              export * from "${originalPath}";`,
+              export * from ${JSON.stringify(originalPath)};`,
             resolveDir: originalResolveDir,
           };
         });

--- a/packages/esbuild-plugin/src/index.ts
+++ b/packages/esbuild-plugin/src/index.ts
@@ -83,7 +83,7 @@ function esbuildDebugIdInjectionPlugin(): UnpluginOptions {
           return {
             loader: "js",
             pluginName,
-            // We need to use JSON.stringify below in order not to break paths on windows
+            // We need to use JSON.stringify below so that any escape backslashes stay escape backslashes, in order not to break paths on windows
             contents: `
               import "_sentry-debug-id-injection-stub";
               import * as OriginalModule from ${JSON.stringify(originalPath)};

--- a/packages/esbuild-plugin/src/index.ts
+++ b/packages/esbuild-plugin/src/index.ts
@@ -83,6 +83,7 @@ function esbuildDebugIdInjectionPlugin(): UnpluginOptions {
           return {
             loader: "js",
             pluginName,
+            // We need to use JSON.stringify below in order not to break paths on windows
             contents: `
               import "_sentry-debug-id-injection-stub";
               import * as OriginalModule from ${JSON.stringify(originalPath)};

--- a/packages/integration-tests/fixtures/debug-id-injection/debug-id-injection.test.ts
+++ b/packages/integration-tests/fixtures/debug-id-injection/debug-id-injection.test.ts
@@ -1,0 +1,62 @@
+/* eslint-disable jest/no-standalone-expect */
+/* eslint-disable jest/expect-expect */
+import childProcess from "child_process";
+import path from "path";
+import { testIfNodeMajorVersionIsLessThan18 } from "../../utils/testIf";
+
+function checkBundle(bundlePath1: string, bundlePath2: string): string[] {
+  const process1Output = childProcess.execSync(`node ${bundlePath1}`, { encoding: "utf-8" });
+  const debugIdMap1 = JSON.parse(process1Output) as Record<string, string>;
+  const debugIds1 = Object.values(debugIdMap1);
+  expect(debugIds1.length).toBeGreaterThan(0);
+  expect(debugIds1).toContainEqual(
+    expect.stringMatching(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/)
+  );
+
+  const process2Output = childProcess.execSync(`node ${bundlePath2}`, { encoding: "utf-8" });
+  const debugIdMap2 = JSON.parse(process2Output) as Record<string, string>;
+  const debugIds2 = Object.values(debugIdMap2);
+  expect(debugIds2.length).toBeGreaterThan(0);
+  expect(debugIds2).toContainEqual(
+    expect.stringMatching(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/)
+  );
+
+  expect(debugIds1).not.toEqual(debugIds2);
+
+  return [...debugIds1, ...debugIds2];
+}
+
+test("esbuild bundle", () => {
+  checkBundle(
+    path.join(__dirname, "out", "esbuild", "bundle1.js"),
+    path.join(__dirname, "out", "esbuild", "bundle2.js")
+  );
+});
+
+test("rollup bundle", () => {
+  checkBundle(
+    path.join(__dirname, "out", "rollup", "bundle1.js"),
+    path.join(__dirname, "out", "rollup", "bundle2.js")
+  );
+});
+
+test("vite bundle", () => {
+  checkBundle(
+    path.join(__dirname, "out", "vite", "bundle1.js"),
+    path.join(__dirname, "out", "vite", "bundle2.js")
+  );
+});
+
+testIfNodeMajorVersionIsLessThan18("webpack 4 bundle", () => {
+  checkBundle(
+    path.join(__dirname, "out", "webpack4", "bundle1.js"),
+    path.join(__dirname, "out", "webpack4", "bundle2.js")
+  );
+});
+
+test("webpack 5 bundle", () => {
+  checkBundle(
+    path.join(__dirname, "out", "webpack5", "bundle1.js"),
+    path.join(__dirname, "out", "webpack5", "bundle2.js")
+  );
+});

--- a/packages/integration-tests/fixtures/debug-id-injection/input/bundle1.js
+++ b/packages/integration-tests/fixtures/debug-id-injection/input/bundle1.js
@@ -1,0 +1,5 @@
+// eslint-disable-next-line no-console
+console.log(JSON.stringify(global._sentryDebugIds));
+
+// Just so the two bundles generate different hashes:
+global.iAmBundle1 = 1;

--- a/packages/integration-tests/fixtures/debug-id-injection/input/bundle2.js
+++ b/packages/integration-tests/fixtures/debug-id-injection/input/bundle2.js
@@ -1,0 +1,5 @@
+// eslint-disable-next-line no-console
+console.log(JSON.stringify(global._sentryDebugIds));
+
+// Just so the two bundles generate different hashes:
+global.iAmBundle2 = 2;

--- a/packages/integration-tests/fixtures/debug-id-injection/setup.ts
+++ b/packages/integration-tests/fixtures/debug-id-injection/setup.ts
@@ -1,0 +1,16 @@
+import * as path from "path";
+import { createCjsBundles } from "../../utils/create-cjs-bundles";
+
+const outputDir = path.resolve(__dirname, "out");
+
+createCjsBundles(
+  {
+    bundle1: path.resolve(__dirname, "input", "bundle1.js"),
+    bundle2: path.resolve(__dirname, "input", "bundle2.js"),
+  },
+  outputDir,
+  {
+    telemetry: false,
+    release: { name: "I AM A RELEASE!", create: false },
+  }
+);


### PR DESCRIPTION
Since I accidentally broke debug ID generation for esbuild, the time has come to write some tests too...

Writing tests made it obvious that we also don't generate entirely valid debug IDs since the `variant` wasn't correct. This PR also fixes that.