### PR TITLE
feat(webpack): Gate forced process exit behind experimental flag

### DIFF
--- a/packages/bundler-plugin-core/src/index.ts
+++ b/packages/bundler-plugin-core/src/index.ts
@@ -382,9 +382,9 @@ export function sentryUnpluginFactory({
     } else {
       // This option is only strongly typed for the webpack plugin, where it is used. It has no effect on other plugins
       const webpack_forceExitOnBuildComplete =
-        (typeof options._experiments["forceExitOnBuildCompletion"] === "boolean" &&
-          options._experiments["forceExitOnBuildCompletion"]) ??
-        false;
+        typeof options._experiments["forceExitOnBuildCompletion"] === "boolean"
+          ? options._experiments["forceExitOnBuildCompletion"]
+          : undefined;
 
       plugins.push(
         debugIdUploadPlugin(

--- a/packages/bundler-plugin-core/src/index.ts
+++ b/packages/bundler-plugin-core/src/index.ts
@@ -35,7 +35,8 @@ interface SentryUnpluginFactoryOptions {
   debugIdInjectionPlugin: (logger: Logger) => UnpluginOptions;
   debugIdUploadPlugin: (
     upload: (buildArtifacts: string[]) => Promise<void>,
-    logger: Logger
+    logger: Logger,
+    webpack_forceExitOnBuildComplete?: boolean
   ) => UnpluginOptions;
   bundleSizeOptimizationsPlugin: (buildFlags: SentrySDKBuildFlags) => UnpluginOptions;
 }
@@ -379,6 +380,12 @@ export function sentryUnpluginFactory({
         "No project provided. Will not upload source maps. Please set the `project` option to your Sentry project slug."
       );
     } else {
+      // This option is only strongly typed for the webpack plugin, where it is used. It has no effect on other plugins
+      const webpack_forceExitOnBuildComplete =
+        (typeof options._experiments["forceExitOnBuildCompletion"] === "boolean" &&
+          options._experiments["forceExitOnBuildCompletion"]) ??
+        false;
+
       plugins.push(
         debugIdUploadPlugin(
           createDebugIdUploadFunction({
@@ -402,7 +409,8 @@ export function sentryUnpluginFactory({
               headers: options.headers,
             },
           }),
-          logger
+          logger,
+          webpack_forceExitOnBuildComplete
         )
       );
     }

--- a/packages/bundler-plugin-core/src/types.ts
+++ b/packages/bundler-plugin-core/src/types.ts
@@ -324,7 +324,7 @@ export interface Options {
      * Defaults to `false`.
      */
     injectBuildInformation?: boolean;
-  };
+  } & Record<string, unknown>;
 
   /**
    * Options that are useful for building wrappers around the plugin. You likely don't need these options unless you

--- a/packages/webpack-plugin/src/index.ts
+++ b/packages/webpack-plugin/src/index.ts
@@ -186,7 +186,7 @@ const sentryUnplugin = sentryUnpluginFactory({
 });
 
 type SentryWebpackPluginOptions = Options & {
-  _experiments: Options["_experiments"] & {
+  _experiments?: Options["_experiments"] & {
     /**
      * If enabled, the webpack plugin will exit the build process after the build completes.
      * Use this with caution, as it will terminate the process.

--- a/packages/webpack-plugin/src/index.ts
+++ b/packages/webpack-plugin/src/index.ts
@@ -119,7 +119,8 @@ function webpackDebugIdInjectionPlugin(): UnpluginOptions {
 
 function webpackDebugIdUploadPlugin(
   upload: (buildArtifacts: string[]) => Promise<void>,
-  logger: Logger
+  logger: Logger,
+  forceExitOnBuildCompletion?: boolean
 ): UnpluginOptions {
   const pluginName = "sentry-webpack-debug-id-upload-plugin";
   return {
@@ -136,7 +137,7 @@ function webpackDebugIdUploadPlugin(
         });
       });
 
-      if (compiler.options.mode === "production") {
+      if (forceExitOnBuildCompletion && compiler.options.mode === "production") {
         compiler.hooks.done.tap(pluginName, () => {
           setTimeout(() => {
             logger.debug("Exiting process after debug file upload");
@@ -184,8 +185,24 @@ const sentryUnplugin = sentryUnpluginFactory({
   bundleSizeOptimizationsPlugin: webpackBundleSizeOptimizationsPlugin,
 });
 
+type SentryWebpackPluginOptions = Options & {
+  _experiments: Options["_experiments"] & {
+    /**
+     * If enabled, the webpack plugin will exit the build process after the build completes.
+     * Use this with caution, as it will terminate the process.
+     *
+     * More information: https://github.com/getsentry/sentry-javascript-bundler-plugins/issues/345
+     *
+     * @default false
+     */
+    forceExitOnBuildCompletion?: boolean;
+  };
+};
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const sentryWebpackPlugin: (options?: Options) => any = sentryUnplugin.webpack;
+export const sentryWebpackPlugin: (options?: SentryWebpackPluginOptions) => any =
+  sentryUnplugin.webpack;
 
 export { sentryCliBinaryExists } from "@sentry/bundler-plugin-core";
-export type { Options as SentryWebpackPluginOptions } from "@sentry/bundler-plugin-core";
+
+export type { SentryWebpackPluginOptions };


### PR DESCRIPTION
In #653 I introduced a forced process exit when the webpack build was done. This turned out to happen too early in NextJS builds. My guess is that there are multiple builds in the same process, meaning that we'd exit when the first one is done. This PR now reverts the default behaviour to no longer exit the process. Instead, users can set an experimental flag to force exiting the process (e.g. for https://github.com/getsentry/sentry-javascript-bundler-plugins/issues/345):

```js
sentryWebpackPlugin({
  // ...other options
  _experiments: { forceExitOnBuildCompletion: true },
});
```

Given we received no confirmation that this actually solves #345 so far, I think keeping this experimental for now is the best option.

fixes #662 
probably also addresses https://github.com/getsentry/sentry-javascript-bundler-plugins/pull/653#issuecomment-2599845693