### PR TITLE
fix: Don't crash on failed delete after upload

### DIFF
--- a/packages/bundler-plugin-core/src/debug-id-upload.ts
+++ b/packages/bundler-plugin-core/src/debug-id-upload.ts
@@ -181,7 +181,13 @@ export function createDebugIdUploadFunction({
         });
         await Promise.all(
           filePathsToDelete.map((filePathToDelete) =>
-            fs.promises.rm(filePathToDelete, { force: true })
+            fs.promises.rm(filePathToDelete, { force: true }).catch((e) => {
+              // This is allowed to fail - we just don't do anything
+              logger.debug(
+                `An error occured while attempting to delete asset: ${filePathToDelete}`,
+                e
+              );
+            })
           )
         );
         deleteSpan.finish();


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript-bundler-plugins/issues/370