### PR TITLE
Allow newer versions of 3rd-party dependencies of `core`

### DIFF
--- a/packages/bundler-plugin-core/package.json
+++ b/packages/bundler-plugin-core/package.json
@@ -52,12 +52,12 @@
     "fix": "eslint ./src ./test --format stylish --fix"
   },
   "dependencies": {
-    "@babel/core": "7.18.5",
+    "@babel/core": "^7.18.5",
     "@sentry/babel-plugin-component-annotate": "2.14.2",
     "@sentry/cli": "^2.22.3",
     "dotenv": "^16.3.1",
-    "find-up": "5.0.0",
-    "glob": "9.3.2",
+    "find-up": "^5.0.0",
+    "glob": "^9.3.2",
     "magic-string": "0.27.0",
     "unplugin": "1.0.1"
   },


### PR DESCRIPTION
As per the sole commit:

> Commit fba3468 pinned `@babel/core` as a dependency. In order to allow users to deduplicate the Babel stack, this commit amends the spec to allow newer versions as well. The same change is made to other 3rd-party production dependencies, except for `unplugin` [1] and `magic-string` [2] which apparently need to be pinned.

[1]: https://github.com/getsentry/sentry-javascript-bundler-plugins/pull/496#issuecomment-1976233741
[2]: https://github.com/getsentry/sentry-javascript-bundler-plugins/pull/496#issuecomment-1976513188