### PR TITLE
fix: Save results of rewriteSourcesHook

### DIFF
--- a/packages/bundler-plugin-core/src/debug-id-upload.ts
+++ b/packages/bundler-plugin-core/src/debug-id-upload.ts
@@ -396,7 +396,7 @@ async function prepareSourceMapForDebugIdUpload(
   }
 
   if (map["sources"] && Array.isArray(map["sources"])) {
-    map["sources"].map((source: string) => rewriteSourcesHook(source, map));
+    map["sources"] = map["sources"].map((source: string) => rewriteSourcesHook(source, map));
   }
 
   try {


### PR DESCRIPTION
`map()` returns a new array, doesn't overwrite the current one.