### PR TITLE
Support uploading sourcemaps when bundling from stdin

### DIFF
--- a/packages/esbuild-plugin/src/index.ts
+++ b/packages/esbuild-plugin/src/index.ts
@@ -51,9 +51,7 @@ function esbuildDebugIdInjectionPlugin(): UnpluginOptions {
     esbuild: {
       setup({ initialOptions, onLoad, onResolve }) {
         onResolve({ filter: /.*/ }, (args) => {
-          if (args.kind !== "entry-point") {
-            return;
-          } else {
+          if (args.kind === "entry-point" || (args.kind === "import-statement" && args.importer === "<stdin>")) {
             // Injected modules via the esbuild `inject` option do also have `kind == "entry-point"`.
             // We do not want to inject debug IDs into those files because they are already bundled into the entrypoints
             if (initialOptions.inject?.includes(args.path)) {
@@ -136,9 +134,7 @@ function esbuildModuleMetadataInjectionPlugin(injectionCode: string): UnpluginOp
     esbuild: {
       setup({ initialOptions, onLoad, onResolve }) {
         onResolve({ filter: /.*/ }, (args) => {
-          if (args.kind !== "entry-point") {
-            return;
-          } else {
+          if (args.kind === "entry-point" || (args.kind === "import-statement" && args.importer === "<stdin>")) {
             // Injected modules via the esbuild `inject` option do also have `kind == "entry-point"`.
             // We do not want to inject debug IDs into those files because they are already bundled into the entrypoints
             if (initialOptions.inject?.includes(args.path)) {


### PR DESCRIPTION
Currently, when bundling with esbuild and the entrypoint is from [stdin](https://esbuild.github.io/api/#stdin), no sourcemaps are uploaded to Sentry. Digging into the source, it happens because debug IDs (needed to resolve source maps) are only injected for actual module entrypoints (not stdin entrypoints). 

We can see this with the following esbuild config (taken from my [SST](https://ion.sst.dev) project where I noticed the issue) that SST generates to deploy my functions. 

```typescript
// worker.ts
export default {
  fetch(request: Request) {
    return new Response(null, { status: 204 })
  }
}
```

```typescript
import { build } from "esbuild";
import { sentryEsbuildPlugin } from "@sentry/esbuild-plugin";

build({
	stdin: {
		contents: `
        import handler from "./worker.ts"
        import { wrapCloudflareHandler } from "sst"
        export default wrapCloudflareHandler(handler)
        `,
		loader: "ts",
		resolveDir: "./",
	},
	plugins: [
		sentryEsbuildPlugin({
			org: "OMITTED",
			project: "OMITTED",
			authToken: "OMITTED",
			debug: true,
		}),
	],
	sourcemap: true,
	bundle: true,
	metafile: true,
	outfile: "./dist/index.mjs",
	external: ["node:process"],
}).then(() => process.exit(0))
```

Running a build produces the following logs:

```bash
[sentry-esbuild-plugin] Debug: Could not determine debug ID from bundle. This can happen if you did not clean your output folder before installing the Sentry plugin. File will not be source mapped: /Users/ernest/Downloads/esbuild-sentry/dist/index.mjs
> Found 0 files
> Adding source map references
> Nothing to upload
[sentry-esbuild-plugin] Info: Successfully uploaded source maps to Sentry
```

As you can see, the build script SST uses wraps my handler with some functions to define stuff it needs at runtime. I could get around this issue by:

- Bundling the function _before_ passing it to SST but I'd rather not have to maintain my own build steps when SST supports this (with customisation) already.
- Using the `uploadLegacySourcemaps` options to manually upload the sourcemaps, but I had difficulty with actually getting Sentry to map errors to the source code

However, I feel like this is a valid use-case, even outside of SST, hence why I'm opening this PR (and not an issue in SST). I don't feel too strongly about having this built in and will happily accept an explanation on why this is not a good idea.

Now, the check for modules required by stdin may not be correct, but I think this is along the lines of what's needed to support the feature.