### PR TITLE
ref: Run upload preparation with maximum concurrency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - "You know what they say ‘Fool me once, strike one, but fool me twice… strike three.’" — Michael Scott
 
+## 0.6.1
+
+- ref: Run upload preparation with maximum concurrency (#382)
+
 ## 0.6.0
 
 - feat(webpack): Add debug ID injection to the webpack plugin (#198)

--- a/packages/bundler-plugin-core/src/debug-id.ts
+++ b/packages/bundler-plugin-core/src/debug-id.ts
@@ -67,9 +67,9 @@ export async function prepareBundleForDebugIdUpload(
     bundleFilePath,
     bundleContent,
     logger
-  ).then(async (sourceMapPath): Promise<void> => {
+  ).then(async (sourceMapPath) => {
     if (sourceMapPath) {
-      return await prepareSourceMapForDebugIdUpload(
+      await prepareSourceMapForDebugIdUpload(
         sourceMapPath,
         path.join(uploadFolder, `${uniqueUploadName}.js.map`),
         debugId,
@@ -78,7 +78,8 @@ export async function prepareBundleForDebugIdUpload(
     }
   });
 
-  return Promise.all([writeSourceFilePromise, writeSourceMapFilePromise]);
+  await writeSourceFilePromise;
+  await writeSourceMapFilePromise;
 }
 
 /**


### PR DESCRIPTION
This is a backport of https://github.com/getsentry/sentry-javascript-bundler-plugins/pull/379 for version `0.6.x` to fix https://github.com/getsentry/sentry-javascript/issues/8805