### PR TITLE
fix: Ignore stderr output from git command

### DIFF
--- a/packages/bundler-plugin-core/src/utils.ts
+++ b/packages/bundler-plugin-core/src/utils.ts
@@ -198,7 +198,10 @@ export function stringToUUID(str: string): string {
 function gitRevision(): string | undefined {
   let gitRevision: string | undefined;
   try {
-    gitRevision = childProcess.execSync("git rev-parse HEAD").toString().trim();
+    gitRevision = childProcess
+      .execSync("git rev-parse HEAD", { stdio: ["ignore", "pipe", "ignore"] })
+      .toString()
+      .trim();
   } catch (e) {
     // noop
   }


### PR DESCRIPTION
Ignore the stderr output from the child process.

fixes https://github.com/getsentry/sentry-javascript-bundler-plugins/issues/612
