### PR TITLE
feat: Export esbuild plugin as default

### DIFF
--- a/packages/esbuild-plugin/src/index.ts
+++ b/packages/esbuild-plugin/src/index.ts
@@ -267,5 +267,8 @@ const sentryUnplugin = sentryUnpluginFactory({
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const sentryEsbuildPlugin: (options?: Options) => any = sentryUnplugin.esbuild;
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export default sentryUnplugin.esbuild as (options?: Options) => any;
+
 export type { Options as SentryEsbuildPluginOptions } from "@sentry/bundler-plugin-core";
 export { sentryCliBinaryExists } from "@sentry/bundler-plugin-core";


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript-bundler-plugins/issues/554

We tell users in our docs for setting up the esbuild plugin with Angular and Nx to pass the plugin to the plugins array in the Nx config. However, Nx just takes the default export, or if non-existent, whatever is on `module.exports`, as the plugin.

If we export the plugin as default export the issue is fixed.