### PR TITLE
ref: Add used experiments to telemetry

### DIFF
--- a/packages/bundler-plugin-core/src/sentry/telemetry.ts
+++ b/packages/bundler-plugin-core/src/sentry/telemetry.ts
@@ -70,6 +70,9 @@ export function setTelemetryDataOnHub(options: NormalizedOptions, hub: Hub, bund
     );
   }
 
+  hub.setTag("module-metadata", !!options._experiments.moduleMetadata);
+  hub.setTag("inject-build-information", !!options._experiments.injectBuildInformation);
+
   // Optional release pipeline steps
   hub.setTag("clean-artifacts", release.cleanArtifacts);
   if (release.setCommits) {


### PR DESCRIPTION
Add options under `_experiments` as tags to the telemetry data.

Closes https://github.com/getsentry/sentry-javascript-bundler-plugins/issues/374