### PR TITLE
fix(core): Use sha256 instead of md5 to generate uuids from string

### DIFF
--- a/packages/bundler-plugin-core/src/utils.ts
+++ b/packages/bundler-plugin-core/src/utils.ts
@@ -173,25 +173,23 @@ function lookupPackageJson(cwd: string, stopAt: string): PackageJson | undefined
  * Deterministically hashes a string and turns the hash into a uuid.
  */
 export function stringToUUID(str: string): string {
-  const md5sum = crypto.createHash("md5");
-  md5sum.update(str);
-  const md5Hash = md5sum.digest("hex");
+  const sha256Hash = crypto.createHash("sha256").update(str).digest("hex");
 
   // Position 16 is fixed to either 8, 9, a, or b in the uuid v4 spec (10xx in binary)
   // RFC 4122 section 4.4
-  const v4variant = ["8", "9", "a", "b"][md5Hash.substring(16, 17).charCodeAt(0) % 4] as string;
+  const v4variant = ["8", "9", "a", "b"][sha256Hash.substring(16, 17).charCodeAt(0) % 4] as string;
 
   return (
-    md5Hash.substring(0, 8) +
+    sha256Hash.substring(0, 8) +
     "-" +
-    md5Hash.substring(8, 12) +
+    sha256Hash.substring(8, 12) +
     "-4" +
-    md5Hash.substring(13, 16) +
+    sha256Hash.substring(13, 16) +
     "-" +
     v4variant +
-    md5Hash.substring(17, 20) +
+    sha256Hash.substring(17, 20) +
     "-" +
-    md5Hash.substring(20)
+    sha256Hash.substring(20, 32)
   ).toLowerCase();
 }
 

--- a/packages/bundler-plugin-core/test/utils.test.ts
+++ b/packages/bundler-plugin-core/test/utils.test.ts
@@ -179,7 +179,7 @@ describe("getDependencies", () => {
 
 describe("stringToUUID", () => {
   test("should return a deterministic UUID", () => {
-    expect(stringToUUID("Nothing personnel kid")).toBe("52c7a762-5ddf-49a7-af16-6874a8cb2512");
+    expect(stringToUUID("Nothing personnel kid")).toBe("95543648-7392-49e4-b46a-67dfd0235986");
   });
 });
 


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript-bundler-plugins/issues/618