### PR TITLE
feat: Don't use word "error" in log message about telemetry

### DIFF
--- a/packages/bundler-plugin-core/src/plugins/telemetry.ts
+++ b/packages/bundler-plugin-core/src/plugins/telemetry.ts
@@ -21,7 +21,7 @@ export function telemetryPlugin({
     async buildStart() {
       if (await shouldSendTelemetry) {
         logger.info(
-          "Sending error and performance telemetry data to Sentry. To disable telemetry, set `options.telemetry` to `false`."
+          "Sending telemetry data on issues and performance to Sentry. To disable telemetry, set `options.telemetry` to `false`."
         );
         sentryHub.startTransaction({ name: "Sentry Bundler Plugin execution" }).finish();
         await safeFlushTelemetry(sentryClient);


### PR DESCRIPTION
## Summary
Refactored a log message in the `telemetry.ts` plugin to improve clarity and reduce false positives when searching for errors in logs.

## Files Changed
- packages/bundler-plugin-core/src/plugins/telemetry.ts

## Reason for Changes
The previous log message contained the word "error," which led to confusion when searching for actual errors in the logs using ctrl/cmd + F. The modified message improves the clarity of logs and reduces false positives during searches.

## Impact of Changes
- Improved Log Clarity: The updated log message ensures that searches for "error" in the logs will yield actual error instances rather than telemetry information.
- Reduced False Positives: Developers and users can more easily identify real errors during troubleshooting and debugging sessions.

## Additional Notes
This change aims to enhance developer experience by streamlining the process of locating and addressing genuine errors in the build logs.