### PR TITLE
docs: Update minimum supported Node.js version to 14

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -11,6 +11,7 @@ This document serves as a migration guide, documenting all breaking changes betw
 - Removed `customHeader` option in favor of `headers` option which allows for multiple headers to be attached to outgoing requests.
 - The `cliBinaryExists` function was renamed to `sentryCliBinaryExists`
 - Removed the `configFile` option. Options should now be set explicitly or via environment variables.
+- The minimum supported Node.js version is now 14 and newer.
 
 ## Upgrading from 1.x to 2.x (Webpack Plugin Only)
 

--- a/packages/bundler-plugin-core/package.json
+++ b/packages/bundler-plugin-core/package.json
@@ -84,7 +84,7 @@
     "extends": "../../package.json"
   },
   "engines": {
-    "node": ">= 10"
+    "node": ">= 14"
   },
   "sideEffects": [
     "./sentry-release-injection-file.js",

--- a/packages/esbuild-plugin/package.json
+++ b/packages/esbuild-plugin/package.json
@@ -76,6 +76,6 @@
     "extends": "../../package.json"
   },
   "engines": {
-    "node": ">= 10"
+    "node": ">= 14"
   }
 }

--- a/packages/rollup-plugin/package.json
+++ b/packages/rollup-plugin/package.json
@@ -78,6 +78,6 @@
     "extends": "../../package.json"
   },
   "engines": {
-    "node": ">= 10"
+    "node": ">= 14"
   }
 }

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -74,6 +74,6 @@
     "extends": "../../package.json"
   },
   "engines": {
-    "node": ">= 10"
+    "node": ">= 14"
   }
 }

--- a/packages/webpack-plugin/package.json
+++ b/packages/webpack-plugin/package.json
@@ -81,6 +81,6 @@
     "extends": "../../package.json"
   },
   "engines": {
-    "node": ">= 10"
+    "node": ">= 14"
   }
 }


### PR DESCRIPTION
Ref https://github.com/getsentry/sentry-javascript-bundler-plugins/issues/326

The unplugin dependency uses optional chaining which is only available in Node 14 or higher. Additionally, we only run our tests for versions 14 and higher.