### PR TITLE
fix: Use `sequential` and `post` order for vite artifact deletion

### DIFF
--- a/packages/bundler-plugin-core/src/plugins/sourcemap-deletion.ts
+++ b/packages/bundler-plugin-core/src/plugins/sourcemap-deletion.ts
@@ -26,7 +26,7 @@ export function fileDeletionPlugin({
     name: "sentry-file-deletion-plugin",
     writeBundle: {
       sequential: true,
-			order: 'post',
+      order: 'post',
       async handler() {
         try {
           if (filesToDeleteAfterUpload !== undefined) {


### PR DESCRIPTION
Sometimes writeBundle is executed before the upload task,  need to ensure the order of code execution