### PR TITLE
fix: Support `.jsbundle`s in debug ID uploads

### DIFF
--- a/packages/bundler-plugin-core/src/debug-id-upload.ts
+++ b/packages/bundler-plugin-core/src/debug-id-upload.ts
@@ -86,7 +86,8 @@ export function createDebugIdUploadFunction({
         (debugIdChunkFilePath) =>
           debugIdChunkFilePath.endsWith(".js") ||
           debugIdChunkFilePath.endsWith(".mjs") ||
-          debugIdChunkFilePath.endsWith(".cjs")
+          debugIdChunkFilePath.endsWith(".cjs") ||
+          debugIdChunkFilePath.endsWith(".jsbundle")
       );
 
       // The order of the files output by glob() is not deterministic


### PR DESCRIPTION
React Native bundles usually use `*.jsbundle` as their extensions, but Sentry is not supporting this extension when uploading debug IDs. Added a line to support `*.jsbundle` extension.