### PR TITLE
misc(esbuild): Log warning when attempting to inject debug IDs with esbuild `bundle` option active

### DIFF
--- a/packages/bundler-plugin-core/src/index.ts
+++ b/packages/bundler-plugin-core/src/index.ts
@@ -9,7 +9,7 @@ import { normalizeUserOptions, validateOptions } from "./options-mapping";
 import { createDebugIdUploadFunction } from "./debug-id-upload";
 import { releaseManagementPlugin } from "./plugins/release-management";
 import { telemetryPlugin } from "./plugins/telemetry";
-import { createLogger } from "./sentry/logger";
+import { createLogger, Logger } from "./sentry/logger";
 import { allowedToSendTelemetry, createSentryInstance } from "./sentry/telemetry";
 import { Options, SentrySDKBuildFlags } from "./types";
 import {
@@ -30,7 +30,7 @@ interface SentryUnpluginFactoryOptions {
   releaseInjectionPlugin: (injectionCode: string) => UnpluginOptions;
   componentNameAnnotatePlugin?: () => UnpluginOptions;
   moduleMetadataInjectionPlugin?: (injectionCode: string) => UnpluginOptions;
-  debugIdInjectionPlugin: () => UnpluginOptions;
+  debugIdInjectionPlugin: (logger: Logger) => UnpluginOptions;
   debugIdUploadPlugin: (upload: (buildArtifacts: string[]) => Promise<void>) => UnpluginOptions;
   bundleSizeOptimizationsPlugin: (buildFlags: SentrySDKBuildFlags) => UnpluginOptions;
 }
@@ -283,7 +283,7 @@ export function sentryUnpluginFactory({
       );
     }
 
-    plugins.push(debugIdInjectionPlugin());
+    plugins.push(debugIdInjectionPlugin(logger));
 
     if (!options.authToken) {
       logger.warn(
@@ -594,3 +594,4 @@ export function getDebugIdSnippet(debugId: string): string {
 export { stringToUUID, replaceBooleanFlagsInCode } from "./utils";
 
 export type { Options, SentrySDKBuildFlags } from "./types";
+export type { Logger } from "./sentry/logger";

--- a/packages/esbuild-plugin/src/index.ts
+++ b/packages/esbuild-plugin/src/index.ts
@@ -4,6 +4,7 @@ import {
   getDebugIdSnippet,
   SentrySDKBuildFlags,
 } from "@sentry/bundler-plugin-core";
+import type { Logger } from "@sentry/bundler-plugin-core";
 import type { UnpluginOptions } from "unplugin";
 import * as path from "path";
 
@@ -41,7 +42,7 @@ function esbuildReleaseInjectionPlugin(injectionCode: string): UnpluginOptions {
   };
 }
 
-function esbuildDebugIdInjectionPlugin(): UnpluginOptions {
+function esbuildDebugIdInjectionPlugin(logger: Logger): UnpluginOptions {
   const pluginName = "sentry-esbuild-debug-id-injection-plugin";
   const stubNamespace = "sentry-debug-id-stub";
 
@@ -50,6 +51,12 @@ function esbuildDebugIdInjectionPlugin(): UnpluginOptions {
 
     esbuild: {
       setup({ initialOptions, onLoad, onResolve }) {
+        if (initialOptions.bundle) {
+          logger.warn(
+            "Esbuild's `bundle` option is currently not supported! Esbuild will probably crash now."
+          );
+        }
+
         onResolve({ filter: /.*/ }, (args) => {
           if (args.kind !== "entry-point") {
             return;

--- a/packages/esbuild-plugin/src/index.ts
+++ b/packages/esbuild-plugin/src/index.ts
@@ -53,7 +53,7 @@ function esbuildDebugIdInjectionPlugin(logger: Logger): UnpluginOptions {
       setup({ initialOptions, onLoad, onResolve }) {
         if (initialOptions.bundle) {
           logger.warn(
-            "Esbuild's `bundle` option is currently not supported! Esbuild will probably crash now."
+            "Esbuild's `bundle: true` option is currently not supported! Esbuild will probably crash now. Sorry about that. If you need to upload sourcemaps with the `bundle` option, it is recommended to use Sentry CLI instead: https://docs.sentry.io/platforms/javascript/sourcemaps/uploading/cli/"
           );
         }
 


### PR DESCRIPTION
Relates to: https://github.com/getsentry/sentry-javascript-bundler-plugins/issues/445#issuecomment-2061371373