### PR TITLE
feat(core): Add `loggerPrefixOverride` meta option

### DIFF
--- a/packages/bundler-plugin-core/src/index.ts
+++ b/packages/bundler-plugin-core/src/index.ts
@@ -72,7 +72,9 @@ export function sentryUnpluginFactory({
 }: SentryUnpluginFactoryOptions) {
   return createUnplugin<Options | undefined, true>((userOptions = {}, unpluginMetaContext) => {
     const logger = createLogger({
-      prefix: `[sentry-${unpluginMetaContext.framework}-plugin]`,
+      prefix:
+        userOptions._metaOptions?.loggerPrefixOverride ??
+        `[sentry-${unpluginMetaContext.framework}-plugin]`,
       silent: userOptions.silent ?? false,
       debug: userOptions.debug ?? false,
     });

--- a/packages/bundler-plugin-core/src/types.ts
+++ b/packages/bundler-plugin-core/src/types.ts
@@ -320,6 +320,19 @@ export interface Options {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     moduleMetadata?: any | ModuleMetadataCallback;
   };
+
+  /**
+   * Options that are useful for building wrappers around the plugin. You likely don't need these options unless you
+   * are distributing a tool that depends on this plugin
+   */
+  _metaOptions?: {
+    /**
+     * Overrides the prefix that come before logger messages. (e.g. `[some-prefix] Info: Some log message`)
+     *
+     * Example value: `[sentry-webpack-plugin (client)]`
+     */
+    loggerPrefixOverride?: string;
+  };
 }
 
 export interface ModuleMetadataCallbackArgs {


### PR DESCRIPTION
Adds `_metaOptions` to configure more intimite options for consumption of higher order plugins or build tools.

Adds an option to the meta options (`loggerPrefixOverride`) to allow to configure the prefix for logger messages.