### PR TITLE
chore: Remove deprecated options and update changelog for v3 major

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@
 
 - "You know what they say ‘Fool me once, strike one, but fool me twice… strike three.’" — Michael Scott
 
+## 3.0.0
+
+### Breaking Changes
+
+- Code injected into bundles now uses:
+
+  - `const` which was added in ES6 (ES2015) (#646)
+  - `globalThis` which was added ES2020 but can be polyfilled (#610)
+
+- Deprecated configuration options have been removed:
+  - `deleteFilesAfterUpload` - Use `filesToDeleteAfterUpload` instead
+  - `bundleSizeOptimizations.excludePerformanceMonitoring` - Use `bundleSizeOptimizations.excludeTracing` instead
+  - `_experiments.moduleMetadata` - Use `moduleMetadata` instead
+  - `cleanArtifacts` - Did not do anything
+
+### Other Changes
+
+- fix(webpack): Ensure process exits when done (#653)
+- feat(logger): Use console methods respective to log level (#652)
+
 ## 2.23.0
 
 - chore(deps): bump nanoid from 3.3.6 to 3.3.8 (#641)

--- a/packages/bundler-plugin-core/src/index.ts
+++ b/packages/bundler-plugin-core/src/index.ts
@@ -105,13 +105,6 @@ export function sentryUnpluginFactory({
 
     const options = normalizeUserOptions(userOptions);
 
-    // TODO(v3): Remove this warning
-    if (userOptions._experiments?.moduleMetadata) {
-      logger.warn(
-        "The `_experiments.moduleMetadata` option has been promoted to being stable. You can safely move the option out of the `_experiments` object scope."
-      );
-    }
-
     if (unpluginMetaContext.watchMode || options.disable) {
       return [
         {
@@ -254,10 +247,7 @@ export function sentryUnpluginFactory({
       if (bundleSizeOptimizations.excludeDebugStatements) {
         replacementValues["__SENTRY_DEBUG__"] = false;
       }
-      if (
-        bundleSizeOptimizations.excludePerformanceMonitoring ||
-        bundleSizeOptimizations.excludeTracing
-      ) {
+      if (bundleSizeOptimizations.excludeTracing) {
         replacementValues["__SENTRY_TRACE__"] = false;
       }
       if (bundleSizeOptimizations.excludeReplayCanvas) {
@@ -437,9 +427,7 @@ export function sentryUnpluginFactory({
     plugins.push(
       fileDeletionPlugin({
         waitUntilSourcemapFileDependenciesAreFreed,
-        filesToDeleteAfterUpload:
-          options.sourcemaps?.filesToDeleteAfterUpload ??
-          options.sourcemaps?.deleteFilesAfterUpload,
+        filesToDeleteAfterUpload: options.sourcemaps?.filesToDeleteAfterUpload,
         logger,
         handleRecoverableError,
         sentryScope,

--- a/packages/bundler-plugin-core/src/options-mapping.ts
+++ b/packages/bundler-plugin-core/src/options-mapping.ts
@@ -35,7 +35,7 @@ export function normalizeUserOptions(userOptions: UserOptions) {
       },
     },
     applicationKey: userOptions.applicationKey,
-    moduleMetadata: userOptions.moduleMetadata || userOptions._experiments?.moduleMetadata,
+    moduleMetadata: userOptions.moduleMetadata,
     _experiments: userOptions._experiments ?? {},
   };
 

--- a/packages/bundler-plugin-core/src/sentry/telemetry.ts
+++ b/packages/bundler-plugin-core/src/sentry/telemetry.ts
@@ -86,10 +86,7 @@ export function setTelemetryDataOnScope(options: NormalizedOptions, scope: Scope
   // Miscellaneous options
   scope.setTag("custom-error-handler", !!errorHandler);
   scope.setTag("sourcemaps-assets", !!sourcemaps?.assets);
-  scope.setTag(
-    "delete-after-upload",
-    !!sourcemaps?.deleteFilesAfterUpload || !!sourcemaps?.filesToDeleteAfterUpload
-  );
+  scope.setTag("delete-after-upload", !!sourcemaps?.filesToDeleteAfterUpload);
   scope.setTag("sourcemaps-disabled", !!sourcemaps?.disable);
 
   scope.setTag("react-annotate", !!reactComponentAnnotation?.enabled);

--- a/packages/bundler-plugin-core/src/types.ts
+++ b/packages/bundler-plugin-core/src/types.ts
@@ -133,18 +133,6 @@ export interface Options {
      * The globbing patterns follow the implementation of the `glob` package. (https://www.npmjs.com/package/glob)
      *
      * Use the `debug` option to print information about which files end up being deleted.
-     *
-     * @deprecated Use `filesToDeleteAfterUpload` instead.
-     */
-    // TODO(v3): Remove this option.
-    deleteFilesAfterUpload?: string | string[];
-
-    /**
-     * A glob or an array of globs that specifies the build artifacts that should be deleted after the artifact upload to Sentry has been completed.
-     *
-     * The globbing patterns follow the implementation of the `glob` package. (https://www.npmjs.com/package/glob)
-     *
-     * Use the `debug` option to print information about which files end up being deleted.
      */
     filesToDeleteAfterUpload?: string | string[];
   };
@@ -217,18 +205,6 @@ export interface Options {
     deploy?: DeployOptions;
 
     /**
-     * Remove all previously uploaded artifacts for this release on Sentry before the upload.
-     *
-     * Defaults to `false`.
-     *
-     * @deprecated `cleanArtifacts` is deprecated and currently doesn't do anything. Historically it was needed
-     * since uploading the same artifacts twice was not allowed. Nowadays, when uploading artifacts with the same name
-     * more than once to the same release on Sentry, Sentry will prefer the most recent artifact for source mapping.
-     */
-    // TODO(v3): Remove this option
-    cleanArtifacts?: boolean;
-
-    /**
      * Legacy method of uploading source maps. (not recommended unless necessary)
      *
      * One or more paths that should be scanned recursively for sources.
@@ -252,17 +228,6 @@ export interface Options {
      * Setting this option to `true` will disable features like the SDK's `debug` option.
      */
     excludeDebugStatements?: boolean;
-
-    /**
-     * If set to `true`, the plugin will attempt to tree-shake (remove) code within the Sentry SDK that is related to tracing and performance monitoring.
-     * Note that the success of this depends on tree shaking being enabled in your build tooling.
-     *
-     * **Notice**: Do not enable this when you're using any performance monitoring-related SDK features (e.g. `Sentry.startTransaction()`).
-     *
-     * @deprecated This option has been replaced with the `excludeTracing`. Currently, this option is an alias for `excludeTracing` but `excludePerformanceMonitoring` will be removed in the next major version.
-     */
-    // TODO(v3): Remove this option
-    excludePerformanceMonitoring?: boolean;
 
     /**
      * If set to `true`, the plugin will attempt to tree-shake (remove) code within the Sentry SDK that is related to tracing and performance monitoring.
@@ -351,7 +316,6 @@ export interface Options {
    *
    * @experimental API that does not follow semantic versioning and may change in any release
    */
-  // TODO(v3): Remove these
   _experiments?: {
     /**
      * If set to true, the plugin will inject an additional `SENTRY_BUILD_INFO` variable.
@@ -360,25 +324,6 @@ export interface Options {
      * Defaults to `false`.
      */
     injectBuildInformation?: boolean;
-
-    /**
-     * NOTE: This option has been promoted to stable.
-     *
-     * Metadata that should be associated with the built application.
-     *
-     * The metadata is serialized and can be looked up at runtime from within the SDK (for example in the `beforeSend`,
-     * event processors, or the transport), allowing for custom event filtering logic or routing of events.
-     *
-     * Metadata can either be passed directly or alternatively a callback can be provided that will be
-     * called with the following parameters:
-     * - `org`: The organization slug.
-     * - `project`: The project slug.
-     * - `release`: The release name.
-     *
-     * @deprecated Use the non-experimental `moduleMetadata` option instead. (Basically just move this option out of `_experiments`)
-     */
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    moduleMetadata?: ModuleMetadata | ModuleMetadataCallback;
   };
 
   /**

--- a/packages/integration-tests/fixtures/bundle-size-optimizations/setup.ts
+++ b/packages/integration-tests/fixtures/bundle-size-optimizations/setup.ts
@@ -16,7 +16,7 @@ createCjsBundles(
     telemetry: false,
     bundleSizeOptimizations: {
       excludeDebugStatements: true,
-      excludePerformanceMonitoring: true,
+      excludeTracing: true,
       excludeReplayCanvas: true,
       excludeReplayIframe: true,
       excludeReplayShadowDom: true,


### PR DESCRIPTION
- Ref #651

Do you want to remove `injectBuildInformation` from `_experiments` too? It hasn't been deprecated yet 🤔