### PR TITLE
feat: Add `bundleSizeOptimizations.excludeTracing` option as alias to deprecated `bundleSizeOptimizations.excludePerformanceMonitoring`

### DIFF
--- a/packages/bundler-plugin-core/src/index.ts
+++ b/packages/bundler-plugin-core/src/index.ts
@@ -237,7 +237,10 @@ export function sentryUnpluginFactory({
       if (bundleSizeOptimizations.excludeDebugStatements) {
         replacementValues["__SENTRY_DEBUG__"] = false;
       }
-      if (bundleSizeOptimizations.excludePerformanceMonitoring) {
+      if (
+        bundleSizeOptimizations.excludePerformanceMonitoring ||
+        bundleSizeOptimizations.excludeTracing
+      ) {
         replacementValues["__SENTRY_TRACE__"] = false;
       }
       if (bundleSizeOptimizations.excludeReplayCanvas) {

--- a/packages/bundler-plugin-core/src/types.ts
+++ b/packages/bundler-plugin-core/src/types.ts
@@ -245,47 +245,63 @@ export interface Options {
    */
   bundleSizeOptimizations?: {
     /**
-     * If set to true, the plugin will try to tree-shake debug statements out.
-     * Note that the success of this depends on tree shaking generally being enabled in your build.
+     * If set to `true`, the plugin will attempt to tree-shake (remove) any debugging code within the Sentry SDK.
+     * Note that the success of this depends on tree shaking being enabled in your build tooling.
+     *
+     * Setting this option to `true` will disable features like the SDK's `debug` option.
      */
     excludeDebugStatements?: boolean;
 
     /**
-     * If set to true, the plugin will try to tree-shake performance monitoring statements out.
-     * Note that the success of this depends on tree shaking generally being enabled in your build.
-     * Attention: DO NOT enable this when you're using any performance monitoring-related SDK features (e.g. Sentry.startTransaction()).
-     * This flag is intended to be used in combination with packages like @sentry/next or @sentry/sveltekit,
-     * which automatically include performance monitoring functionality.
+     * If set to `true`, the plugin will attempt to tree-shake (remove) code within the Sentry SDK that is related to tracing and performance monitoring.
+     * Note that the success of this depends on tree shaking being enabled in your build tooling.
+     *
+     * **Notice**: Do not enable this when you're using any performance monitoring-related SDK features (e.g. `Sentry.startTransaction()`).
+     *
+     * @deprecated This option has been replaced with the `excludeTracing`. Currently, this option is an alias for `excludeTracing` but `excludePerformanceMonitoring` will be removed in the next major version.
      */
+    // TODO(v3): Remove this option
     excludePerformanceMonitoring?: boolean;
 
     /**
-     * If set to true, the plugin will try to tree-shake Session Replay's Canvas recording functionality out.
-     * You can safely do this when you do not want to capture any Canvas activity via Replay.
-     * Note that the success of this depends on tree shaking generally being enabled in your build.
+     * If set to `true`, the plugin will attempt to tree-shake (remove) code within the Sentry SDK that is related to tracing and performance monitoring.
+     * Note that the success of this depends on tree shaking being enabled in your build tooling.
      *
-     * @deprecated Versions v7.78.0 and later of the Sentry JavaScript SDKs do not include canvas support by default, making this option redundant.
+     * **Notice:** Do not enable this when you're using any performance monitoring-related SDK features (e.g. `Sentry.startTransaction()`).
+     */
+    excludeTracing?: boolean;
+
+    /**
+     * If set to `true`, the plugin will attempt to tree-shake (remove) code related to the Sentry SDK's Session Replay Canvas recording functionality.
+     * Note that the success of this depends on tree shaking being enabled in your build tooling.
+     *
+     * You can safely do this when you do not want to capture any Canvas activity via Sentry Session Replay.
+     *
+     * @deprecated In versions v7.78.0 and later of the Sentry JavaScript SDKs, canvas recording is opt-in making this option redundant.
      */
     excludeReplayCanvas?: boolean;
 
     /**
-     * If set to true, the plugin will try to tree-shake Session Replay's Shadow DOM recording functionality out.
-     * You can safely do this when you do not want to capture any Shadow DOM activity via Replay.
-     * Note that the success of this depends on tree shaking generally being enabled in your build.
+     * If set to `true`, the plugin will attempt to tree-shake (remove) code related to the Sentry SDK's Session Replay Shadow DOM recording functionality.
+     * Note that the success of this depends on tree shaking being enabled in your build tooling.
+     *
+     * This option is safe to be used when you do not want to capture any Shadow DOM activity via Sentry Session Replay.
      */
     excludeReplayShadowDom?: boolean;
 
     /**
-     * If set to true, the plugin will try to tree-shake Session Replay's IFrame recording functionality out.
-     * You can safely do this when you do not want to capture any IFrame activity via Replay.
-     * Note that the success of this depends on tree shaking generally being enabled in your build.
+     * If set to `true`, the plugin will attempt to tree-shake (remove) code related to the Sentry SDK's Session Replay `iframe` recording functionality.
+     * Note that the success of this depends on tree shaking being enabled in your build tooling.
+     *
+     * You can safely do this when you do not want to capture any `iframe` activity via Sentry Session Replay.
      */
     excludeReplayIframe?: boolean;
 
     /**
-     * If set to true, the plugin will try to tree-shake Session Replay's Compression Web Worker out.
-     * You should only do this if you manually host a compression worker and configure it in your Replay config via `workerUrl`.
-     * Note that the success of this depends on tree shaking generally being enabled in your build.
+     * If set to `true`, the plugin will attempt to tree-shake (remove) code related to the Sentry SDK's Session Replay's Compression Web Worker.
+     * Note that the success of this depends on tree shaking being enabled in your build tooling.
+     *
+     * **Notice:** You should only do use this option if you manually host a compression worker and configure it in your Sentry Session Replay integration config via the `workerUrl` option.
      */
     excludeReplayWorker?: boolean;
   };

--- a/packages/dev-utils/src/generate-documentation-table.ts
+++ b/packages/dev-utils/src/generate-documentation-table.ts
@@ -344,6 +344,37 @@ type IncludeEntry = {
     ],
   },
   {
+    name: "bundleSizeOptimizations",
+    fullDescription: `Options related to bundle size optimizations. These options will allow you to optimize and reduce the bundle size of the Sentry SDK.`,
+    children: [
+      {
+        name: "excludeDebugStatements",
+        type: "boolean",
+        fullDescription: `If set to \`true\`, the plugin will attempt to tree-shake (remove) any debugging code within the Sentry SDK.\nNote that the success of this depends on tree shaking being enabled in your build tooling.\n\nSetting this option to \`true\` will disable features like the SDK's \`debug\` option.`,
+      },
+      {
+        name: "excludeTracing",
+        type: "boolean",
+        fullDescription: `If set to \`true\`, the plugin will attempt to tree-shake (remove) code within the Sentry SDK that is related to tracing and performance monitoring.\nNote that the success of this depends on tree shaking being enabled in your build tooling.\n\n**Notice:** Do not enable this when you're using any performance monitoring-related SDK features (e.g. \`Sentry.startTransaction()\`).`,
+      },
+      {
+        name: "excludeReplayShadowDom",
+        type: "boolean",
+        fullDescription: `If set to \`true\`, the plugin will attempt to tree-shake (remove) code related to the Sentry SDK's Session Replay Shadow DOM recording functionality.\nNote that the success of this depends on tree shaking being enabled in your build tooling.\n\nThis option is safe to be used when you do not want to capture any Shadow DOM activity via Sentry Session Replay.`,
+      },
+      {
+        name: "excludeReplayIframe",
+        type: "boolean",
+        fullDescription: `If set to \`true\`, the plugin will attempt to tree-shake (remove) code related to the Sentry SDK's Session Replay \`iframe\` recording functionality.\nNote that the success of this depends on tree shaking being enabled in your build tooling.\n\nYou can safely do this when you do not want to capture any \`iframe\` activity via Sentry Session Replay.`,
+      },
+      {
+        name: "excludeReplayWorker",
+        type: "boolean",
+        fullDescription: `If set to \`true\`, the plugin will attempt to tree-shake (remove) code related to the Sentry SDK's Session Replay's Compression Web Worker.\nNote that the success of this depends on tree shaking being enabled in your build tooling.\n\n**Notice:** You should only do use this option if you manually host a compression worker and configure it in your Sentry Session Replay integration config via the \`workerUrl\` option.`,
+      },
+    ],
+  },
+  {
     name: "reactComponentAnnotation",
     fullDescription: `Options related to react component name annotations.
       Disabled by default, unless a value is set for this option.


### PR DESCRIPTION
Adds an alias because we are rephrasing everything around performance and tracing.

Also adds docs to readme we should have added before.