### PR TITLE
feat: Deprecate and noop `cleanArtifacts`

### DIFF
--- a/packages/bundler-plugin-core/src/index.ts
+++ b/packages/bundler-plugin-core/src/index.ts
@@ -54,11 +54,10 @@ interface SentryUnpluginFactoryOptions {
  * release creation pipeline:
  *
  * 1. Create a new release
- * 2. Delete already uploaded artifacts for this release (if `cleanArtifacts` is enabled)
- * 3. Upload sourcemaps based on `include` and source-map-specific options
- * 4. Associate a range of commits with the release (if `setCommits` is specified)
- * 5. Finalize the release (unless `finalize` is disabled)
- * 6. Add deploy information to the release (if `deploy` is specified)
+ * 2. Upload sourcemaps based on `include` and source-map-specific options
+ * 3. Associate a range of commits with the release (if `setCommits` is specified)
+ * 4. Finalize the release (unless `finalize` is disabled)
+ * 5. Add deploy information to the release (if `deploy` is specified)
  *
  * This release creation pipeline relies on Sentry CLI to execute the different steps.
  */
@@ -261,7 +260,6 @@ export function sentryUnpluginFactory({
           logger,
           releaseName: options.release.name,
           shouldCreateRelease: options.release.create,
-          shouldCleanArtifacts: options.release.cleanArtifacts,
           shouldFinalizeRelease: options.release.finalize,
           include: options.release.uploadLegacySourcemaps,
           setCommitsOption: options.release.setCommits,

--- a/packages/bundler-plugin-core/src/options-mapping.ts
+++ b/packages/bundler-plugin-core/src/options-mapping.ts
@@ -26,7 +26,6 @@ export function normalizeUserOptions(userOptions: UserOptions) {
       create: userOptions.release?.create ?? true,
       finalize: userOptions.release?.finalize ?? true,
       vcsRemote: userOptions.release?.vcsRemote ?? process.env["SENTRY_VSC_REMOTE"] ?? "origin",
-      cleanArtifacts: userOptions.release?.cleanArtifacts ?? false,
     },
     bundleSizeOptimizations: userOptions.bundleSizeOptimizations,
     reactComponentAnnotation: userOptions.reactComponentAnnotation,

--- a/packages/bundler-plugin-core/src/plugins/release-management.ts
+++ b/packages/bundler-plugin-core/src/plugins/release-management.ts
@@ -10,7 +10,6 @@ interface ReleaseManagementPluginOptions {
   logger: Logger;
   releaseName: string;
   shouldCreateRelease: boolean;
-  shouldCleanArtifacts: boolean;
   shouldFinalizeRelease: boolean;
   include?: string | IncludeEntry | Array<string | IncludeEntry>;
   setCommitsOption?: SentryCliCommitsOptions;
@@ -36,7 +35,6 @@ export function releaseManagementPlugin({
   dist,
   setCommitsOption,
   shouldCreateRelease,
-  shouldCleanArtifacts,
   shouldFinalizeRelease,
   deployOptions,
   handleRecoverableError,
@@ -52,13 +50,6 @@ export function releaseManagementPlugin({
 
         if (shouldCreateRelease) {
           await cliInstance.releases.new(releaseName);
-        }
-
-        if (shouldCleanArtifacts) {
-          await cliInstance.releases.execute(
-            ["releases", "files", releaseName, "delete", "--all"],
-            true
-          );
         }
 
         if (include) {

--- a/packages/bundler-plugin-core/src/sentry/telemetry.ts
+++ b/packages/bundler-plugin-core/src/sentry/telemetry.ts
@@ -74,7 +74,6 @@ export function setTelemetryDataOnHub(options: NormalizedOptions, hub: Hub, bund
   hub.setTag("inject-build-information", !!options._experiments.injectBuildInformation);
 
   // Optional release pipeline steps
-  hub.setTag("clean-artifacts", release.cleanArtifacts);
   if (release.setCommits) {
     hub.setTag("set-commits", release.setCommits.auto === true ? "auto" : "manual");
   } else {

--- a/packages/bundler-plugin-core/src/types.ts
+++ b/packages/bundler-plugin-core/src/types.ts
@@ -213,7 +213,7 @@ export interface Options {
      *
      * Defaults to `false`.
      *
-     * @deprecated `cleanArtifacts` is deprecated and will does currently not do anything. Historically it was needed
+     * @deprecated `cleanArtifacts` is deprecated and currently doesn't do anything. Historically it was needed
      * since uploading the same artifacts twice was not allowed. Nowadays, when uploading artifacts with the same name
      * more than once to the same release on Sentry, Sentry will prefer the most recent artifact for source mapping.
      */

--- a/packages/bundler-plugin-core/src/types.ts
+++ b/packages/bundler-plugin-core/src/types.ts
@@ -212,7 +212,12 @@ export interface Options {
      * Remove all previously uploaded artifacts for this release on Sentry before the upload.
      *
      * Defaults to `false`.
+     *
+     * @deprecated `cleanArtifacts` is deprecated and will does currently not do anything. Historically it was needed
+     * since uploading the same artifacts twice was not allowed. Nowadays, when uploading artifacts with the same name
+     * more than once to the same release on Sentry, Sentry will prefer the most recent artifact for source mapping.
      */
+    // TODO(v3): Remove this option
     cleanArtifacts?: boolean;
 
     /**

--- a/packages/bundler-plugin-core/test/option-mappings.test.ts
+++ b/packages/bundler-plugin-core/test/option-mappings.test.ts
@@ -20,7 +20,6 @@ describe("normalizeUserOptions()", () => {
         name: "my-release",
         finalize: true,
         inject: true,
-        cleanArtifacts: false,
         create: true,
         vcsRemote: "origin",
         uploadLegacySourcemaps: "./out",
@@ -62,7 +61,6 @@ describe("normalizeUserOptions()", () => {
         finalize: true,
         create: true,
         inject: true,
-        cleanArtifacts: false,
         uploadLegacySourcemaps: {
           ext: ["js", "map", ".foo"],
           ignore: ["./files"],

--- a/packages/bundler-plugin-core/test/sentry/telemetry.test.ts
+++ b/packages/bundler-plugin-core/test/sentry/telemetry.test.ts
@@ -104,7 +104,6 @@ describe("addPluginOptionTagsToHub", () => {
       normalizeUserOptions({
         ...defaultOptions,
         release: {
-          cleanArtifacts: true,
           finalize: true,
         },
       }),

--- a/packages/bundler-plugin-core/test/sentry/telemetry.test.ts
+++ b/packages/bundler-plugin-core/test/sentry/telemetry.test.ts
@@ -111,7 +111,6 @@ describe("addPluginOptionTagsToHub", () => {
       "rollup"
     );
 
-    expect(mockedHub.setTag).toHaveBeenCalledWith("clean-artifacts", true);
     expect(mockedHub.setTag).toHaveBeenCalledWith("finalize-release", true);
   });
 

--- a/packages/dev-utils/src/generate-documentation-table.ts
+++ b/packages/dev-utils/src/generate-documentation-table.ts
@@ -232,7 +232,7 @@ errorHandler: (err) => {
         name: "cleanArtifacts",
         type: "boolean",
         fullDescription:
-          "Remove all previously uploaded artifacts for this release on Sentry before the upload.\n\nDefaults to `false`.",
+          "Remove all previously uploaded artifacts for this release on Sentry before the upload.\n\nDefaults to `false`.\n\n**Deprecation Notice:** `cleanArtifacts` is deprecated and will does currently not do anything. Historically it was needed since uploading the same artifacts twice was not allowed. Nowadays, when uploading artifacts with the same name more than once to the same release on Sentry, Sentry will prefer the most recent artifact for source mapping.",
       },
       {
         name: "uploadLegacySourcemaps",

--- a/packages/playground/vite.config.smallNodeApp.js
+++ b/packages/playground/vite.config.smallNodeApp.js
@@ -23,7 +23,6 @@ export default defineConfig({
       debug: true,
       release: "0.0.14",
       include: "out/vite-smallNodeApp",
-      cleanArtifacts: true,
       // ignore: ["out/*", "!out/vite-smallNodeApp/index.js.map"],
       ignore: ["!out/vite-smallNodeApp/index.js.map"],
       ignoreFile: ".sentryignore",


### PR DESCRIPTION
`cleanArtifacts` was historically needed to remove artifacts before uploading to avoid collisions. Since Sentry can nowadays accept multiple artifacts with the same name per release and prefer the most recent one this option is unnecessary.

Additionally, it causes problems like these: https://github.com/getsentry/sentry-javascript-bundler-plugins/issues/481  with org auth tokens so moving forward it should noop.