### PR TITLE
chore: Log only to stderr

### DIFF
--- a/packages/bundler-plugin-core/src/sentry/logger.ts
+++ b/packages/bundler-plugin-core/src/sentry/logger.ts
@@ -11,30 +11,31 @@ export type Logger = {
   debug(message: string, ...params: unknown[]): void;
 };
 
+// Logging everything to stderr not to interfere with stdout
 export function createLogger(options: LoggerOptions): Logger {
   return {
     info(message: string, ...params: unknown[]) {
       if (!options.silent) {
         // eslint-disable-next-line no-console
-        console.log(`${options.prefix} Info: ${message}`, ...params);
+        console.error(`${options.prefix} Info: ${message}`, ...params);
       }
     },
     warn(message: string, ...params: unknown[]) {
       if (!options.silent) {
         // eslint-disable-next-line no-console
-        console.log(`${options.prefix} Warning: ${message}`, ...params);
+        console.error(`${options.prefix} Warning: ${message}`, ...params);
       }
     },
     error(message: string, ...params: unknown[]) {
       if (!options.silent) {
         // eslint-disable-next-line no-console
-        console.log(`${options.prefix} Error: ${message}`, ...params);
+        console.error(`${options.prefix} Error: ${message}`, ...params);
       }
     },
     debug(message: string, ...params: unknown[]) {
       if (!options.silent && options.debug) {
         // eslint-disable-next-line no-console
-        console.log(`${options.prefix} Debug: ${message}`, ...params);
+        console.error(`${options.prefix} Debug: ${message}`, ...params);
       }
     },
   };

--- a/packages/bundler-plugin-core/test/sentry/logger.test.ts
+++ b/packages/bundler-plugin-core/test/sentry/logger.test.ts
@@ -1,10 +1,10 @@
 import { createLogger } from "../../src/sentry/logger";
 
 describe("Logger", () => {
-  const consoleLogSpy = jest.spyOn(console, "log").mockImplementation(() => undefined);
+  const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => undefined);
 
   afterEach(() => {
-    consoleLogSpy.mockReset();
+    consoleErrorSpy.mockReset();
   });
 
   it.each([
@@ -17,7 +17,7 @@ describe("Logger", () => {
 
     logger[loggerMethod]("Hey!");
 
-    expect(consoleLogSpy).toHaveBeenCalledWith(`[some-prefix] ${logLevel}: Hey!`);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(`[some-prefix] ${logLevel}: Hey!`);
   });
 
   it.each([
@@ -30,7 +30,7 @@ describe("Logger", () => {
 
     logger[loggerMethod]("Hey!", "this", "is", "a test with", 5, "params");
 
-    expect(consoleLogSpy).toHaveBeenCalledWith(
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
       `[some-prefix] ${logLevel}: Hey!`,
       "this",
       "is",
@@ -46,7 +46,7 @@ describe("Logger", () => {
 
     logger.debug("Hey!");
 
-    expect(consoleLogSpy).toHaveBeenCalledWith(`[some-prefix] Debug: Hey!`);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(`[some-prefix] Debug: Hey!`);
   });
 
   it(".debug() should log multiple params correctly", () => {
@@ -55,7 +55,7 @@ describe("Logger", () => {
 
     logger.debug("Hey!", "this", "is", "a test with", 5, "params");
 
-    expect(consoleLogSpy).toHaveBeenCalledWith(
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
       `[some-prefix] Debug: Hey!`,
       "this",
       "is",
@@ -72,7 +72,7 @@ describe("Logger", () => {
 
       logger[loggerMethod]("Hey!");
 
-      expect(consoleLogSpy).not.toHaveBeenCalled();
+      expect(consoleErrorSpy).not.toHaveBeenCalled();
     });
   });
 
@@ -82,6 +82,6 @@ describe("Logger", () => {
 
     logger.debug("Hey!");
 
-    expect(consoleLogSpy).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Resolves: https://github.com/getsentry/sentry-javascript-bundler-plugins/issues/551

Switches logger to use `stderr`, not to interfere with `stdout`.