### PR TITLE
fix(vite-plugin): Ensure `post` order of `sentry-vite-release-injection-plugin` to avoid breaking `@rollup/plugin-commonjs` step

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules
 yarn-error.log
 
 .vscode/settings.json
+.idea
 
 *.tgz
 

--- a/packages/bundler-plugin-core/src/index.ts
+++ b/packages/bundler-plugin-core/src/index.ts
@@ -43,7 +43,7 @@ interface SentryUnpluginFactoryOptions {
  *
  * Release injection:
  * Per default the sentry bundler plugin will inject a global `SENTRY_RELEASE` into each JavaScript/TypeScript module
- * that is part of the bundle. On a technical level this is done by appending an import (`import "sentry-release-injector;"`)
+ * that is part of the bundle. On a technical level this is done by appending an import (`import "sentry-release-injector";`)
  * to all entrypoint files of the user code (see `transformInclude` and `transform` hooks). This import is then resolved
  * by the sentry plugin to a virtual module that sets the global variable (see `resolveId` and `load` hooks).
  * If a user wants to inject the release into a particular set of modules they can use the `releaseInjectionTargets` option.

--- a/packages/playground/vite.config.smallNodeApp.js
+++ b/packages/playground/vite.config.smallNodeApp.js
@@ -1,5 +1,5 @@
 // @ts-check
-import { sentryVitePlugin } from "@sentry/bundler-plugin-core";
+import { sentryVitePlugin } from "@sentry/vite-plugin";
 import { defineConfig } from "vite";
 import * as path from "path";
 

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -14,7 +14,9 @@ import { UnpluginOptions } from "unplugin";
 function viteReleaseInjectionPlugin(injectionCode: string): UnpluginOptions {
   return {
     name: "sentry-vite-release-injection-plugin",
-    enforce: "pre" as const, // need this so that vite runs the resolveId hook
+    // run `post` to avoid tripping up @rollup/plugin-commonjs when cjs is used
+    // as we inject an `import` statement
+    enforce: "post" as const, // need this so that vite runs the resolveId hook
     vite: createRollupReleaseInjectionHooks(injectionCode),
   };
 }


### PR DESCRIPTION
I didn't really find any good way of testing this so I just relied on manual testing with the user submitted reproduction in https://github.com/getsentry/sentry-javascript-bundler-plugins/issues/552 as well as trying it out in two sample apps, a react app and a solid app which built and uploaded sourcemaps fine.

Closes: https://github.com/getsentry/sentry-javascript-bundler-plugins/issues/552