### PR TITLE
feat: deprecate `excludeReplayCanvas` config

### DIFF
--- a/packages/bundler-plugin-core/src/types.ts
+++ b/packages/bundler-plugin-core/src/types.ts
@@ -252,9 +252,7 @@ export interface Options {
      * You can safely do this when you do not want to capture any Canvas activity via Replay.
      * Note that the success of this depends on tree shaking generally being enabled in your build.
      *
-     * This option is not needed since v7.78.0 of the JavaScript SDK, because canvas is automatically excluded from the build.
-     *
-     * @deprecated Since v7.78.0 of the JavaScript SDK, this is excluded by default - no need to configure anything!
+     * @deprecated Versions v7.78.0 and later of the Sentry JavaScript SDKs do not include canvas support by default, making this option redundant.
      */
     excludeReplayCanvas?: boolean;
 

--- a/packages/bundler-plugin-core/src/types.ts
+++ b/packages/bundler-plugin-core/src/types.ts
@@ -251,6 +251,10 @@ export interface Options {
      * If set to true, the plugin will try to tree-shake Session Replay's Canvas recording functionality out.
      * You can safely do this when you do not want to capture any Canvas activity via Replay.
      * Note that the success of this depends on tree shaking generally being enabled in your build.
+     *
+     * This option is not needed since v7.78.0 of the JavaScript SDK, because canvas is automatically excluded from the build.
+     *
+     * @deprecated Since v7.78.0 of the JavaScript SDK, this is excluded by default - no need to configure anything!
      */
     excludeReplayCanvas?: boolean;
 


### PR DESCRIPTION
Not needed since v7.78.0 of the SDK as there this is excluded by default.