### PR TITLE
ref: Use full git SHA for release name

### DIFF
--- a/packages/bundler-plugin-core/src/utils.ts
+++ b/packages/bundler-plugin-core/src/utils.ts
@@ -200,7 +200,7 @@ export function stringToUUID(str: string): string {
 export function determineReleaseName(): string | undefined {
   let gitRevision: string | undefined;
   try {
-    gitRevision = childProcess.execSync("git rev-parse --short HEAD").toString().trim();
+    gitRevision = childProcess.execSync("git rev-parse HEAD").toString().trim();
   } catch (e) {
     // noop
   }


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry-javascript-bundler-plugins/issues/328

I think https://github.com/getsentry/sentry-javascript-bundler-plugins/issues/328 makes a fair point. I originally used the short git sha because I thought it was gonna be prettier on the interface but using the long sha actually has technical upsides:

- Better alignment with Sentry CLI
- Less likely collisions