### PR TITLE
docs: Remove misleading documentation

### DIFF
--- a/packages/bundler-plugin-core/src/types.ts
+++ b/packages/bundler-plugin-core/src/types.ts
@@ -87,7 +87,6 @@ export interface Options {
 
   /**
    * Options for source maps uploading.
-   * Leave this option undefined if you do not want to upload source maps to Sentry.
    */
   sourcemaps?: {
     /**

--- a/packages/dev-utils/src/generate-documentation-table.ts
+++ b/packages/dev-utils/src/generate-documentation-table.ts
@@ -72,8 +72,7 @@ errorHandler: (err) => {
   },
   {
     name: "sourcemaps",
-    fullDescription:
-      "Options for source maps uploading. Leave this option undefined if you do not want to upload source maps to Sentry.",
+    fullDescription: "Options for source maps uploading.",
     children: [
       {
         name: "assets",

--- a/packages/dev-utils/src/generate-documentation-table.ts
+++ b/packages/dev-utils/src/generate-documentation-table.ts
@@ -72,7 +72,7 @@ errorHandler: (err) => {
   },
   {
     name: "sourcemaps",
-    fullDescription: "Options for source maps uploading.",
+    fullDescription: "Options for uploading source maps.",
     children: [
       {
         name: "assets",


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript-bundler-plugins/issues/338

We previously documented that leaving away the `sourcemaps` option will disable debug ID injection. That is pre v2 behaviour and not the case anymore so we should remove it.