### PR TITLE
fix: Always delete files when `sourcemaps.filesToDeleteAfterUpload` is set

### DIFF
--- a/packages/bundler-plugin-core/src/index.ts
+++ b/packages/bundler-plugin-core/src/index.ts
@@ -332,7 +332,7 @@ export function sentryUnpluginFactory({
     plugins.push(
       fileDeletionPlugin({
         deleteFilesUpForDeletion,
-        handleRecoverableError: handleRecoverableError,
+        handleRecoverableError,
         sentryHub,
         sentryClient,
       })

--- a/packages/bundler-plugin-core/src/plugins/release-management.ts
+++ b/packages/bundler-plugin-core/src/plugins/release-management.ts
@@ -27,6 +27,7 @@ interface ReleaseManagementPluginOptions {
     silent: boolean;
     headers?: Record<string, string>;
   };
+  deleteFilesUpForDeletion: () => Promise<void>;
 }
 
 export function releaseManagementPlugin({
@@ -41,6 +42,7 @@ export function releaseManagementPlugin({
   sentryHub,
   sentryClient,
   sentryCliOptions,
+  deleteFilesUpForDeletion,
 }: ReleaseManagementPluginOptions): UnpluginOptions {
   return {
     name: "sentry-debug-id-upload-plugin",
@@ -83,6 +85,8 @@ export function releaseManagementPlugin({
         if (deployOptions) {
           await cliInstance.releases.newDeploy(releaseName, deployOptions);
         }
+
+        await deleteFilesUpForDeletion();
       } catch (e) {
         sentryHub.captureException('Error in "releaseManagementPlugin" writeBundle hook');
         await safeFlushTelemetry(sentryClient);

--- a/packages/bundler-plugin-core/src/plugins/sourcemap-deletion.ts
+++ b/packages/bundler-plugin-core/src/plugins/sourcemap-deletion.ts
@@ -1,0 +1,30 @@
+import { Hub, NodeClient } from "@sentry/node";
+import { UnpluginOptions } from "unplugin";
+import { safeFlushTelemetry } from "../sentry/telemetry";
+
+interface FileDeletionPlugin {
+  handleRecoverableError: (error: unknown) => void;
+  deleteFilesUpForDeletion: () => Promise<void>;
+  sentryHub: Hub;
+  sentryClient: NodeClient;
+}
+
+export function fileDeletionPlugin({
+  handleRecoverableError,
+  sentryHub,
+  sentryClient,
+  deleteFilesUpForDeletion,
+}: FileDeletionPlugin): UnpluginOptions {
+  return {
+    name: "sentry-file-deletion-plugin",
+    async buildEnd() {
+      try {
+        await deleteFilesUpForDeletion();
+      } catch (e) {
+        sentryHub.captureException('Error in "sentry-file-deletion-plugin" buildEnd hook');
+        await safeFlushTelemetry(sentryClient);
+        handleRecoverableError(e);
+      }
+    },
+  };
+}

--- a/packages/bundler-plugin-core/src/plugins/sourcemap-deletion.ts
+++ b/packages/bundler-plugin-core/src/plugins/sourcemap-deletion.ts
@@ -17,7 +17,7 @@ export function fileDeletionPlugin({
 }: FileDeletionPlugin): UnpluginOptions {
   return {
     name: "sentry-file-deletion-plugin",
-    async buildEnd() {
+    async writeBundle() {
       try {
         await deleteFilesUpForDeletion();
       } catch (e) {

--- a/packages/integration-tests/fixtures/after-upload-deletion/after-upload-deletion.test.ts
+++ b/packages/integration-tests/fixtures/after-upload-deletion/after-upload-deletion.test.ts
@@ -1,0 +1,27 @@
+/* eslint-disable jest/no-standalone-expect */
+/* eslint-disable jest/expect-expect */
+import path from "path";
+import fs from "fs";
+import { testIfNodeMajorVersionIsLessThan18 } from "../../utils/testIf";
+
+describe("Deletes with `filesToDeleteAfterUpload` even without uploading anything", () => {
+  testIfNodeMajorVersionIsLessThan18("webpack 4 bundle", () => {
+    expect(fs.existsSync(path.join(__dirname, "out", "webpack4", "bundle.js.map"))).toBe(false);
+  });
+
+  test("webpack 5 bundle", () => {
+    expect(fs.existsSync(path.join(__dirname, "out", "webpack5", "bundle.js.map"))).toBe(false);
+  });
+
+  test("esbuild bundle", () => {
+    expect(fs.existsSync(path.join(__dirname, "out", "esbuild", "bundle.js.map"))).toBe(false);
+  });
+
+  test("rollup bundle", () => {
+    expect(fs.existsSync(path.join(__dirname, "out", "rollup", "bundle.js.map"))).toBe(false);
+  });
+
+  test("vite bundle", () => {
+    expect(fs.existsSync(path.join(__dirname, "out", "vite", "bundle.js.map"))).toBe(false);
+  });
+});

--- a/packages/integration-tests/fixtures/after-upload-deletion/input/bundle.js
+++ b/packages/integration-tests/fixtures/after-upload-deletion/input/bundle.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line no-console
+console.log("whatever");

--- a/packages/integration-tests/fixtures/after-upload-deletion/setup.ts
+++ b/packages/integration-tests/fixtures/after-upload-deletion/setup.ts
@@ -11,7 +11,7 @@ const outputDir = path.resolve(__dirname, "out");
     outputDir,
     {
       sourcemaps: {
-        filesToDeleteAfterUpload: path.join(__dirname, "out", bundler, "*.map"),
+        filesToDeleteAfterUpload: path.join(".", "**", "after-upload-deletion", "**", "*.map"),
       },
     },
     [bundler]

--- a/packages/integration-tests/fixtures/after-upload-deletion/setup.ts
+++ b/packages/integration-tests/fixtures/after-upload-deletion/setup.ts
@@ -19,4 +19,9 @@ const outputDir = path.resolve(__dirname, "out");
   );
 });
 
-console.log("ASDFASDF", path.join(".", "**", "after-upload-deletion", "**", "*.map"));
+console.log(
+  "ASDFASDF",
+  __dirname,
+  process.cwd(),
+  path.join(".", "**", "after-upload-deletion", "**", "*.map")
+);

--- a/packages/integration-tests/fixtures/after-upload-deletion/setup.ts
+++ b/packages/integration-tests/fixtures/after-upload-deletion/setup.ts
@@ -11,7 +11,7 @@ const outputDir = path.resolve(__dirname, "out");
     outputDir,
     {
       sourcemaps: {
-        filesToDeleteAfterUpload: path.join("./**/after-upload-deletion/**/*.map"),
+        filesToDeleteAfterUpload: [path.join(__dirname, "out", bundler, "bundle.js.map")],
       },
     },
     [bundler]

--- a/packages/integration-tests/fixtures/after-upload-deletion/setup.ts
+++ b/packages/integration-tests/fixtures/after-upload-deletion/setup.ts
@@ -10,6 +10,7 @@ const outputDir = path.resolve(__dirname, "out");
     },
     outputDir,
     {
+      debug: true,
       sourcemaps: {
         filesToDeleteAfterUpload: path.join(".", "**", "after-upload-deletion", "**", "*.map"),
       },
@@ -17,3 +18,5 @@ const outputDir = path.resolve(__dirname, "out");
     [bundler]
   );
 });
+
+console.log("ASDFASDF", path.join(".", "**", "after-upload-deletion", "**", "*.map"));

--- a/packages/integration-tests/fixtures/after-upload-deletion/setup.ts
+++ b/packages/integration-tests/fixtures/after-upload-deletion/setup.ts
@@ -10,18 +10,10 @@ const outputDir = path.resolve(__dirname, "out");
     },
     outputDir,
     {
-      debug: true,
       sourcemaps: {
-        filesToDeleteAfterUpload: path.join(".", "**", "after-upload-deletion", "**", "*.map"),
+        filesToDeleteAfterUpload: path.join("./**/after-upload-deletion/**/*.map"),
       },
     },
     [bundler]
   );
 });
-
-console.log(
-  "ASDFASDF",
-  __dirname,
-  process.cwd(),
-  path.join(".", "**", "after-upload-deletion", "**", "*.map")
-);

--- a/packages/integration-tests/fixtures/after-upload-deletion/setup.ts
+++ b/packages/integration-tests/fixtures/after-upload-deletion/setup.ts
@@ -1,0 +1,19 @@
+import * as path from "path";
+import { createCjsBundles } from "../../utils/create-cjs-bundles";
+
+const outputDir = path.resolve(__dirname, "out");
+
+["webpack4", "webpack5", "esbuild", "rollup", "vite"].forEach((bundler) => {
+  createCjsBundles(
+    {
+      bundle: path.resolve(__dirname, "input", "bundle.js"),
+    },
+    outputDir,
+    {
+      sourcemaps: {
+        filesToDeleteAfterUpload: path.join(__dirname, "out", bundler, "*.map"),
+      },
+    },
+    [bundler]
+  );
+});

--- a/packages/integration-tests/utils/create-cjs-bundles.ts
+++ b/packages/integration-tests/utils/create-cjs-bundles.ts
@@ -23,6 +23,7 @@ export function createCjsBundles(
     void vite.build({
       clearScreen: false,
       build: {
+        sourcemap: true,
         outDir: path.join(outFolder, "vite"),
         rollupOptions: {
           input: entrypoints,
@@ -43,6 +44,7 @@ export function createCjsBundles(
       })
       .then((bundle) =>
         bundle.write({
+          sourcemap: true,
           dir: path.join(outFolder, "rollup"),
           format: "cjs",
           exports: "named",
@@ -52,6 +54,7 @@ export function createCjsBundles(
 
   if (plugins.length === 0 || plugins.includes("esbuild")) {
     void esbuild.build({
+      sourcemap: true,
       entryPoints: entrypoints,
       outdir: path.join(outFolder, "esbuild"),
       plugins: [sentryEsbuildPlugin(sentryUnpluginOptions)],
@@ -65,6 +68,7 @@ export function createCjsBundles(
   if (parseInt(nodejsMajorversion) < 18 && (plugins.length === 0 || plugins.includes("webpack4"))) {
     webpack4(
       {
+        devtool: "source-map",
         mode: "production",
         entry: entrypoints,
         cache: false,
@@ -86,6 +90,7 @@ export function createCjsBundles(
   if (plugins.length === 0 || plugins.includes("webpack5")) {
     webpack5(
       {
+        devtool: "source-map",
         cache: false,
         entry: entrypoints,
         output: {


### PR DESCRIPTION
Currently we only delete files when the debug ID upload was initiated. This is extremely confusing if you use the legacy upload or didn't upload at all - for example when not providing an auth token.

With this we will always run deletion when `sourcemaps.filesToDeleteAfterUpload` is set, and up to two additional times, after the debug ID upload and the legacy upload have completed.