### PR TITLE
fix(core): Stop .env files from being picked up

### DIFF
--- a/packages/bundler-plugin-core/src/index.ts
+++ b/packages/bundler-plugin-core/src/index.ts
@@ -83,7 +83,7 @@ export function sentryUnpluginFactory({
         path.join(process.cwd(), ".env.sentry-build-plugin"),
         "utf-8"
       );
-      // NOTE: Do not use the dotenv library directly to read the dotenv file! For some ungodly reason, it falls back to reading `${process.cwd()}/.env` which is absolutely not what we want.
+      // NOTE: Do not use the dotenv.config API directly to read the dotenv file! For some ungodly reason, it falls back to reading `${process.cwd()}/.env` which is absolutely not what we want.
       const dotenvResult = dotenv.parse(dotenvFile);
       process.env = { ...process.env, ...dotenvResult };
       logger.info('Using environment variables configured in ".env.sentry-build-plugin".');


### PR DESCRIPTION
For some reason `dotenv` is falling back to reading the local `.env` file when the file you actually wanted to read is not present. Obviously this is not what we want so instead we just read it ourselves and just use dotenv to parse it for us.

Fixes https://github.com/getsentry/sentry-javascript-bundler-plugins/issues/484