### PR TITLE
feat: Add option to disable sourcemaps

### DIFF
--- a/packages/bundler-plugin-core/src/index.ts
+++ b/packages/bundler-plugin-core/src/index.ts
@@ -301,7 +301,9 @@ export function sentryUnpluginFactory({
       plugins.push(moduleMetadataInjectionPlugin(injectionCode));
     }
 
-    if (!options.release.name) {
+    if (options.sourcemaps?.disable) {
+      logger.debug("Source map upload was disabled. Will not upload sourcemaps.");
+    } else if (!options.release.name) {
       logger.warn(
         "No release name provided. Will not create release. Please set the `release.name` option to identify your release."
       );

--- a/packages/bundler-plugin-core/src/sentry/telemetry.ts
+++ b/packages/bundler-plugin-core/src/sentry/telemetry.ts
@@ -89,6 +89,7 @@ export function setTelemetryDataOnHub(options: NormalizedOptions, hub: Hub, bund
     "delete-after-upload",
     !!sourcemaps?.deleteFilesAfterUpload || !!sourcemaps?.filesToDeleteAfterUpload
   );
+  hub.setTag("sourcemaps-disabled", !!sourcemaps?.disable);
 
   hub.setTag("react-annotate", !!reactComponentAnnotation?.enabled);
 

--- a/packages/bundler-plugin-core/src/types.ts
+++ b/packages/bundler-plugin-core/src/types.ts
@@ -91,6 +91,13 @@ export interface Options {
    */
   sourcemaps?: {
     /**
+     * Disables all functionality related to sourcemaps.
+     *
+     * Defaults to `false`.
+     */
+    disable?: boolean;
+
+    /**
      * A glob or an array of globs that specifies the build artifacts that should be uploaded to Sentry.
      *
      * If this option is not specified, the plugin will try to upload all JavaScript files and source map files that are created during build.

--- a/packages/dev-utils/src/generate-documentation-table.ts
+++ b/packages/dev-utils/src/generate-documentation-table.ts
@@ -102,6 +102,12 @@ errorHandler: (err) => {
         fullDescription:
           "A glob or an array of globs that specifies the build artifacts that should be deleted after the artifact upload to Sentry has been completed.\n\nThe globbing patterns follow the implementation of the `glob` package. (https://www.npmjs.com/package/glob)\n\nUse the `debug` option to print information about which files end up being deleted.",
       },
+      {
+        name: "disable",
+        type: "boolean",
+        fullDescription:
+          "Disables all functionality related to sourcemaps.\n\nDefaults to `false`.",
+      },
     ],
   },
 


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry-javascript-bundler-plugins/issues/560

Adds an option `sourcemaps.disable` to completely disable all functionality related to sourcemaps (debug ID process).