### PR TITLE
feat: Add configuration via `.env.sentry-build-plugin` file

### DIFF
--- a/packages/bundler-plugin-core/package.json
+++ b/packages/bundler-plugin-core/package.json
@@ -55,6 +55,7 @@
     "@sentry/cli": "^2.17.0",
     "@sentry/node": "7.53.1",
     "@sentry/utils": "7.53.1",
+    "dotenv": "^16.3.1",
     "find-up": "5.0.0",
     "glob": "9.3.2",
     "magic-string": "0.27.0",

--- a/packages/bundler-plugin-core/src/index.ts
+++ b/packages/bundler-plugin-core/src/index.ts
@@ -69,7 +69,12 @@ export function sentryUnpluginFactory({
       path: path.join(process.cwd(), ".env.sentry-build-plugin"),
     });
 
-    if ("parsed" in dotenvResult) {
+    // Ignore "file not found" errors but throw all others
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore Accessing `code` on error should be safe
+    if (dotenvResult.error && dotenvResult.error.code !== "ENOENT") {
+      throw dotenvResult.error;
+    } else if (dotenvResult.parsed) {
       logger.info('Using environment variables configured in ".env.sentry-build-plugin".');
     }
 

--- a/packages/bundler-plugin-core/src/index.ts
+++ b/packages/bundler-plugin-core/src/index.ts
@@ -18,6 +18,7 @@ import {
   stringToUUID,
   stripQueryAndHashFromPath,
 } from "./utils";
+import * as dotenv from "dotenv";
 
 interface SentryUnpluginFactoryOptions {
   releaseInjectionPlugin: (injectionCode: string) => UnpluginOptions;
@@ -58,6 +59,20 @@ export function sentryUnpluginFactory({
   debugIdUploadPlugin,
 }: SentryUnpluginFactoryOptions) {
   return createUnplugin<Options, true>((userOptions, unpluginMetaContext) => {
+    const logger = createLogger({
+      prefix: `[sentry-${unpluginMetaContext.framework}-plugin]`,
+      silent: userOptions.silent ?? false,
+      debug: userOptions.debug ?? false,
+    });
+
+    const dotenvResult = dotenv.config({
+      path: path.join(process.cwd(), ".env.sentry-build-plugin"),
+    });
+
+    if ("parsed" in dotenvResult) {
+      logger.info('Using environment variables configured in ".env.sentry-build-plugin".');
+    }
+
     const options = normalizeUserOptions(userOptions);
 
     if (unpluginMetaContext.watchMode || options.disable) {
@@ -84,12 +99,6 @@ export function sentryUnpluginFactory({
         sentryHub.endSession();
         sentEndSession = true;
       }
-    });
-
-    const logger = createLogger({
-      prefix: `[sentry-${unpluginMetaContext.framework}-plugin]`,
-      silent: options.silent,
-      debug: options.debug,
     });
 
     // Set the User-Agent that Sentry CLI will use when interacting with Sentry

--- a/packages/esbuild-plugin/README_TEMPLATE.md
+++ b/packages/esbuild-plugin/README_TEMPLATE.md
@@ -56,6 +56,10 @@ require("esbuild").build({
 
 #OPTIONS_SECTION_INSERT#
 
+### Configuration File
+
+As an additional configuration method, the Sentry esbuild plugin will pick up environment variables configured inside a `.env.sentry-build-plugin` file located in the current working directory when building your app.
+
 ## More information
 
 - [Sentry Documentation](https://docs.sentry.io/quickstart/)

--- a/packages/integration-tests/scripts/run-fixture-setups.ts
+++ b/packages/integration-tests/scripts/run-fixture-setups.ts
@@ -1,5 +1,6 @@
 import fs from "fs";
 import path from "path";
+import childProcess from "child_process";
 
 const fixturePaths = fs
   .readdirSync(path.join(__dirname, "..", "fixtures"))
@@ -8,6 +9,8 @@ const fixturePaths = fs
 fixturePaths.forEach((fixturePath) => {
   const setupScriptPath = path.join(fixturePath, "setup.ts");
   if (fs.existsSync(setupScriptPath)) {
-    require(setupScriptPath);
+    childProcess.execSync(`yarn ts-node --transpileOnly ${setupScriptPath}`, {
+      stdio: "inherit",
+    });
   }
 });

--- a/packages/playground/.gitignore
+++ b/packages/playground/.gitignore
@@ -1,3 +1,4 @@
 out/
 .env
+.env.sentry-build-plugin
 scripts/request-logger-logs/*.txt

--- a/packages/rollup-plugin/README_TEMPLATE.md
+++ b/packages/rollup-plugin/README_TEMPLATE.md
@@ -58,6 +58,10 @@ export default {
 
 #OPTIONS_SECTION_INSERT#
 
+### Configuration File
+
+As an additional configuration method, the Sentry Rollup plugin will pick up environment variables configured inside a `.env.sentry-build-plugin` file located in the current working directory when building your app.
+
 ## More information
 
 - [Sentry Documentation](https://docs.sentry.io/quickstart/)

--- a/packages/vite-plugin/README_TEMPLATE.md
+++ b/packages/vite-plugin/README_TEMPLATE.md
@@ -63,6 +63,10 @@ export default defineConfig({
 
 #OPTIONS_SECTION_INSERT#
 
+### Configuration File
+
+As an additional configuration method, the Sentry Vite plugin will pick up environment variables configured inside a `.env.sentry-build-plugin` file located in the current working directory when building your app.
+
 ## More information
 
 - [Sentry Documentation](https://docs.sentry.io/quickstart/)

--- a/packages/webpack-plugin/README_TEMPLATE.md
+++ b/packages/webpack-plugin/README_TEMPLATE.md
@@ -57,6 +57,10 @@ module.exports = {
 
 #OPTIONS_SECTION_INSERT#
 
+### Configuration File
+
+As an additional configuration method, the Sentry Webpack plugin will pick up environment variables configured inside a `.env.sentry-build-plugin` file located in the current working directory when building your app.
+
 ## More information
 
 - [Sentry Documentation](https://docs.sentry.io/quickstart/)

--- a/yarn.lock
+++ b/yarn.lock
@@ -5080,6 +5080,11 @@ dot-prop@^5.1.0:
   dependencies:
     is-obj "^2.0.0"
 
+dotenv@^16.3.1:
+  version "16.3.1"
+  resolved "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz#369034de7d7e5b120972693352a3bf112172cc3e"
+  integrity sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==
+
 dotenv@~10.0.0:
   version "10.0.0"
   resolved "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz#3d4227b8fb95f81096cdd2b66653fb2c7085ba81"


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry-javascript-bundler-plugins/issues/332

Adds option to configure environment variables via a `.env.sentry-build-plugin` file inside the cwd.

This is necessary for efforts in https://github.com/getsentry/sentry-wizard/issues/290