### PR TITLE
fix(webpack): Ensure process exits when done

### DIFF
--- a/packages/bundler-plugin-core/src/index.ts
+++ b/packages/bundler-plugin-core/src/index.ts
@@ -33,7 +33,10 @@ interface SentryUnpluginFactoryOptions {
   componentNameAnnotatePlugin?: (ignoredComponents?: string[]) => UnpluginOptions;
   moduleMetadataInjectionPlugin: (injectionCode: string) => UnpluginOptions;
   debugIdInjectionPlugin: (logger: Logger) => UnpluginOptions;
-  debugIdUploadPlugin: (upload: (buildArtifacts: string[]) => Promise<void>) => UnpluginOptions;
+  debugIdUploadPlugin: (
+    upload: (buildArtifacts: string[]) => Promise<void>,
+    logger: Logger
+  ) => UnpluginOptions;
   bundleSizeOptimizationsPlugin: (buildFlags: SentrySDKBuildFlags) => UnpluginOptions;
 }
 
@@ -408,7 +411,8 @@ export function sentryUnpluginFactory({
               vcsRemote: options.release.vcsRemote,
               headers: options.headers,
             },
-          })
+          }),
+          logger
         )
       );
     }

--- a/packages/webpack-plugin/src/index.ts
+++ b/packages/webpack-plugin/src/index.ts
@@ -136,12 +136,14 @@ function webpackDebugIdUploadPlugin(
         });
       });
 
-      compiler.hooks.done.tap(pluginName, () => {
-        setTimeout(() => {
-          logger.debug("Exiting process after debug file upload");
-          process.exit(0);
+      if (compiler.options.mode === "production") {
+        compiler.hooks.done.tap(pluginName, () => {
+          setTimeout(() => {
+            logger.debug("Exiting process after debug file upload");
+            process.exit(0);
+          });
         });
-      });
+      }
     },
   };
 }

--- a/packages/webpack-plugin/src/index.ts
+++ b/packages/webpack-plugin/src/index.ts
@@ -5,6 +5,7 @@ import {
   stringToUUID,
   SentrySDKBuildFlags,
   createComponentNameAnnotateHooks,
+  Logger,
 } from "@sentry/bundler-plugin-core";
 import * as path from "path";
 import { UnpluginOptions } from "unplugin";
@@ -117,7 +118,8 @@ function webpackDebugIdInjectionPlugin(): UnpluginOptions {
 }
 
 function webpackDebugIdUploadPlugin(
-  upload: (buildArtifacts: string[]) => Promise<void>
+  upload: (buildArtifacts: string[]) => Promise<void>,
+  logger: Logger
 ): UnpluginOptions {
   const pluginName = "sentry-webpack-debug-id-upload-plugin";
   return {
@@ -131,6 +133,13 @@ function webpackDebugIdUploadPlugin(
         );
         void upload(buildArtifacts).then(() => {
           callback();
+        });
+      });
+
+      compiler.hooks.done.tap(pluginName, () => {
+        setTimeout(() => {
+          logger.debug("Exiting process after debug file upload");
+          process.exit(0);
         });
       });
     },


### PR DESCRIPTION
This PR is heavily inspired by https://github.com/unjs/unplugin/issues/323#issuecomment-2208626770 where the suggestion is made to exit the process in the `done` hook of the webpack compiler. We have multiple reports of our webpack plugin stalling angular builds. This came up again recently so I thought we could give this fix a try.

Full disclosure: I cannot reproduce the stall posted in https://github.com/getsentry/sentry-javascript-bundler-plugins/issues/345, but from my limited local testing, this at least doesn't seem to break anything. However, exiting the process is still scary, so not sure if we should really do it. I guess with TanStack, there's at least precedence for this.

Reviewers - WDYT?