### PR TITLE
fix: Disable debug ID injection when `sourcemaps.disable` is set

### DIFF
--- a/packages/bundler-plugin-core/src/index.ts
+++ b/packages/bundler-plugin-core/src/index.ts
@@ -351,7 +351,9 @@ export function sentryUnpluginFactory({
       );
     }
 
-    plugins.push(debugIdInjectionPlugin(logger));
+    if (!options.sourcemaps?.disable) {
+      plugins.push(debugIdInjectionPlugin(logger));
+    }
 
     if (options.sourcemaps?.disable) {
       logger.debug(

--- a/packages/integration-tests/fixtures/disabled-debug-id-injection/disabled-debug-id-injection.test.ts
+++ b/packages/integration-tests/fixtures/disabled-debug-id-injection/disabled-debug-id-injection.test.ts
@@ -1,0 +1,50 @@
+/* eslint-disable jest/no-standalone-expect */
+/* eslint-disable jest/expect-expect */
+import childProcess from "child_process";
+import path from "path";
+import { testIfNodeMajorVersionIsLessThan18 } from "../../utils/testIf";
+
+function checkBundle(bundlePath1: string, bundlePath2: string) {
+  const process1Output = childProcess.execSync(`node ${bundlePath1}`, { encoding: "utf-8" });
+  expect(process1Output).toBe("undefined\n");
+
+  const process2Output = childProcess.execSync(`node ${bundlePath2}`, { encoding: "utf-8" });
+  expect(process2Output).toBe("undefined\n");
+}
+
+describe("should not inject debug IDs when `sourcemaps.disable` is `true`", () => {
+  test("esbuild bundle", () => {
+    checkBundle(
+      path.join(__dirname, "out", "esbuild", "bundle1.js"),
+      path.join(__dirname, "out", "esbuild", "bundle2.js")
+    );
+  });
+
+  test("rollup bundle", () => {
+    checkBundle(
+      path.join(__dirname, "out", "rollup", "bundle1.js"),
+      path.join(__dirname, "out", "rollup", "bundle2.js")
+    );
+  });
+
+  test("vite bundle", () => {
+    checkBundle(
+      path.join(__dirname, "out", "vite", "bundle1.js"),
+      path.join(__dirname, "out", "vite", "bundle2.js")
+    );
+  });
+
+  testIfNodeMajorVersionIsLessThan18("webpack 4 bundle", () => {
+    checkBundle(
+      path.join(__dirname, "out", "webpack4", "bundle1.js"),
+      path.join(__dirname, "out", "webpack4", "bundle2.js")
+    );
+  });
+
+  test("webpack 5 bundle", () => {
+    checkBundle(
+      path.join(__dirname, "out", "webpack5", "bundle1.js"),
+      path.join(__dirname, "out", "webpack5", "bundle2.js")
+    );
+  });
+});

--- a/packages/integration-tests/fixtures/disabled-debug-id-injection/input/bundle1.js
+++ b/packages/integration-tests/fixtures/disabled-debug-id-injection/input/bundle1.js
@@ -1,0 +1,5 @@
+// eslint-disable-next-line no-console
+console.log(JSON.stringify(global._sentryDebugIds));
+
+// Just so the two bundles generate different hashes:
+global.iAmBundle1 = 1;

--- a/packages/integration-tests/fixtures/disabled-debug-id-injection/input/bundle2.js
+++ b/packages/integration-tests/fixtures/disabled-debug-id-injection/input/bundle2.js
@@ -1,0 +1,5 @@
+// eslint-disable-next-line no-console
+console.log(JSON.stringify(global._sentryDebugIds));
+
+// Just so the two bundles generate different hashes:
+global.iAmBundle2 = 2;

--- a/packages/integration-tests/fixtures/disabled-debug-id-injection/setup.ts
+++ b/packages/integration-tests/fixtures/disabled-debug-id-injection/setup.ts
@@ -1,0 +1,18 @@
+import * as path from "path";
+import { createCjsBundles } from "../../utils/create-cjs-bundles";
+
+const outputDir = path.resolve(__dirname, "out");
+
+createCjsBundles(
+  {
+    bundle1: path.resolve(__dirname, "input", "bundle1.js"),
+    bundle2: path.resolve(__dirname, "input", "bundle2.js"),
+  },
+  outputDir,
+  {
+    telemetry: false,
+    sourcemaps: {
+      disable: true,
+    },
+  }
+);


### PR DESCRIPTION
I ran into the case in https://github.com/getsentry/sentry/pull/76051 where it would be super harmful when we injected debug IDs because we later inject debug IDs with the CLI, and the plugin's debug IDs would win, and source maps would break. This is more or less just a reliability patch.