### PR TITLE
fix(docs): Update pnpm install commands

### DIFF
--- a/packages/babel-plugin-component-annotate/README.md
+++ b/packages/babel-plugin-component-annotate/README.md
@@ -46,7 +46,7 @@ yarn add @sentry/babel-plugin-component-annotate --dev
 Using pnpm:
 
 ```bash
-pnpm install @sentry/babel-plugin-component-annotate --dev
+pnpm add @sentry/babel-plugin-component-annotate --save-dev
 ```
 
 ## Example

--- a/packages/esbuild-plugin/README_TEMPLATE.md
+++ b/packages/esbuild-plugin/README_TEMPLATE.md
@@ -29,7 +29,7 @@ yarn add @sentry/esbuild-plugin --dev
 Using pnpm:
 
 ```bash
-pnpm install @sentry/esbuild-plugin --dev
+pnpm add @sentry/esbuild-plugin -D
 ```
 
 ## Example

--- a/packages/esbuild-plugin/README_TEMPLATE.md
+++ b/packages/esbuild-plugin/README_TEMPLATE.md
@@ -29,7 +29,7 @@ yarn add @sentry/esbuild-plugin --dev
 Using pnpm:
 
 ```bash
-pnpm add @sentry/esbuild-plugin -D
+pnpm add @sentry/esbuild-plugin --save-dev
 ```
 
 ## Example

--- a/packages/rollup-plugin/README_TEMPLATE.md
+++ b/packages/rollup-plugin/README_TEMPLATE.md
@@ -29,7 +29,7 @@ yarn add @sentry/rollup-plugin --dev
 Using pnpm:
 
 ```bash
-pnpm install @sentry/rollup-plugin --dev
+pnpm add @sentry/rollup-plugin --save-dev
 ```
 
 ## Example

--- a/packages/vite-plugin/README_TEMPLATE.md
+++ b/packages/vite-plugin/README_TEMPLATE.md
@@ -29,7 +29,7 @@ yarn add @sentry/vite-plugin --dev
 Using pnpm:
 
 ```bash
-pnpm add -D @sentry/vite-plugin
+pnpm add @sentry/vite-plugin --save-dev
 ```
 
 ## Example

--- a/packages/webpack-plugin/README_TEMPLATE.md
+++ b/packages/webpack-plugin/README_TEMPLATE.md
@@ -29,7 +29,7 @@ yarn add @sentry/webpack-plugin --dev
 Using pnpm:
 
 ```bash
-pnpm install @sentry/webpack-plugin --dev
+pnpm add @sentry/webpack-plugin --save-dev
 ```
 
 ## Example


### PR DESCRIPTION
`pnpm install` is used to install all dependencies for a project, according to the pnpm documentation.

and the appropriate command to install a single package is `pnpm add`. 

## Reference 
- https://pnpm.io/cli/add
- https://pnpm.io/cli/install