### PR TITLE
docs: Point to org auth token page

### DIFF
--- a/packages/bundler-plugin-core/src/types.ts
+++ b/packages/bundler-plugin-core/src/types.ts
@@ -13,7 +13,7 @@ export interface Options {
 
   /**
    * The authentication token to use for all communication with Sentry.
-   * Can be obtained from https://sentry.io/settings/account/api/auth-tokens/.
+   * Can be obtained from https://sentry.io/orgredirect/organizations/:orgslug/settings/auth-tokens/.
    * Required scopes: project:releases (and org:read if setCommits option is used).
    *
    * This value can also be specified via the `SENTRY_AUTH_TOKEN` environment variable.

--- a/packages/bundler-plugin-core/src/types.ts
+++ b/packages/bundler-plugin-core/src/types.ts
@@ -14,7 +14,6 @@ export interface Options {
   /**
    * The authentication token to use for all communication with Sentry.
    * Can be obtained from https://sentry.io/orgredirect/organizations/:orgslug/settings/auth-tokens/.
-   * Required scopes: project:releases (and org:read if setCommits option is used).
    *
    * This value can also be specified via the `SENTRY_AUTH_TOKEN` environment variable.
    */

--- a/packages/dev-utils/src/generate-documentation-table.ts
+++ b/packages/dev-utils/src/generate-documentation-table.ts
@@ -20,7 +20,7 @@ const options: OptionDocumentation[] = [
     name: "authToken",
     type: "string",
     fullDescription:
-      "The authentication token to use for all communication with Sentry. Can be obtained from https://sentry.io/orgredirect/organizations/:orgslug/settings/auth-tokens/. Required scopes: project:releases (and org:read if setCommits option is used).\n\nThis value can also be specified via the `SENTRY_AUTH_TOKEN` environment variable.",
+      "The authentication token to use for all communication with Sentry. Can be obtained from https://sentry.io/orgredirect/organizations/:orgslug/settings/auth-tokens/.\n\nThis value can also be specified via the `SENTRY_AUTH_TOKEN` environment variable.",
   },
   {
     name: "url",

--- a/packages/dev-utils/src/generate-documentation-table.ts
+++ b/packages/dev-utils/src/generate-documentation-table.ts
@@ -20,7 +20,7 @@ const options: OptionDocumentation[] = [
     name: "authToken",
     type: "string",
     fullDescription:
-      "The authentication token to use for all communication with Sentry. Can be obtained from https://sentry.io/settings/account/api/auth-tokens/. Required scopes: project:releases (and org:read if setCommits option is used).\n\nThis value can also be specified via the `SENTRY_AUTH_TOKEN` environment variable.",
+      "The authentication token to use for all communication with Sentry. Can be obtained from https://sentry.io/orgredirect/organizations/:orgslug/settings/auth-tokens/. Required scopes: project:releases (and org:read if setCommits option is used).\n\nThis value can also be specified via the `SENTRY_AUTH_TOKEN` environment variable.",
   },
   {
     name: "url",

--- a/packages/esbuild-plugin/README_TEMPLATE.md
+++ b/packages/esbuild-plugin/README_TEMPLATE.md
@@ -47,7 +47,6 @@ require("esbuild").build({
       project: process.env.SENTRY_PROJECT,
 
       // Auth tokens can be obtained from https://sentry.io/orgredirect/organizations/:orgslug/settings/auth-tokens/
-      // and need `project:releases` and `org:read` scopes
       authToken: process.env.SENTRY_AUTH_TOKEN,
     }),
   ],

--- a/packages/esbuild-plugin/README_TEMPLATE.md
+++ b/packages/esbuild-plugin/README_TEMPLATE.md
@@ -46,7 +46,7 @@ require("esbuild").build({
       org: process.env.SENTRY_ORG,
       project: process.env.SENTRY_PROJECT,
 
-      // Auth tokens can be obtained from https://sentry.io/settings/account/api/auth-tokens/
+      // Auth tokens can be obtained from https://sentry.io/orgredirect/organizations/:orgslug/settings/auth-tokens/
       // and need `project:releases` and `org:read` scopes
       authToken: process.env.SENTRY_AUTH_TOKEN,
     }),

--- a/packages/rollup-plugin/README_TEMPLATE.md
+++ b/packages/rollup-plugin/README_TEMPLATE.md
@@ -45,7 +45,7 @@ export default {
       org: process.env.SENTRY_ORG,
       project: process.env.SENTRY_PROJECT,
 
-      // Auth tokens can be obtained from https://sentry.io/settings/account/api/auth-tokens/
+      // Auth tokens can be obtained from https://sentry.io/orgredirect/organizations/:orgslug/settings/auth-tokens/
       // and need `project:releases` and `org:read` scopes
       authToken: process.env.SENTRY_AUTH_TOKEN,
     }),

--- a/packages/rollup-plugin/README_TEMPLATE.md
+++ b/packages/rollup-plugin/README_TEMPLATE.md
@@ -46,7 +46,6 @@ export default {
       project: process.env.SENTRY_PROJECT,
 
       // Auth tokens can be obtained from https://sentry.io/orgredirect/organizations/:orgslug/settings/auth-tokens/
-      // and need `project:releases` and `org:read` scopes
       authToken: process.env.SENTRY_AUTH_TOKEN,
     }),
   ],

--- a/packages/vite-plugin/README_TEMPLATE.md
+++ b/packages/vite-plugin/README_TEMPLATE.md
@@ -53,7 +53,7 @@ export default defineConfig({
       org: process.env.SENTRY_ORG,
       project: process.env.SENTRY_PROJECT,
 
-      // Auth tokens can be obtained from https://sentry.io/settings/account/api/auth-tokens/
+      // Auth tokens can be obtained from https://sentry.io/orgredirect/organizations/:orgslug/settings/auth-tokens/
       // and need `project:releases` and `org:read` scopes
       authToken: process.env.SENTRY_AUTH_TOKEN,
     }),

--- a/packages/vite-plugin/README_TEMPLATE.md
+++ b/packages/vite-plugin/README_TEMPLATE.md
@@ -54,7 +54,6 @@ export default defineConfig({
       project: process.env.SENTRY_PROJECT,
 
       // Auth tokens can be obtained from https://sentry.io/orgredirect/organizations/:orgslug/settings/auth-tokens/
-      // and need `project:releases` and `org:read` scopes
       authToken: process.env.SENTRY_AUTH_TOKEN,
     }),
   ],

--- a/packages/webpack-plugin/README_TEMPLATE.md
+++ b/packages/webpack-plugin/README_TEMPLATE.md
@@ -48,7 +48,6 @@ module.exports = {
       project: process.env.SENTRY_PROJECT,
 
       // Auth tokens can be obtained from https://sentry.io/orgredirect/organizations/:orgslug/settings/auth-tokens/
-      // and need `project:releases` and `org:read` scopes
       authToken: process.env.SENTRY_AUTH_TOKEN,
     }),
   ],

--- a/packages/webpack-plugin/README_TEMPLATE.md
+++ b/packages/webpack-plugin/README_TEMPLATE.md
@@ -47,7 +47,7 @@ module.exports = {
       org: process.env.SENTRY_ORG,
       project: process.env.SENTRY_PROJECT,
 
-      // Auth tokens can be obtained from https://sentry.io/settings/account/api/auth-tokens/
+      // Auth tokens can be obtained from https://sentry.io/orgredirect/organizations/:orgslug/settings/auth-tokens/
       // and need `project:releases` and `org:read` scopes
       authToken: process.env.SENTRY_AUTH_TOKEN,
     }),


### PR DESCRIPTION
Updates all links that pointed to the user auth token settings page to point to the org auth token settings page instead.