### PR TITLE
fix: Create word-based fidelity source mapping for code transformations

### DIFF
--- a/packages/bundler-plugin-core/package.json
+++ b/packages/bundler-plugin-core/package.json
@@ -58,7 +58,7 @@
     "dotenv": "^16.3.1",
     "find-up": "^5.0.0",
     "glob": "^9.3.2",
-    "magic-string": "0.27.0",
+    "magic-string": "0.30.8",
     "unplugin": "1.0.1"
   },
   "devDependencies": {

--- a/packages/bundler-plugin-core/src/index.ts
+++ b/packages/bundler-plugin-core/src/index.ts
@@ -419,7 +419,7 @@ export function createRollupReleaseInjectionHooks(injectionCode: string) {
 
       return {
         code: ms.toString(),
-        map: ms.generateMap({ hires: true }),
+        map: ms.generateMap(),
       };
     },
   };
@@ -464,7 +464,7 @@ export function createRollupDebugIdInjectionHooks() {
 
         return {
           code: ms.toString(),
-          map: ms.generateMap({ file: chunk.fileName, hires: true }),
+          map: ms.generateMap({ file: chunk.fileName }),
         };
       } else {
         return null; // returning null means not modifying the chunk at all
@@ -495,7 +495,7 @@ export function createRollupModuleMetadataInjectionHooks(injectionCode: string) 
 
         return {
           code: ms.toString(),
-          map: ms.generateMap({ file: chunk.fileName, hires: true }),
+          map: ms.generateMap({ file: chunk.fileName }),
         };
       } else {
         return null; // returning null means not modifying the chunk at all

--- a/packages/bundler-plugin-core/src/index.ts
+++ b/packages/bundler-plugin-core/src/index.ts
@@ -419,7 +419,7 @@ export function createRollupReleaseInjectionHooks(injectionCode: string) {
 
       return {
         code: ms.toString(),
-        map: ms.generateMap(),
+        map: ms.generateMap({ hires: "boundary" }),
       };
     },
   };
@@ -464,7 +464,7 @@ export function createRollupDebugIdInjectionHooks() {
 
         return {
           code: ms.toString(),
-          map: ms.generateMap({ file: chunk.fileName }),
+          map: ms.generateMap({ file: chunk.fileName, hires: "boundary" }),
         };
       } else {
         return null; // returning null means not modifying the chunk at all
@@ -495,7 +495,7 @@ export function createRollupModuleMetadataInjectionHooks(injectionCode: string) 
 
         return {
           code: ms.toString(),
-          map: ms.generateMap({ file: chunk.fileName }),
+          map: ms.generateMap({ file: chunk.fileName, hires: "boundary" }),
         };
       } else {
         return null; // returning null means not modifying the chunk at all

--- a/packages/bundler-plugin-core/src/utils.ts
+++ b/packages/bundler-plugin-core/src/utils.ts
@@ -326,7 +326,7 @@ export function replaceBooleanFlagsInCode(
   if (ms.hasChanged()) {
     return {
       code: ms.toString(),
-      map: ms.generateMap({ hires: true }),
+      map: ms.generateMap(),
     };
   }
 

--- a/packages/bundler-plugin-core/src/utils.ts
+++ b/packages/bundler-plugin-core/src/utils.ts
@@ -326,7 +326,7 @@ export function replaceBooleanFlagsInCode(
   if (ms.hasChanged()) {
     return {
       code: ms.toString(),
-      map: ms.generateMap(),
+      map: ms.generateMap({ hires: "boundary" }),
     };
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2001,7 +2001,7 @@
   resolved "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz#add4c98d341472a289190b424efbdb096991bb24"
   integrity sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==
 
-"@jridgewell/sourcemap-codec@^1.4.10", "@jridgewell/sourcemap-codec@^1.4.13", "@jridgewell/sourcemap-codec@^1.4.15":
+"@jridgewell/sourcemap-codec@^1.4.10", "@jridgewell/sourcemap-codec@^1.4.15":
   version "1.4.15"
   resolved "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz#d7c6e6755c78567a951e04ab52ef0fd26de59f32"
   integrity sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==
@@ -9314,12 +9314,12 @@ lru_map@^0.3.3:
   resolved "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz#b5c8351b9464cbd750335a79650a0ec0e56118dd"
   integrity sha512-Pn9cox5CsMYngeDbmChANltQl+5pi6XmTrraMSzhPmMBbmgcxmqWry0U3PGapCU1yB4/LqCcom7qhHZiF/jGfQ==
 
-magic-string@0.27.0:
-  version "0.27.0"
-  resolved "https://registry.npmjs.org/magic-string/-/magic-string-0.27.0.tgz#e4a3413b4bab6d98d2becffd48b4a257effdbbf3"
-  integrity sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==
+magic-string@0.30.8:
+  version "0.30.8"
+  resolved "https://registry.npmjs.org/magic-string/-/magic-string-0.30.8.tgz#14e8624246d2bedba70d5462aa99ac9681844613"
+  integrity sha512-ISQTe55T2ao7XtlAStud6qwYPZjE4GK1S/BeVPus4jrq6JuOnQ00YKQC581RWhR122W7msZV263KzVeLoqidyQ==
   dependencies:
-    "@jridgewell/sourcemap-codec" "^1.4.13"
+    "@jridgewell/sourcemap-codec" "^1.4.15"
 
 magic-string@^0.25.7:
   version "0.25.9"


### PR DESCRIPTION
Attempt to fix https://github.com/getsentry/sentry-javascript-bundler-plugins/issues/512

It seems like we are OOMing users with the plugin. I previously wrote this off as an upstream issue, but looking at the comment https://github.com/getsentry/sentry-javascript-bundler-plugins/pull/379#issuecomment-1714745412 which narrows the OOM issue down to version 2.7.0 or 2.7.1, it seems like https://github.com/getsentry/sentry-javascript-bundler-plugins/pull/383 could have introduced memory issues since `hires: true` will create mappings for every single character.

Now that I am wiser I don't think that is entirely necesary - especially for our use-case. Let's see if removing that option would fix it. It looks like simply removing `hires: true` will drastically reduce the fidelity of source maps to line based mappings, however, a [newer release of `magic-string`](https://github.com/Rich-Harris/magic-string/pull/255) includes a new option value `'boundary'` which does word-based mapping. I hope this will reduce memory pressure while still preserving high quality source maps.