### PR TITLE
ref: Make asset detection more robust

### DIFF
--- a/packages/bundler-plugin-core/src/index.ts
+++ b/packages/bundler-plugin-core/src/index.ts
@@ -20,6 +20,7 @@ import {
   stripQueryAndHashFromPath,
 } from "./utils";
 import * as dotenv from "dotenv";
+import { glob } from "glob";
 
 interface SentryUnpluginFactoryOptions {
   releaseInjectionPlugin: (injectionCode: string) => UnpluginOptions;
@@ -420,7 +421,11 @@ export function createRollupDebugIdUploadHooks(
     ) {
       if (outputOptions.dir) {
         const outputDir = outputOptions.dir;
-        const buildArtifacts = Object.keys(bundle).map((asset) => path.join(outputDir, asset));
+        const buildArtifacts = await glob(["/**/*.js", "/**/*.js.map"], {
+          root: outputDir,
+          absolute: true,
+          nodir: true,
+        });
         await upload(buildArtifacts);
       } else if (outputOptions.file) {
         await upload([outputOptions.file]);


### PR DESCRIPTION
This change will glob for `.js` and `.js.map` files in the defined output folder of rollup and vite instead of relying on the assets provided in the `writeBundle` hook. We assume that this will make the upload a bit more robust in regards to files being missed.