### PR TITLE
feat(logger): Use console methods respective to log level

### DIFF
--- a/packages/bundler-plugin-core/src/sentry/logger.ts
+++ b/packages/bundler-plugin-core/src/sentry/logger.ts
@@ -17,13 +17,13 @@ export function createLogger(options: LoggerOptions): Logger {
     info(message: string, ...params: unknown[]) {
       if (!options.silent) {
         // eslint-disable-next-line no-console
-        console.error(`${options.prefix} Info: ${message}`, ...params);
+        console.info(`${options.prefix} Info: ${message}`, ...params);
       }
     },
     warn(message: string, ...params: unknown[]) {
       if (!options.silent) {
         // eslint-disable-next-line no-console
-        console.error(`${options.prefix} Warning: ${message}`, ...params);
+        console.warn(`${options.prefix} Warning: ${message}`, ...params);
       }
     },
     error(message: string, ...params: unknown[]) {
@@ -35,7 +35,7 @@ export function createLogger(options: LoggerOptions): Logger {
     debug(message: string, ...params: unknown[]) {
       if (!options.silent && options.debug) {
         // eslint-disable-next-line no-console
-        console.error(`${options.prefix} Debug: ${message}`, ...params);
+        console.debug(`${options.prefix} Debug: ${message}`, ...params);
       }
     },
   };

--- a/packages/bundler-plugin-core/test/sentry/logger.test.ts
+++ b/packages/bundler-plugin-core/test/sentry/logger.test.ts
@@ -2,43 +2,52 @@ import { createLogger } from "../../src/sentry/logger";
 
 describe("Logger", () => {
   const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => undefined);
+  const consoleInfoSpy = jest.spyOn(console, "info").mockImplementation(() => undefined);
+  const consoleWarnSpy = jest.spyOn(console, "warn").mockImplementation(() => undefined);
+  const consoleDebugSpy = jest.spyOn(console, "debug").mockImplementation(() => undefined);
 
   afterEach(() => {
     consoleErrorSpy.mockReset();
+    consoleInfoSpy.mockReset();
+    consoleWarnSpy.mockReset();
+    consoleDebugSpy.mockReset();
   });
 
   it.each([
-    ["info", "Info"],
-    ["warn", "Warning"],
-    ["error", "Error"],
-  ] as const)(".%s() should log correctly", (loggerMethod, logLevel) => {
+    ["info", "Info", consoleInfoSpy],
+    ["warn", "Warning", consoleWarnSpy],
+    ["error", "Error", consoleErrorSpy],
+  ] as const)(".%s() should log correctly", (loggerMethod, logLevel, consoleSpy) => {
     const prefix = "[some-prefix]";
     const logger = createLogger({ prefix, silent: false, debug: true });
 
     logger[loggerMethod]("Hey!");
 
-    expect(consoleErrorSpy).toHaveBeenCalledWith(`[some-prefix] ${logLevel}: Hey!`);
+    expect(consoleSpy).toHaveBeenCalledWith(`[some-prefix] ${logLevel}: Hey!`);
   });
 
   it.each([
-    ["info", "Info"],
-    ["warn", "Warning"],
-    ["error", "Error"],
-  ] as const)(".%s() should log multiple params correctly", (loggerMethod, logLevel) => {
-    const prefix = "[some-prefix]";
-    const logger = createLogger({ prefix, silent: false, debug: true });
+    ["info", "Info", consoleInfoSpy],
+    ["warn", "Warning", consoleWarnSpy],
+    ["error", "Error", consoleErrorSpy],
+  ] as const)(
+    ".%s() should log multiple params correctly",
+    (loggerMethod, logLevel, consoleSpy) => {
+      const prefix = "[some-prefix]";
+      const logger = createLogger({ prefix, silent: false, debug: true });
 
-    logger[loggerMethod]("Hey!", "this", "is", "a test with", 5, "params");
+      logger[loggerMethod]("Hey!", "this", "is", "a test with", 5, "params");
 
-    expect(consoleErrorSpy).toHaveBeenCalledWith(
-      `[some-prefix] ${logLevel}: Hey!`,
-      "this",
-      "is",
-      "a test with",
-      5,
-      "params"
-    );
-  });
+      expect(consoleSpy).toHaveBeenCalledWith(
+        `[some-prefix] ${logLevel}: Hey!`,
+        "this",
+        "is",
+        "a test with",
+        5,
+        "params"
+      );
+    }
+  );
 
   it(".debug() should log correctly", () => {
     const prefix = "[some-prefix]";
@@ -46,7 +55,7 @@ describe("Logger", () => {
 
     logger.debug("Hey!");
 
-    expect(consoleErrorSpy).toHaveBeenCalledWith(`[some-prefix] Debug: Hey!`);
+    expect(consoleDebugSpy).toHaveBeenCalledWith(`[some-prefix] Debug: Hey!`);
   });
 
   it(".debug() should log multiple params correctly", () => {
@@ -55,7 +64,7 @@ describe("Logger", () => {
 
     logger.debug("Hey!", "this", "is", "a test with", 5, "params");
 
-    expect(consoleErrorSpy).toHaveBeenCalledWith(
+    expect(consoleDebugSpy).toHaveBeenCalledWith(
       `[some-prefix] Debug: Hey!`,
       "this",
       "is",
@@ -66,13 +75,17 @@ describe("Logger", () => {
   });
 
   describe("doesn't log when `silent` option is `true`", () => {
-    it.each(["info", "warn", "error"] as const)(".%s()", (loggerMethod) => {
+    it.each([
+      ["info", consoleInfoSpy],
+      ["warn", consoleWarnSpy],
+      ["error", consoleErrorSpy],
+    ] as const)(".%s()", (loggerMethod, consoleSpy) => {
       const prefix = "[some-prefix]";
       const logger = createLogger({ prefix, silent: true, debug: true });
 
       logger[loggerMethod]("Hey!");
 
-      expect(consoleErrorSpy).not.toHaveBeenCalled();
+      expect(consoleSpy).not.toHaveBeenCalled();
     });
   });
 
@@ -82,6 +95,6 @@ describe("Logger", () => {
 
     logger.debug("Hey!");
 
-    expect(consoleErrorSpy).not.toHaveBeenCalled();
+    expect(consoleDebugSpy).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
All log levels were directed to `stderr` here: https://github.com/getsentry/sentry-javascript-bundler-plugins/pull/624

However, this also can lead to problems as other frameworks like Nuxt prettify the console output and attach text like `ERROR` to the output as described in this issue: https://github.com/getsentry/sentry-javascript/issues/14879

The [issue reported with knip](https://github.com/getsentry/sentry-javascript-bundler-plugins/issues/551) occurs because knip only writes valid JSON to `stdout`. The change in this PR should not re-introduce this error as knip was failing because of a warning (which is directed to `stderr`). If anyone still experience problems, you can set `silent: true`.

closes https://github.com/getsentry/sentry-javascript/issues/14879