### PR TITLE
fix(core): Safely flush telemetry

### DIFF
--- a/packages/bundler-plugin-core/src/debug-id-upload.ts
+++ b/packages/bundler-plugin-core/src/debug-id-upload.ts
@@ -8,6 +8,7 @@ import { promisify } from "util";
 import { Hub, NodeClient } from "@sentry/node";
 import SentryCli from "@sentry/cli";
 import { dynamicSamplingContextToSentryBaggageHeader } from "@sentry/utils";
+import { safeFlushTelemetry } from "./sentry/telemetry";
 
 interface RewriteSourcesHook {
   (source: string, map: any): string;
@@ -224,7 +225,7 @@ export function createDebugIdUploadFunction({
         cleanupSpan.finish();
       }
       artifactBundleUploadTransaction.finish();
-      await sentryClient.flush();
+      await safeFlushTelemetry(sentryClient);
     }
   };
 }

--- a/packages/bundler-plugin-core/src/plugins/release-management.ts
+++ b/packages/bundler-plugin-core/src/plugins/release-management.ts
@@ -2,6 +2,7 @@ import SentryCli, { SentryCliCommitsOptions, SentryCliNewDeployOptions } from "@
 import { Hub, NodeClient } from "@sentry/node";
 import { UnpluginOptions } from "unplugin";
 import { Logger } from "../sentry/logger";
+import { safeFlushTelemetry } from "../sentry/telemetry";
 import { IncludeEntry } from "../types";
 import { arrayify } from "../utils";
 
@@ -93,7 +94,7 @@ export function releaseManagementPlugin({
         }
       } catch (e) {
         sentryHub.captureException('Error in "releaseManagementPlugin" writeBundle hook');
-        await sentryClient.flush();
+        await safeFlushTelemetry(sentryClient);
         handleRecoverableError(e);
       }
     },

--- a/packages/bundler-plugin-core/src/plugins/telemetry.ts
+++ b/packages/bundler-plugin-core/src/plugins/telemetry.ts
@@ -1,6 +1,7 @@
 import { Hub, NodeClient } from "@sentry/node";
 import { UnpluginOptions } from "unplugin";
 import { Logger } from "../sentry/logger";
+import { safeFlushTelemetry } from "../sentry/telemetry";
 
 interface TelemetryPluginOptions {
   sentryHub: Hub;
@@ -23,7 +24,7 @@ export function telemetryPlugin({
           "Sending error and performance telemetry data to Sentry. To disable telemetry, set `options.telemetry` to `false`."
         );
         sentryHub.startTransaction({ name: "Sentry Bundler Plugin execution" }).finish();
-        await sentryClient.flush(3000);
+        await safeFlushTelemetry(sentryClient);
       }
     },
   };

--- a/packages/bundler-plugin-core/src/sentry/telemetry.ts
+++ b/packages/bundler-plugin-core/src/sentry/telemetry.ts
@@ -147,3 +147,15 @@ export async function allowedToSendTelemetry(options: NormalizedOptions): Promis
 
   return new URL(cliInfoUrl).hostname === SENTRY_SAAS_HOSTNAME;
 }
+
+/**
+ * Flushing the SDK client can fail. We never want to crash the plugin because of telemetry.
+ */
+export async function safeFlushTelemetry(sentryClient: NodeClient) {
+  try {
+    await sentryClient.flush(2000);
+  } catch {
+    // Noop when flushing fails.
+    // We don't even need to log anything because there's likely nothing the user can do and they likely will not care.
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript-bundler-plugins/issues/461

I keep forgetting that flushing may throw.