### PR TITLE
fix: Escape release string in injection snippet

### DIFF
--- a/packages/bundler-plugin-core/src/utils.ts
+++ b/packages/bundler-plugin-core/src/utils.ts
@@ -321,7 +321,7 @@ export function generateGlobalInjectorCode({
             self :
             {};
 
-    _global.SENTRY_RELEASE={id:"${release}"};`;
+    _global.SENTRY_RELEASE={id:${JSON.stringify(release)}};`;
 
   if (injectBuildInformation) {
     const buildInfo = getBuildInformation();

--- a/packages/integration-tests/fixtures/release-value-with-quotes/input/bundle.js
+++ b/packages/integration-tests/fixtures/release-value-with-quotes/input/bundle.js
@@ -1,0 +1,3 @@
+// Simply output the metadata to the console so it can be checked in a test
+// eslint-disable-next-line no-console, @typescript-eslint/no-unsafe-member-access
+console.log(JSON.stringify(global.SENTRY_RELEASE.id));

--- a/packages/integration-tests/fixtures/release-value-with-quotes/release-value-with-quotes.test.ts
+++ b/packages/integration-tests/fixtures/release-value-with-quotes/release-value-with-quotes.test.ts
@@ -1,0 +1,32 @@
+/* eslint-disable jest/no-standalone-expect */
+/* eslint-disable jest/expect-expect */
+import { execSync } from "child_process";
+import path from "path";
+import { testIfNodeMajorVersionIsLessThan18 } from "../../utils/testIf";
+
+function checkBundle(bundlePath: string): void {
+  const output = execSync(`node ${bundlePath}`, { encoding: "utf-8" });
+  expect(output).toBe('i am a dangerous release value because I contain a "');
+}
+
+describe("Properly escapes release values before injecting", () => {
+  testIfNodeMajorVersionIsLessThan18("webpack 4 bundle", () => {
+    checkBundle(path.join(__dirname, "out", "webpack4", "bundle.js"));
+  });
+
+  test("webpack 5 bundle", () => {
+    checkBundle(path.join(__dirname, "out", "webpack5", "bundle.js"));
+  });
+
+  test("esbuild bundle", () => {
+    checkBundle(path.join(__dirname, "out", "esbuild", "bundle.js"));
+  });
+
+  test("rollup bundle", () => {
+    checkBundle(path.join(__dirname, "out", "rollup", "bundle.js"));
+  });
+
+  test("vite bundle", () => {
+    checkBundle(path.join(__dirname, "out", "vite", "bundle.js"));
+  });
+});

--- a/packages/integration-tests/fixtures/release-value-with-quotes/release-value-with-quotes.test.ts
+++ b/packages/integration-tests/fixtures/release-value-with-quotes/release-value-with-quotes.test.ts
@@ -6,7 +6,7 @@ import { testIfNodeMajorVersionIsLessThan18 } from "../../utils/testIf";
 
 function checkBundle(bundlePath: string): void {
   const output = execSync(`node ${bundlePath}`, { encoding: "utf-8" });
-  expect(output).toBe('i am a dangerous release value because I contain a "');
+  expect(output.trimEnd()).toBe('"i am a dangerous release value because I contain a \\""');
 }
 
 describe("Properly escapes release values before injecting", () => {

--- a/packages/integration-tests/fixtures/release-value-with-quotes/setup.ts
+++ b/packages/integration-tests/fixtures/release-value-with-quotes/setup.ts
@@ -1,0 +1,15 @@
+import * as path from "path";
+import { createCjsBundles } from "../../utils/create-cjs-bundles";
+
+const outputDir = path.resolve(__dirname, "out");
+
+createCjsBundles(
+  {
+    bundle: path.resolve(__dirname, "input", "bundle.js"),
+  },
+  outputDir,
+  {
+    release: { name: 'i am a dangerous release value because I contain a "' },
+  },
+  ["webpack4", "webpack5", "esbuild", "rollup", "vite"]
+);


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript-bundler-plugins/issues/584

Properly escapes strings passed as release option.