### PR TITLE
fix(esbuild): Invert warning about `bundle: true`

### DIFF
--- a/packages/esbuild-plugin/src/index.ts
+++ b/packages/esbuild-plugin/src/index.ts
@@ -53,7 +53,7 @@ function esbuildDebugIdInjectionPlugin(logger: Logger): UnpluginOptions {
       setup({ initialOptions, onLoad, onResolve }) {
         if (!initialOptions.bundle) {
           logger.warn(
-            "The Sentry esbuild plugin only supports esbuild with `bundle: true` being set in the esbuild build options! Esbuild will probably crash now. Sorry about that. If you need to upload sourcemaps without `bundle: true`, it is recommended to use Sentry CLI instead: https://docs.sentry.io/platforms/javascript/sourcemaps/uploading/cli/"
+            "The Sentry esbuild plugin only supports esbuild with `bundle: true` being set in the esbuild build options. Esbuild will probably crash now. Sorry about that. If you need to upload sourcemaps without `bundle: true`, it is recommended to use Sentry CLI instead: https://docs.sentry.io/platforms/javascript/sourcemaps/uploading/cli/"
           );
         }
 

--- a/packages/esbuild-plugin/src/index.ts
+++ b/packages/esbuild-plugin/src/index.ts
@@ -51,9 +51,9 @@ function esbuildDebugIdInjectionPlugin(logger: Logger): UnpluginOptions {
 
     esbuild: {
       setup({ initialOptions, onLoad, onResolve }) {
-        if (initialOptions.bundle) {
+        if (!initialOptions.bundle) {
           logger.warn(
-            "Esbuild's `bundle: true` option is currently not supported! Esbuild will probably crash now. Sorry about that. If you need to upload sourcemaps with the `bundle` option, it is recommended to use Sentry CLI instead: https://docs.sentry.io/platforms/javascript/sourcemaps/uploading/cli/"
+            "The Sentry esbuild plugin only supports esbuild with `bundle: true` being set in the esbuild build options! Esbuild will probably crash now. Sorry about that. If you need to upload sourcemaps without `bundle: true`, it is recommended to use Sentry CLI instead: https://docs.sentry.io/platforms/javascript/sourcemaps/uploading/cli/"
           );
         }
 


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript-bundler-plugins/issues/537

In https://github.com/getsentry/sentry-javascript-bundler-plugins/pull/526 we introduced a log message that esbuild's `bundle: true` is not supported. We messed up because it is actually the complete opposite. We don't support `bundle: false`.

This PR flips the logic.