### PR TITLE
Document SENTRY_ORG variable

### DIFF
--- a/packages/dev-utils/src/generate-documentation-table.ts
+++ b/packages/dev-utils/src/generate-documentation-table.ts
@@ -9,7 +9,7 @@ const options: OptionDocumentation[] = [
   {
     name: "org",
     type: "string",
-    fullDescription: "The slug of the Sentry organization associated with the app.",
+    fullDescription: "The slug of the Sentry organization associated with the app.\n\nThis value can also be specified via the `SENTRY_ORG` environment variable.",
   },
   {
     name: "project",


### PR DESCRIPTION
Not sure if this was omitted by accident or is not supported in some of the plugins. But sent the PR anyway 😄