### PR TITLE
feat(core): Add telemetry for React component annotations

### DIFF
--- a/packages/bundler-plugin-core/src/sentry/telemetry.ts
+++ b/packages/bundler-plugin-core/src/sentry/telemetry.ts
@@ -60,7 +60,7 @@ export function createSentryInstance(
 }
 
 export function setTelemetryDataOnHub(options: NormalizedOptions, hub: Hub, bundler: string) {
-  const { org, project, release, errorHandler, sourcemaps } = options;
+  const { org, project, release, errorHandler, sourcemaps, reactComponentAnnotation } = options;
 
   hub.setTag("upload-legacy-sourcemaps", !!release.uploadLegacySourcemaps);
   if (release.uploadLegacySourcemaps) {
@@ -90,6 +90,8 @@ export function setTelemetryDataOnHub(options: NormalizedOptions, hub: Hub, bund
     "delete-after-upload",
     !!sourcemaps?.deleteFilesAfterUpload || !!sourcemaps?.filesToDeleteAfterUpload
   );
+
+  hub.setTag("react-annotate", !!reactComponentAnnotation?.enabled);
 
   hub.setTag("node", process.version);
   hub.setTag("platform", process.platform);


### PR DESCRIPTION
Forgot to port this over from the first PR! Just adds a tag on the transaction so we can track how many users have enabled the react component annotation feature.

In a future PR, I can also look into using Sentry metrics to do this as well, for the sake of 🐶 fooding .