### PR TITLE
deps: Bump sentry-cli to 2.20.1 to fix debugid injection issue

### DIFF
--- a/packages/bundler-plugin-core/package.json
+++ b/packages/bundler-plugin-core/package.json
@@ -52,7 +52,7 @@
     "fix": "eslint ./src ./test --format stylish --fix"
   },
   "dependencies": {
-    "@sentry/cli": "^2.17.0",
+    "@sentry/cli": "^2.20.1",
     "@sentry/node": "^7.60.0",
     "@sentry/utils": "^7.60.0",
     "dotenv": "^16.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2259,10 +2259,10 @@
     "@sentry/utils" "7.60.0"
     tslib "^2.4.1 || ^1.9.3"
 
-"@sentry/cli@^2.17.0":
-  version "2.18.1"
-  resolved "https://registry.npmjs.org/@sentry/cli/-/cli-2.18.1.tgz#c44f189a1a72a83087a297c5fcc7668f86dd4308"
-  integrity sha512-lc/dX/cvcmznWNbLzDbzxn224vwY5zLIDBe3yOO6Usg3CDgkZZ3xfjN4AIUZwkiTEPIOELodrOfdoMxqpXyYDw==
+"@sentry/cli@^2.20.1":
+  version "2.20.1"
+  resolved "https://registry.npmjs.org/@sentry/cli/-/cli-2.20.1.tgz#e0a04d9c0153fc8606f90ee3f6b17abed81a85bc"
+  integrity sha512-HxzwFQf5gPKfksyj2ZhUicg/avHLCOd/EjZTERSXv5V7GohaTlsNxf9Sbvv/nsu8479vogTllSU6xg5BgXAVUw==
   dependencies:
     https-proxy-agent "^5.0.0"
     node-fetch "^2.6.7"


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript/issues/8665