### PR TITLE
fix(vite): Fix environment variable loading issue for Windows

### DIFF
--- a/packages/bundler-plugin-core/src/index.ts
+++ b/packages/bundler-plugin-core/src/index.ts
@@ -85,7 +85,11 @@ export function sentryUnpluginFactory({
       );
       // NOTE: Do not use the dotenv.config API directly to read the dotenv file! For some ungodly reason, it falls back to reading `${process.cwd()}/.env` which is absolutely not what we want.
       const dotenvResult = dotenv.parse(dotenvFile);
-      process.env = Object.assign(process.env, dotenvResult);
+
+      // Vite has a bug/behaviour where spreading into process.env will cause it to crash
+      // https://github.com/vitest-dev/vitest/issues/1870#issuecomment-1501140251
+      Object.assign(process.env, dotenvResult);
+
       logger.info('Using environment variables configured in ".env.sentry-build-plugin".');
     } catch (e: unknown) {
       // Ignore "file not found" errors but throw all others

--- a/packages/bundler-plugin-core/src/index.ts
+++ b/packages/bundler-plugin-core/src/index.ts
@@ -85,7 +85,7 @@ export function sentryUnpluginFactory({
       );
       // NOTE: Do not use the dotenv.config API directly to read the dotenv file! For some ungodly reason, it falls back to reading `${process.cwd()}/.env` which is absolutely not what we want.
       const dotenvResult = dotenv.parse(dotenvFile);
-      process.env = { ...process.env, ...dotenvResult };
+      process.env = Object.assign(process.env, dotenvResult);
       logger.info('Using environment variables configured in ".env.sentry-build-plugin".');
     } catch (e: unknown) {
       // Ignore "file not found" errors but throw all others


### PR DESCRIPTION
This PR fixes an error that occurs when running the "vite" command on some Windows machines (We encountered this issue on 2 out of 5 of our Windows development environments, I'm not sure whats effecting it). The issue and its solution are detailed in https://github.com/vitest-dev/vitest/issues/1870#issuecomment-1501140251 

Applied the fix on affected Windows machines; the error did not reoccur.

Example output of the error;
```
Windows 11
node 22.2.0
vite 5.2.12
@sentry/vite-plugin 2.18.0

node:events:498
      throw er; // Unhandled 'error' event
      ^

Error: spawn undefined\System32\WindowsPowerShell\v1.0\powershell ENOENT
    at ChildProcess._handle.onexit (node:internal/child_process:286:19)
    at onErrorNT (node:internal/child_process:484:16)
    at process.processTicksAndRejections (node:internal/process/task_queues:82:21)
Emitted 'error' event on ChildProcess instance at:
    at ChildProcess._handle.onexit (node:internal/child_process:292:12)
    at onErrorNT (node:internal/child_process:484:16)
    at process.processTicksAndRejections (node:internal/process/task_queues:82:21) {
  errno: -4058,
  code: 'ENOENT',
  syscall: 'spawn undefined\\System32\\WindowsPowerShell\\v1.0\\powershell',
  path: 'undefined\\System32\\WindowsPowerShell\\v1.0\\powershell',
  spawnargs: [
    '-NoProfile',
    '-NonInteractive',
    '–ExecutionPolicy',
    'Bypass',
    '-EncodedCommand',
    'UwB0AGEAcgB0ACAAIgBoAHQAdABwADoALwAvAGwAbwBjAGEAbABoAG8AcwB0ADoAMwAwADAAMAAvACIA'
  ]
}
```