### PR TITLE
feat: Support Heroku env vars when infering release name

### DIFF
--- a/packages/bundler-plugin-core/src/utils.ts
+++ b/packages/bundler-plugin-core/src/utils.ts
@@ -233,6 +233,10 @@ export function determineReleaseName(): string | undefined {
     process.env["ZEIT_BITBUCKET_COMMIT_SHA"] ||
     // Flightcontrol - https://www.flightcontrol.dev/docs/guides/flightcontrol/environment-variables#built-in-environment-variables
     process.env["FC_GIT_COMMIT_SHA"] ||
+    // Heroku #1 https://devcenter.heroku.com/changelog-items/630
+    process.env["SOURCE_VERSION"] ||
+    // Heroku #2 https://docs.sentry.io/product/integrations/deployment/heroku/#configure-releases
+    process.env["HEROKU_SLUG_COMMIT"] ||
     gitRevision()
   );
 }


### PR DESCRIPTION
This PR checks Heroku env vars when trying to determine a release name.

This should align with other Sentry tools (including the Rust cli) and this library also used to support them a very long time ago:

https://github.com/getsentry/sentry-javascript-bundler-plugins/blob/484a719a187fdfdf456b9da1489b8eed1e7dde19/packages/unplugin/src/getReleaseName.ts#L18-L25

Feel free to not add this if this is not wanted!