### PR TITLE
fix: disable sourcemaps from the modern way of uploading

### DIFF
--- a/packages/bundler-plugin-core/src/index.ts
+++ b/packages/bundler-plugin-core/src/index.ts
@@ -355,7 +355,9 @@ export function sentryUnpluginFactory({
 
     plugins.push(debugIdInjectionPlugin(logger));
 
-    if (!options.authToken) {
+    if (options.sourcemaps?.disable) {
+      logger.debug("Source map upload was disabled. Will not upload sourcemaps.");
+    }  else if (!options.authToken) {
       logger.warn(
         "No auth token provided. Will not upload source maps. Please set the `authToken` option. You can find information on how to generate a Sentry auth token here: https://docs.sentry.io/api/auth/"
       );


### PR DESCRIPTION
should fix at least the really nasty part of #520 where it uploads sourcemaps even though
i explicitly configured it not to.

I assume the fix for dev mode would be similar, though I didn't dig into how it tends to
be detected in this project (if at all?)
