### PR TITLE
fix: Fix regex in source map locating heuristic via `sourceMappingURL`

### DIFF
--- a/packages/bundler-plugin-core/src/debug-id-upload.ts
+++ b/packages/bundler-plugin-core/src/debug-id-upload.ts
@@ -295,7 +295,7 @@ async function determineSourceMapPathFromBundle(
   logger: Logger
 ): Promise<string | undefined> {
   // 1. try to find source map at `sourceMappingURL` location
-  const sourceMappingUrlMatch = bundleSource.match(/^\/\/# sourceMappingURL=(.*)$/);
+  const sourceMappingUrlMatch = bundleSource.match(/^\s*\/\/# sourceMappingURL=(.*)$/m);
   if (sourceMappingUrlMatch) {
     const sourceMappingUrl = path.normalize(sourceMappingUrlMatch[1] as string);
     if (path.isAbsolute(sourceMappingUrl)) {


### PR DESCRIPTION
Fixes #375

We have a regex that tries to find the path of a source map of a file via the `//# sourceMappingURL=` comment. It never worked because the this regex was intended to be a multiline regex ... which it wasn't.

This PR turns it into a multiline regex. While we're at it, let's also allow some whitespace in front of the comment.