### PR TITLE
ref: Run upload preparation with maximum concurrency

### DIFF
--- a/packages/bundler-plugin-core/src/debug-id-upload.ts
+++ b/packages/bundler-plugin-core/src/debug-id-upload.ts
@@ -107,7 +107,7 @@ export function createDebugIdUploadFunction({
         });
 
         // Preparing the bundles can be a lot of work and doing it all at once has the potential of nuking the heap so
-        // instead we do it with a maximum of 8 concurrent workers
+        // instead we do it with a maximum of 16 concurrent workers
         const preparationTasks = debugIdChunkFilePaths.map(
           (chunkFilePath, chunkIndex) => async (): Promise<void> => {
             await prepareBundleForDebugIdUpload(
@@ -128,7 +128,7 @@ export function createDebugIdUploadFunction({
             }
           }
         };
-        for (let workerIndex = 0; workerIndex <= 8; workerIndex++) {
+        for (let workerIndex = 0; workerIndex <= 16; workerIndex++) {
           workers.push(worker());
         }
         await Promise.all(workers);
@@ -268,9 +268,9 @@ export async function prepareBundleForDebugIdUpload(
     bundleFilePath,
     bundleContent,
     logger
-  ).then(async (sourceMapPath): Promise<void> => {
+  ).then(async (sourceMapPath) => {
     if (sourceMapPath) {
-      return await prepareSourceMapForDebugIdUpload(
+      await prepareSourceMapForDebugIdUpload(
         sourceMapPath,
         path.join(uploadFolder, `${uniqueUploadName}.js.map`),
         debugId,
@@ -280,7 +280,8 @@ export async function prepareBundleForDebugIdUpload(
     }
   });
 
-  return Promise.all([writeSourceFilePromise, writeSourceMapFilePromise]);
+  await writeSourceFilePromise;
+  await writeSourceMapFilePromise;
 }
 
 /**

--- a/packages/bundler-plugin-core/src/debug-id-upload.ts
+++ b/packages/bundler-plugin-core/src/debug-id-upload.ts
@@ -105,8 +105,11 @@ export function createDebugIdUploadFunction({
         const prepareSpan = artifactBundleUploadTransaction.startChild({
           description: "prepare-bundles",
         });
-        await Promise.all(
-          debugIdChunkFilePaths.map(async (chunkFilePath, chunkIndex): Promise<void> => {
+
+        // Preparing the bundles can be a lot of work and doing it all at once has the potential of nuking the heap so
+        // instead we do it with a maximum of 8 concurrent workers
+        const preparationTasks = debugIdChunkFilePaths.map(
+          (chunkFilePath, chunkIndex) => async (): Promise<void> => {
             await prepareBundleForDebugIdUpload(
               chunkFilePath,
               tmpUploadFolder,
@@ -114,8 +117,22 @@ export function createDebugIdUploadFunction({
               logger,
               rewriteSourcesHook ?? defaultRewriteSourcesHook
             );
-          })
+          }
         );
+        const workers: Promise<void>[] = [];
+        const worker = async () => {
+          while (preparationTasks.length > 0) {
+            const task = preparationTasks.shift();
+            if (task) {
+              await task();
+            }
+          }
+        };
+        for (let workerIndex = 0; workerIndex <= 8; workerIndex++) {
+          workers.push(worker());
+        }
+        await Promise.all(workers);
+
         prepareSpan.finish();
 
         const files = await fs.promises.readdir(tmpUploadFolder);

--- a/packages/bundler-plugin-core/src/debug-id-upload.ts
+++ b/packages/bundler-plugin-core/src/debug-id-upload.ts
@@ -109,7 +109,7 @@ export function createDebugIdUploadFunction({
         // Preparing the bundles can be a lot of work and doing it all at once has the potential of nuking the heap so
         // instead we do it with a maximum of 16 concurrent workers
         const preparationTasks = debugIdChunkFilePaths.map(
-          (chunkFilePath, chunkIndex) => async (): Promise<void> => {
+          (chunkFilePath, chunkIndex) => async () => {
             await prepareBundleForDebugIdUpload(
               chunkFilePath,
               tmpUploadFolder,

--- a/packages/bundler-plugin-core/src/debug-id-upload.ts
+++ b/packages/bundler-plugin-core/src/debug-id-upload.ts
@@ -128,7 +128,7 @@ export function createDebugIdUploadFunction({
             }
           }
         };
-        for (let workerIndex = 0; workerIndex <= 16; workerIndex++) {
+        for (let workerIndex = 0; workerIndex < 16; workerIndex++) {
           workers.push(worker());
         }
         await Promise.all(workers);


### PR DESCRIPTION
Attempts to fix https://github.com/getsentry/sentry-javascript-bundler-plugins/issues/352

When there are a lot of source files and source maps we do a lot of moving and modifying concurrently which might take up a lot of memory.

In the case of https://github.com/getsentry/sentry-javascript-bundler-plugins/issues/352 there were 226 source files + source maps which could be a lot, especially when a source map can take up several megabytes of data.

In order not to use as much ram we limit the amount of concurrent preparation jobs to 16. We might see longer compilation times in projects with a lot of output files but we're at least somewhat capping max memory usage.

Probably related: https://github.com/getsentry/sentry-javascript/issues/8805