### PR TITLE
fix: Wait for tasks depending on sourcemaps before deleting

### DIFF
--- a/packages/bundler-plugin-core/src/debug-id-upload.ts
+++ b/packages/bundler-plugin-core/src/debug-id-upload.ts
@@ -33,7 +33,7 @@ interface DebugIdUploadPluginOptions {
     silent: boolean;
     headers?: Record<string, string>;
   };
-  completeTaskDependingOnSourcemaps: () => void;
+  freeDependencyOnSourcemapFiles: () => void;
 }
 
 export function createDebugIdUploadFunction({
@@ -47,7 +47,7 @@ export function createDebugIdUploadFunction({
   sentryClient,
   sentryCliOptions,
   rewriteSourcesHook,
-  completeTaskDependingOnSourcemaps,
+  freeDependencyOnSourcemapFiles,
 }: DebugIdUploadPluginOptions) {
   return async (buildArtifactPaths: string[]) => {
     const artifactBundleUploadTransaction = sentryHub.startTransaction({
@@ -194,7 +194,7 @@ export function createDebugIdUploadFunction({
         cleanupSpan.finish();
       }
       artifactBundleUploadTransaction.finish();
-      completeTaskDependingOnSourcemaps();
+      freeDependencyOnSourcemapFiles();
       await safeFlushTelemetry(sentryClient);
     }
   };

--- a/packages/bundler-plugin-core/src/plugins/release-management.ts
+++ b/packages/bundler-plugin-core/src/plugins/release-management.ts
@@ -27,7 +27,7 @@ interface ReleaseManagementPluginOptions {
     silent: boolean;
     headers?: Record<string, string>;
   };
-  deleteFilesUpForDeletion: () => Promise<void>;
+  completeTaskDependingOnSourcemaps: () => void;
 }
 
 export function releaseManagementPlugin({
@@ -42,7 +42,7 @@ export function releaseManagementPlugin({
   sentryHub,
   sentryClient,
   sentryCliOptions,
-  deleteFilesUpForDeletion,
+  completeTaskDependingOnSourcemaps,
 }: ReleaseManagementPluginOptions): UnpluginOptions {
   return {
     name: "sentry-debug-id-upload-plugin",
@@ -85,12 +85,12 @@ export function releaseManagementPlugin({
         if (deployOptions) {
           await cliInstance.releases.newDeploy(releaseName, deployOptions);
         }
-
-        await deleteFilesUpForDeletion();
       } catch (e) {
         sentryHub.captureException('Error in "releaseManagementPlugin" writeBundle hook');
         await safeFlushTelemetry(sentryClient);
         handleRecoverableError(e);
+      } finally {
+        completeTaskDependingOnSourcemaps();
       }
     },
   };

--- a/packages/bundler-plugin-core/src/plugins/release-management.ts
+++ b/packages/bundler-plugin-core/src/plugins/release-management.ts
@@ -27,7 +27,7 @@ interface ReleaseManagementPluginOptions {
     silent: boolean;
     headers?: Record<string, string>;
   };
-  completeTaskDependingOnSourcemaps: () => void;
+  freeDependencyOnSourcemapFiles: () => void;
 }
 
 export function releaseManagementPlugin({
@@ -42,7 +42,7 @@ export function releaseManagementPlugin({
   sentryHub,
   sentryClient,
   sentryCliOptions,
-  completeTaskDependingOnSourcemaps,
+  freeDependencyOnSourcemapFiles,
 }: ReleaseManagementPluginOptions): UnpluginOptions {
   return {
     name: "sentry-debug-id-upload-plugin",
@@ -90,7 +90,7 @@ export function releaseManagementPlugin({
         await safeFlushTelemetry(sentryClient);
         handleRecoverableError(e);
       } finally {
-        completeTaskDependingOnSourcemaps();
+        freeDependencyOnSourcemapFiles();
       }
     },
   };

--- a/packages/bundler-plugin-core/src/plugins/sourcemap-deletion.ts
+++ b/packages/bundler-plugin-core/src/plugins/sourcemap-deletion.ts
@@ -1,25 +1,59 @@
 import { Hub, NodeClient } from "@sentry/node";
+import { glob } from "glob";
 import { UnpluginOptions } from "unplugin";
+import { Logger } from "../sentry/logger";
 import { safeFlushTelemetry } from "../sentry/telemetry";
+import fs from "fs";
 
 interface FileDeletionPlugin {
   handleRecoverableError: (error: unknown) => void;
-  deleteFilesUpForDeletion: () => Promise<void>;
+  dependenciesAreFreedPromise: Promise<void>;
   sentryHub: Hub;
   sentryClient: NodeClient;
+  filesToDeleteAfterUpload: string | string[] | undefined;
+  logger: Logger;
 }
 
 export function fileDeletionPlugin({
   handleRecoverableError,
   sentryHub,
   sentryClient,
-  deleteFilesUpForDeletion,
+  filesToDeleteAfterUpload,
+  dependenciesAreFreedPromise,
+  logger,
 }: FileDeletionPlugin): UnpluginOptions {
   return {
     name: "sentry-file-deletion-plugin",
     async writeBundle() {
       try {
-        await deleteFilesUpForDeletion();
+        if (filesToDeleteAfterUpload !== undefined) {
+          const filePathsToDelete = await glob(filesToDeleteAfterUpload, {
+            absolute: true,
+            nodir: true,
+          });
+
+          logger.debug(
+            "Waiting for dependencies on generated files to be freed before deleting..."
+          );
+
+          await dependenciesAreFreedPromise;
+
+          filePathsToDelete.forEach((filePathToDelete) => {
+            logger.debug(`Deleting asset after upload: ${filePathToDelete}`);
+          });
+
+          await Promise.all(
+            filePathsToDelete.map((filePathToDelete) =>
+              fs.promises.rm(filePathToDelete, { force: true }).catch((e) => {
+                // This is allowed to fail - we just don't do anything
+                logger.debug(
+                  `An error occurred while attempting to delete asset: ${filePathToDelete}`,
+                  e
+                );
+              })
+            )
+          );
+        }
       } catch (e) {
         sentryHub.captureException('Error in "sentry-file-deletion-plugin" buildEnd hook');
         await safeFlushTelemetry(sentryClient);


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript-bundler-plugins/issues/556

I introduced a dumb bug where we would delete sourcemaps before they have been uploaded due to a race condition.

This PR introduces a sort-of dependency tracking mechanism where we only initiate the file deletions after all the functionalities depending on the files have been completed.