### PR TITLE
feat: Add `applicationKey` option to identify application code from within the SDK

### DIFF
--- a/packages/bundler-plugin-core/src/index.ts
+++ b/packages/bundler-plugin-core/src/index.ts
@@ -228,10 +228,11 @@ export function sentryUnpluginFactory({
       let metadata: Record<string, unknown> = {};
 
       if (options.applicationKey) {
-        // We use different keys so that if code receives multiple bundling passes.
-        // It is a bit unfortunate that we have to inject the metadata snippet at the top, which means that if we didn't
-        // have this mechanism, the first bundling pass would always "win". If this weren't the case we would be fine with
-        // the last pass winning but the first pass winning is very bad, because it would prevent any sort of overriding.
+        // We use different keys so that if user-code receives multiple bundling passes, we will store the application keys of all the passes.
+        // It is a bit unfortunate that we have to inject the metadata snippet at the top, because after multiple
+        // injections, the first injection will always "win" because it comes last in the code. We would generally be
+        // fine with making the last bundling pass win. But because it cannot win, we have to use a workaround of storing
+        // the app keys in different object keys.
         // We can simply use the `_sentryBundlerPluginAppKey:` to filter for app keys in the SDK.
         metadata[`_sentryBundlerPluginAppKey:${options.applicationKey}`] = true;
       }

--- a/packages/bundler-plugin-core/src/options-mapping.ts
+++ b/packages/bundler-plugin-core/src/options-mapping.ts
@@ -34,6 +34,7 @@ export function normalizeUserOptions(userOptions: UserOptions) {
         metaFramework: userOptions._metaOptions?.telemetry?.metaFramework,
       },
     },
+    applicationKey: userOptions.applicationKey,
     moduleMetadata: userOptions.moduleMetadata || userOptions._experiments?.moduleMetadata,
     _experiments: userOptions._experiments ?? {},
   };

--- a/packages/bundler-plugin-core/src/types.ts
+++ b/packages/bundler-plugin-core/src/types.ts
@@ -313,6 +313,12 @@ export interface Options {
   moduleMetadata?: ModuleMetadata | ModuleMetadataCallback;
 
   /**
+   * A key which will embedded in all the bundled files. The SDK will be able to use the key to apply filtering
+   * rules, for example using the `thirdPartyErrorFilterIntegration`.
+   */
+  applicationKey?: string;
+
+  /**
    * Options that are considered experimental and subject to change.
    *
    * @experimental API that does not follow semantic versioning and may change in any release

--- a/packages/integration-tests/fixtures/application-key-injection/input/bundle.js
+++ b/packages/integration-tests/fixtures/application-key-injection/input/bundle.js
@@ -1,0 +1,3 @@
+// Simply output the metadata to the console so it can be checked in a test
+// eslint-disable-next-line no-console
+console.log(JSON.stringify(global._sentryModuleMetadata));

--- a/packages/integration-tests/fixtures/application-key-injection/metadata-injection.test.ts
+++ b/packages/integration-tests/fixtures/application-key-injection/metadata-injection.test.ts
@@ -1,0 +1,38 @@
+/* eslint-disable jest/no-standalone-expect */
+/* eslint-disable jest/expect-expect */
+import { execSync } from "child_process";
+import path from "path";
+import { testIfNodeMajorVersionIsLessThan18 } from "../../utils/testIf";
+
+function checkBundle(bundlePath: string): void {
+  const output = execSync(`node ${bundlePath}`, { encoding: "utf-8" });
+
+  const map = JSON.parse(output) as Record<string, string>;
+
+  // There should be only one key in the map
+  expect(Object.values(map)).toHaveLength(1);
+  // The value should be the expected metadata
+  expect(Object.values(map)).toEqual([{ ["_sentryBundlerPluginAppKey:my-app"]: true }]);
+}
+
+describe("appKey injection", () => {
+  testIfNodeMajorVersionIsLessThan18("webpack 4 bundle", () => {
+    checkBundle(path.join(__dirname, "out", "webpack4", "bundle.js"));
+  });
+
+  test("webpack 5 bundle", () => {
+    checkBundle(path.join(__dirname, "out", "webpack5", "bundle.js"));
+  });
+
+  test("esbuild bundle", () => {
+    checkBundle(path.join(__dirname, "out", "esbuild", "bundle.js"));
+  });
+
+  test("rollup bundle", () => {
+    checkBundle(path.join(__dirname, "out", "rollup", "bundle.js"));
+  });
+
+  test("vite bundle", () => {
+    checkBundle(path.join(__dirname, "out", "vite", "bundle.js"));
+  });
+});

--- a/packages/integration-tests/fixtures/application-key-injection/setup.ts
+++ b/packages/integration-tests/fixtures/application-key-injection/setup.ts
@@ -1,0 +1,15 @@
+import * as path from "path";
+import { createCjsBundles } from "../../utils/create-cjs-bundles";
+
+const outputDir = path.resolve(__dirname, "out");
+
+createCjsBundles(
+  {
+    bundle: path.resolve(__dirname, "input", "bundle.js"),
+  },
+  outputDir,
+  {
+    applicationKey: "my-app",
+  },
+  ["webpack4", "webpack5", "esbuild", "rollup", "vite"]
+);


### PR DESCRIPTION
Ties into https://github.com/getsentry/sentry-javascript/pull/12267
Ref https://github.com/getsentry/sentry-javascript/issues/10882

Allows users to mark their bundles with an application key which will allow the SDK to filter events based on application keys in stack frames.