### PR TITLE
fix(core): Don't abort source map location guessing when the reference is a URL

### DIFF
--- a/packages/bundler-plugin-core/src/debug-id-upload.ts
+++ b/packages/bundler-plugin-core/src/debug-id-upload.ts
@@ -332,19 +332,21 @@ async function determineSourceMapPathFromBundle(
     if (isSupportedUrl) {
       absoluteSourceMapPath = sourceMappingUrl;
     } else if (isUrl) {
-      return;
+      // noop
     } else if (path.isAbsolute(sourceMappingUrl)) {
       absoluteSourceMapPath = sourceMappingUrl;
     } else {
       absoluteSourceMapPath = path.join(path.dirname(bundlePath), sourceMappingUrl);
     }
 
-    try {
-      // Check if the file actually exists
-      await util.promisify(fs.access)(absoluteSourceMapPath);
-      return absoluteSourceMapPath;
-    } catch (e) {
-      // noop
+    if (absoluteSourceMapPath) {
+      try {
+        // Check if the file actually exists
+        await util.promisify(fs.access)(absoluteSourceMapPath);
+        return absoluteSourceMapPath;
+      } catch (e) {
+        // noop
+      }
     }
   }
 


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript-bundler-plugins/issues/423