### PR TITLE
Revert "feat(core)!: Use `globalThis` for code injection"

### DIFF
--- a/packages/bundler-plugin-core/sentry-esbuild-debugid-injection-file.js
+++ b/packages/bundler-plugin-core/sentry-esbuild-debugid-injection-file.js
@@ -1,7 +1,16 @@
 try {
-  let globalObject = globalThis;
+  var globalObject =
+    "undefined" != typeof window
+      ? window
+      : "undefined" != typeof global
+      ? global
+      : "undefined" != typeof globalThis
+      ? global
+      : "undefined" != typeof self
+      ? self
+      : {};
 
-  let stack = new globalObject.Error().stack;
+  var stack = new globalObject.Error().stack;
 
   if (stack) {
     globalObject._sentryDebugIds = globalObject._sentryDebugIds || {};

--- a/packages/bundler-plugin-core/sentry-esbuild-debugid-injection-file.js
+++ b/packages/bundler-plugin-core/sentry-esbuild-debugid-injection-file.js
@@ -1,5 +1,5 @@
 try {
-  var globalObject =
+  let globalObject =
     "undefined" != typeof window
       ? window
       : "undefined" != typeof global
@@ -10,7 +10,7 @@ try {
       ? self
       : {};
 
-  var stack = new globalObject.Error().stack;
+  let stack = new globalObject.Error().stack;
 
   if (stack) {
     globalObject._sentryDebugIds = globalObject._sentryDebugIds || {};

--- a/packages/bundler-plugin-core/src/index.ts
+++ b/packages/bundler-plugin-core/src/index.ts
@@ -695,7 +695,7 @@ export function createComponentNameAnnotateHooks(ignoredComponents?: string[]) {
 }
 
 export function getDebugIdSnippet(debugId: string): string {
-  return `;!function(){try{var e="undefined"!=typeof window?window:"undefined"!=typeof global?global:"undefined"!=typeof globalThis?globalThis:"undefined"!=typeof self?self:{},n=(new e.Error).stack;n&&(e._sentryDebugIds=e._sentryDebugIds||{},e._sentryDebugIds[n]="${debugId}",e._sentryDebugIdIdentifier="sentry-dbid-${debugId}")}catch(e){}}();`;
+  return `;{try{let e="undefined"!=typeof window?window:"undefined"!=typeof global?global:"undefined"!=typeof globalThis?globalThis:"undefined"!=typeof self?self:{},n=(new e.Error).stack;n&&(e._sentryDebugIds=e._sentryDebugIds||{},e._sentryDebugIds[n]="${debugId}",e._sentryDebugIdIdentifier="sentry-dbid-${debugId}")}catch(e){}};`;
 }
 
 export { stringToUUID, replaceBooleanFlagsInCode } from "./utils";

--- a/packages/bundler-plugin-core/src/index.ts
+++ b/packages/bundler-plugin-core/src/index.ts
@@ -695,7 +695,7 @@ export function createComponentNameAnnotateHooks(ignoredComponents?: string[]) {
 }
 
 export function getDebugIdSnippet(debugId: string): string {
-  return `;{try{let e=globalThis,n=(new e.Error).stack;n&&(e._sentryDebugIds=e._sentryDebugIds||{},e._sentryDebugIds[n]="${debugId}",e._sentryDebugIdIdentifier="sentry-dbid-${debugId}")}catch(e){}};`;
+  return `;!function(){try{var e="undefined"!=typeof window?window:"undefined"!=typeof global?global:"undefined"!=typeof globalThis?globalThis:"undefined"!=typeof self?self:{},n=(new e.Error).stack;n&&(e._sentryDebugIds=e._sentryDebugIds||{},e._sentryDebugIds[n]="${debugId}",e._sentryDebugIdIdentifier="sentry-dbid-${debugId}")}catch(e){}}();`;
 }
 
 export { stringToUUID, replaceBooleanFlagsInCode } from "./utils";

--- a/packages/bundler-plugin-core/src/utils.ts
+++ b/packages/bundler-plugin-core/src/utils.ts
@@ -315,7 +315,7 @@ export function generateGlobalInjectorCode({
   // The code below is mostly ternary operators because it saves bundle size.
   // The checks are to support as many environments as possible. (Node.js, Browser, webworkers, etc.)
   let code = `{
-    const _global =
+    let _global =
       typeof window !== 'undefined' ?
         window :
         typeof global !== 'undefined' ?
@@ -346,7 +346,7 @@ export function generateModuleMetadataInjectorCode(metadata: any) {
   // The checks are to support as many environments as possible. (Node.js, Browser, webworkers, etc.)
   // We are merging the metadata objects in case modules are bundled twice with the plugin
   return `{
-  const _sentryModuleMetadataGlobal =
+  let _sentryModuleMetadataGlobal =
     typeof window !== "undefined"
       ? window
       : typeof global !== "undefined"

--- a/packages/bundler-plugin-core/src/utils.ts
+++ b/packages/bundler-plugin-core/src/utils.ts
@@ -312,8 +312,20 @@ export function generateGlobalInjectorCode({
   release: string;
   injectBuildInformation: boolean;
 }) {
+  // The code below is mostly ternary operators because it saves bundle size.
+  // The checks are to support as many environments as possible. (Node.js, Browser, webworkers, etc.)
   let code = `{
-    let _global = globalThis;
+    const _global =
+      typeof window !== 'undefined' ?
+        window :
+        typeof global !== 'undefined' ?
+          global :
+          typeof globalThis !== 'undefined' ?
+            globalThis :
+            typeof self !== 'undefined' ?
+              self :
+              {};
+
     _global.SENTRY_RELEASE={id:${JSON.stringify(release)}};`;
 
   if (injectBuildInformation) {
@@ -330,9 +342,20 @@ export function generateGlobalInjectorCode({
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function generateModuleMetadataInjectorCode(metadata: any) {
+  // The code below is mostly ternary operators because it saves bundle size.
+  // The checks are to support as many environments as possible. (Node.js, Browser, webworkers, etc.)
   // We are merging the metadata objects in case modules are bundled twice with the plugin
   return `{
-  let _sentryModuleMetadataGlobal = globalThis;
+  const _sentryModuleMetadataGlobal =
+    typeof window !== "undefined"
+      ? window
+      : typeof global !== "undefined"
+      ? global
+      : typeof globalThis !== "undefined"
+      ? globalThis
+      : typeof self !== "undefined"
+      ? self
+      : {};
 
   _sentryModuleMetadataGlobal._sentryModuleMetadata =
     _sentryModuleMetadataGlobal._sentryModuleMetadata || {};

--- a/packages/bundler-plugin-core/test/index.test.ts
+++ b/packages/bundler-plugin-core/test/index.test.ts
@@ -4,7 +4,7 @@ describe("getDebugIdSnippet", () => {
   it("returns the debugId injection snippet for a passed debugId", () => {
     const snippet = getDebugIdSnippet("1234");
     expect(snippet).toMatchInlineSnapshot(
-      `";!function(){try{var e=\\"undefined\\"!=typeof window?window:\\"undefined\\"!=typeof global?global:\\"undefined\\"!=typeof globalThis?globalThis:\\"undefined\\"!=typeof self?self:{},n=(new e.Error).stack;n&&(e._sentryDebugIds=e._sentryDebugIds||{},e._sentryDebugIds[n]=\\"1234\\",e._sentryDebugIdIdentifier=\\"sentry-dbid-1234\\")}catch(e){}}();"`
+      `";{try{let e=\\"undefined\\"!=typeof window?window:\\"undefined\\"!=typeof global?global:\\"undefined\\"!=typeof globalThis?globalThis:\\"undefined\\"!=typeof self?self:{},n=(new e.Error).stack;n&&(e._sentryDebugIds=e._sentryDebugIds||{},e._sentryDebugIds[n]=\\"1234\\",e._sentryDebugIdIdentifier=\\"sentry-dbid-1234\\")}catch(e){}};"`
     );
   });
 });

--- a/packages/bundler-plugin-core/test/index.test.ts
+++ b/packages/bundler-plugin-core/test/index.test.ts
@@ -4,7 +4,7 @@ describe("getDebugIdSnippet", () => {
   it("returns the debugId injection snippet for a passed debugId", () => {
     const snippet = getDebugIdSnippet("1234");
     expect(snippet).toMatchInlineSnapshot(
-      `";{try{let e=globalThis,n=(new e.Error).stack;n&&(e._sentryDebugIds=e._sentryDebugIds||{},e._sentryDebugIds[n]=\\"1234\\",e._sentryDebugIdIdentifier=\\"sentry-dbid-1234\\")}catch(e){}};"`
+      `";!function(){try{var e=\\"undefined\\"!=typeof window?window:\\"undefined\\"!=typeof global?global:\\"undefined\\"!=typeof globalThis?globalThis:\\"undefined\\"!=typeof self?self:{},n=(new e.Error).stack;n&&(e._sentryDebugIds=e._sentryDebugIds||{},e._sentryDebugIds[n]=\\"1234\\",e._sentryDebugIdIdentifier=\\"sentry-dbid-1234\\")}catch(e){}}();"`
     );
   });
 });

--- a/packages/bundler-plugin-core/test/utils.test.ts
+++ b/packages/bundler-plugin-core/test/utils.test.ts
@@ -221,7 +221,7 @@ describe("generateModuleMetadataInjectorCode", () => {
     const generatedCode = generateModuleMetadataInjectorCode({});
     expect(generatedCode).toMatchInlineSnapshot(`
       "{
-        const _sentryModuleMetadataGlobal =
+        let _sentryModuleMetadataGlobal =
           typeof window !== \\"undefined\\"
             ? window
             : typeof global !== \\"undefined\\"
@@ -256,7 +256,7 @@ describe("generateModuleMetadataInjectorCode", () => {
     });
     expect(generatedCode).toMatchInlineSnapshot(`
       "{
-        const _sentryModuleMetadataGlobal =
+        let _sentryModuleMetadataGlobal =
           typeof window !== \\"undefined\\"
             ? window
             : typeof global !== \\"undefined\\"

--- a/packages/bundler-plugin-core/test/utils.test.ts
+++ b/packages/bundler-plugin-core/test/utils.test.ts
@@ -221,7 +221,16 @@ describe("generateModuleMetadataInjectorCode", () => {
     const generatedCode = generateModuleMetadataInjectorCode({});
     expect(generatedCode).toMatchInlineSnapshot(`
       "{
-        let _sentryModuleMetadataGlobal = globalThis;
+        const _sentryModuleMetadataGlobal =
+          typeof window !== \\"undefined\\"
+            ? window
+            : typeof global !== \\"undefined\\"
+            ? global
+            : typeof globalThis !== \\"undefined\\"
+            ? globalThis
+            : typeof self !== \\"undefined\\"
+            ? self
+            : {};
 
         _sentryModuleMetadataGlobal._sentryModuleMetadata =
           _sentryModuleMetadataGlobal._sentryModuleMetadata || {};
@@ -247,7 +256,16 @@ describe("generateModuleMetadataInjectorCode", () => {
     });
     expect(generatedCode).toMatchInlineSnapshot(`
       "{
-        let _sentryModuleMetadataGlobal = globalThis;
+        const _sentryModuleMetadataGlobal =
+          typeof window !== \\"undefined\\"
+            ? window
+            : typeof global !== \\"undefined\\"
+            ? global
+            : typeof globalThis !== \\"undefined\\"
+            ? globalThis
+            : typeof self !== \\"undefined\\"
+            ? self
+            : {};
 
         _sentryModuleMetadataGlobal._sentryModuleMetadata =
           _sentryModuleMetadataGlobal._sentryModuleMetadata || {};


### PR DESCRIPTION
Reverts getsentry/sentry-javascript-bundler-plugins#610

See https://github.com/getsentry/sentry-javascript-bundler-plugins/pull/610#issuecomment-2591919621 as to why.