### PR TITLE
ref(core): Rename release management plugin name

### DIFF
--- a/packages/bundler-plugin-core/src/plugins/release-management.ts
+++ b/packages/bundler-plugin-core/src/plugins/release-management.ts
@@ -31,6 +31,11 @@ interface ReleaseManagementPluginOptions {
   createDependencyOnSourcemapFiles: () => () => void;
 }
 
+/**
+ * Creates a plugin that creates releases, sets commits, deploys and finalizes releases.
+ *
+ * Additionally, if legacy upload options are set, it uploads source maps in the legacy (non-debugId) way.
+ */
 export function releaseManagementPlugin({
   releaseName,
   include,
@@ -47,7 +52,7 @@ export function releaseManagementPlugin({
 }: ReleaseManagementPluginOptions): UnpluginOptions {
   const freeGlobalDependencyOnSourcemapFiles = createDependencyOnSourcemapFiles();
   return {
-    name: "sentry-debug-id-upload-plugin",
+    name: "sentry-release-management-plugin",
     async writeBundle() {
       // It is possible that this writeBundle hook is called multiple times in one build (for example when reusing the plugin, or when using build tooling like `@vitejs/plugin-legacy`)
       // Therefore we need to actually register the execution of this hook as dependency on the sourcemap files.

--- a/packages/esbuild-plugin/test/public-api.test.ts
+++ b/packages/esbuild-plugin/test/public-api.test.ts
@@ -1,6 +1,20 @@
+import { EsbuildPlugin } from "unplugin";
 import { sentryEsbuildPlugin } from "../src";
 
 test("Esbuild plugin should exist", () => {
   expect(sentryEsbuildPlugin).toBeDefined();
   expect(typeof sentryEsbuildPlugin).toBe("function");
+});
+
+describe("sentryEsbuildPlugin", () => {
+  it("returns an esbuild plugin", () => {
+    const plugins = sentryEsbuildPlugin({
+      authToken: "test-token",
+      org: "test-org",
+      project: "test-project",
+    }) as EsbuildPlugin;
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    expect(plugins).toEqual({ name: "unplugin-host-0", setup: expect.any(Function) });
+  });
 });

--- a/packages/rollup-plugin/test/public-api.test.ts
+++ b/packages/rollup-plugin/test/public-api.test.ts
@@ -1,6 +1,30 @@
+import { Plugin } from "rollup";
 import { sentryRollupPlugin } from "../src";
 
 test("Rollup plugin should exist", () => {
   expect(sentryRollupPlugin).toBeDefined();
   expect(typeof sentryRollupPlugin).toBe("function");
+});
+
+describe("sentryRollupPlugin", () => {
+  it("returns an array of rollup plugins", () => {
+    const plugins = sentryRollupPlugin({
+      authToken: "test-token",
+      org: "test-org",
+      project: "test-project",
+    }) as Plugin[];
+
+    expect(Array.isArray(plugins)).toBe(true);
+
+    const pluginNames = plugins.map((plugin) => plugin.name);
+
+    expect(pluginNames).toEqual([
+      "sentry-telemetry-plugin",
+      "sentry-rollup-release-injection-plugin",
+      "sentry-release-management-plugin",
+      "sentry-rollup-debug-id-injection-plugin",
+      "sentry-rollup-debug-id-upload-plugin",
+      "sentry-file-deletion-plugin",
+    ]);
+  });
 });

--- a/packages/vite-plugin/test/public-api.test.ts
+++ b/packages/vite-plugin/test/public-api.test.ts
@@ -1,6 +1,30 @@
+import { VitePlugin } from "unplugin";
 import { sentryVitePlugin } from "../src";
 
 test("Vite plugin should exist", () => {
   expect(sentryVitePlugin).toBeDefined();
   expect(typeof sentryVitePlugin).toBe("function");
+});
+
+describe("sentryVitePlugin", () => {
+  it("returns an array of Vite plugins", () => {
+    const plugins = sentryVitePlugin({
+      authToken: "test-token",
+      org: "test-org",
+      project: "test-project",
+    }) as VitePlugin[];
+
+    expect(Array.isArray(plugins)).toBe(true);
+
+    const pluginNames = plugins.map((plugin) => plugin.name);
+
+    expect(pluginNames).toEqual([
+      "sentry-telemetry-plugin",
+      "sentry-vite-release-injection-plugin",
+      "sentry-release-management-plugin",
+      "sentry-vite-debug-id-injection-plugin",
+      "sentry-vite-debug-id-upload-plugin",
+      "sentry-file-deletion-plugin",
+    ]);
+  });
 });

--- a/packages/webpack-plugin/test/public-api.test.ts
+++ b/packages/webpack-plugin/test/public-api.test.ts
@@ -1,6 +1,20 @@
+import { Plugin } from "webpack";
 import { sentryWebpackPlugin } from "../src";
 
 test("Webpack plugin should exist", () => {
   expect(sentryWebpackPlugin).toBeDefined();
   expect(typeof sentryWebpackPlugin).toBe("function");
+});
+
+describe("sentryWebpackPlugin", () => {
+  it("returns a webpack plugin", () => {
+    const plugin = sentryWebpackPlugin({
+      authToken: "test-token",
+      org: "test-org",
+      project: "test-project",
+    }) as Plugin;
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    expect(plugin).toEqual({ apply: expect.any(Function) });
+  });
 });


### PR DESCRIPTION
- Renames the release management plugin name from `sentry-debug-id-upload-plugin` to `sentry-release-management-plugin`
- adds simple tests to catch renamings/regressions since they have a potential effect on SDKs like `@sentry/sveltekit`