### PR TITLE
fix: use in memory esbuild build artifact for default source maps

### DIFF
--- a/packages/bundler-plugin-core/src/index.ts
+++ b/packages/bundler-plugin-core/src/index.ts
@@ -4,7 +4,7 @@ import * as path from "path";
 import MagicString from "magic-string";
 import { createUnplugin, UnpluginOptions } from "unplugin";
 import { normalizeUserOptions, validateOptions } from "./options-mapping";
-import { createDebugIdUploadFunction } from "./debug-id-upload";
+import { createDebugIdUploadFunction, InMemoryBundleAsset } from "./debug-id-upload";
 import { releaseManagementPlugin } from "./plugins/release-management";
 import { telemetryPlugin } from "./plugins/telemetry";
 import { createLogger } from "./sentry/logger";
@@ -27,7 +27,9 @@ interface SentryUnpluginFactoryOptions {
   releaseInjectionPlugin: (injectionCode: string) => UnpluginOptions;
   moduleMetadataInjectionPlugin?: (injectionCode: string) => UnpluginOptions;
   debugIdInjectionPlugin: () => UnpluginOptions;
-  debugIdUploadPlugin: (upload: (buildArtifacts: string[]) => Promise<void>) => UnpluginOptions;
+  debugIdUploadPlugin: (
+    upload: (buildArtifacts: string[] | InMemoryBundleAsset[]) => Promise<void>
+  ) => UnpluginOptions;
   bundleSizeOptimizationsPlugin: (buildFlags: SentrySDKBuildFlags) => UnpluginOptions;
 }
 
@@ -517,3 +519,4 @@ export function getDebugIdSnippet(debugId: string): string {
 export { stringToUUID, replaceBooleanFlagsInCode } from "./utils";
 
 export type { Options, SentrySDKBuildFlags } from "./types";
+export type { InMemoryBundleAsset } from "./debug-id-upload";


### PR DESCRIPTION
This fixes an issue when trying to use the esbuild plugin with Angular (or other similar tool chains with `write` set to false)
This does not modify the behavior when an explicit `globAssets` is set (those will still be limited to what is on disk) but at least for the default option the in memory versions will be used.
This may have a benefit for esbuild since it isn't having to read all these files from disk.

fixes: #351