### PR TITLE
feat: Make options object optional

### DIFF
--- a/packages/bundler-plugin-core/src/index.ts
+++ b/packages/bundler-plugin-core/src/index.ts
@@ -70,7 +70,7 @@ export function sentryUnpluginFactory({
   debugIdUploadPlugin,
   bundleSizeOptimizationsPlugin,
 }: SentryUnpluginFactoryOptions) {
-  return createUnplugin<Options, true>((userOptions, unpluginMetaContext) => {
+  return createUnplugin<Options | undefined, true>((userOptions = {}, unpluginMetaContext) => {
     const logger = createLogger({
       prefix: `[sentry-${unpluginMetaContext.framework}-plugin]`,
       silent: userOptions.silent ?? false,

--- a/packages/esbuild-plugin/src/index.ts
+++ b/packages/esbuild-plugin/src/index.ts
@@ -258,7 +258,7 @@ const sentryUnplugin = sentryUnpluginFactory({
 });
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const sentryEsbuildPlugin: (options: Options) => any = sentryUnplugin.esbuild;
+export const sentryEsbuildPlugin: (options?: Options) => any = sentryUnplugin.esbuild;
 
 export type { Options as SentryEsbuildPluginOptions } from "@sentry/bundler-plugin-core";
 export { sentryCliBinaryExists } from "@sentry/bundler-plugin-core";

--- a/packages/rollup-plugin/src/index.ts
+++ b/packages/rollup-plugin/src/index.ts
@@ -67,7 +67,7 @@ const sentryUnplugin = sentryUnpluginFactory({
 });
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const sentryRollupPlugin: (options: Options) => any = sentryUnplugin.rollup;
+export const sentryRollupPlugin: (options?: Options) => any = sentryUnplugin.rollup;
 
 export type { Options as SentryRollupPluginOptions } from "@sentry/bundler-plugin-core";
 export { sentryCliBinaryExists } from "@sentry/bundler-plugin-core";

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -69,7 +69,7 @@ const sentryUnplugin = sentryUnpluginFactory({
 });
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const sentryVitePlugin: (options: Options) => any = sentryUnplugin.vite;
+export const sentryVitePlugin: (options?: Options) => any = sentryUnplugin.vite;
 
 export type { Options as SentryVitePluginOptions } from "@sentry/bundler-plugin-core";
 export { sentryCliBinaryExists } from "@sentry/bundler-plugin-core";

--- a/packages/webpack-plugin/src/index.ts
+++ b/packages/webpack-plugin/src/index.ts
@@ -174,7 +174,7 @@ const sentryUnplugin = sentryUnpluginFactory({
 });
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const sentryWebpackPlugin: (options: Options) => any = sentryUnplugin.webpack;
+export const sentryWebpackPlugin: (options?: Options) => any = sentryUnplugin.webpack;
 
 export { sentryCliBinaryExists } from "@sentry/bundler-plugin-core";
 export type { Options as SentryWebpackPluginOptions } from "@sentry/bundler-plugin-core";


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry-javascript-bundler-plugins/issues/501

It's actually very valid as the plugin doesn't need any options to operate. Everything necessary for source maps upload can also be configured via environment variables.