### PR TITLE
fix(core): Check for dev mode via `process.env.NODE_ENV`

### DIFF
--- a/packages/bundler-plugin-core/src/index.ts
+++ b/packages/bundler-plugin-core/src/index.ts
@@ -84,6 +84,11 @@ export function sentryUnpluginFactory({
       debug: userOptions.debug ?? false,
     });
 
+    // Not a bulletproof check but should be good enough to at least sometimes determine
+    // if the plugin is called in dev/watch mode or for a  prod build. The important part
+    // here is to avoid a false positive. False negatives are okay.
+    const isDevMode = process.env["NODE_ENV"] === "development";
+
     try {
       const dotenvFile = fs.readFileSync(
         path.join(process.cwd(), ".env.sentry-build-plugin"),
@@ -106,7 +111,7 @@ export function sentryUnpluginFactory({
 
     const options = normalizeUserOptions(userOptions);
 
-    if (unpluginMetaContext.watchMode || options.disable) {
+    if (isDevMode || options.disable) {
       return [
         {
           name: "sentry-noop-plugin",
@@ -274,7 +279,7 @@ export function sentryUnpluginFactory({
         "Release injection disabled via `release.inject` option. Will not inject release."
       );
     } else if (!options.release.name) {
-      logger.warn(
+      logger.debug(
         "No release name provided. Will not inject release. Please set the `release.name` option to identify your release."
       );
     } else {
@@ -316,7 +321,7 @@ export function sentryUnpluginFactory({
     }
 
     if (!options.release.name) {
-      logger.warn(
+      logger.debug(
         "No release name provided. Will not create release. Please set the `release.name` option to identify your release."
       );
     } else if (!options.authToken) {

--- a/packages/bundler-plugin-core/src/index.ts
+++ b/packages/bundler-plugin-core/src/index.ts
@@ -111,7 +111,7 @@ export function sentryUnpluginFactory({
 
     const options = normalizeUserOptions(userOptions);
 
-    if (isDevMode || options.disable) {
+    if (options.disable) {
       return [
         {
           name: "sentry-noop-plugin",
@@ -324,6 +324,8 @@ export function sentryUnpluginFactory({
       logger.debug(
         "No release name provided. Will not create release. Please set the `release.name` option to identify your release."
       );
+    } else if (isDevMode) {
+      logger.debug("Running in development mode. Will not create release.");
     } else if (!options.authToken) {
       logger.warn(
         "No auth token provided. Will not create release. Please set the `authToken` option. You can find information on how to generate a Sentry auth token here: https://docs.sentry.io/api/auth/"
@@ -372,6 +374,8 @@ export function sentryUnpluginFactory({
       logger.debug(
         "Source map upload was disabled. Will not upload sourcemaps using debug ID process."
       );
+    } else if (isDevMode) {
+      logger.debug("Running in development mode. Will not upload sourcemaps.");
     } else if (!options.authToken) {
       logger.warn(
         "No auth token provided. Will not upload source maps. Please set the `authToken` option. You can find information on how to generate a Sentry auth token here: https://docs.sentry.io/api/auth/"

--- a/packages/rollup-plugin/test/public-api.test.ts
+++ b/packages/rollup-plugin/test/public-api.test.ts
@@ -7,6 +7,10 @@ test("Rollup plugin should exist", () => {
 });
 
 describe("sentryRollupPlugin", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it("returns an array of rollup plugins", () => {
     const plugins = sentryRollupPlugin({
       authToken: "test-token",
@@ -26,5 +30,42 @@ describe("sentryRollupPlugin", () => {
       "sentry-rollup-debug-id-upload-plugin",
       "sentry-file-deletion-plugin",
     ]);
+  });
+
+  it("doesn't include release management and debug id upload plugins if NODE_ENV is 'development'", () => {
+    const originalNodeEnv = process.env["NODE_ENV"];
+    process.env["NODE_ENV"] = "development";
+
+    const consoleSpy = jest.spyOn(console, "debug").mockImplementation(() => {
+      /* avoid test output pollution */
+    });
+
+    const plugins = sentryRollupPlugin({
+      authToken: "test-token",
+      org: "test-org",
+      project: "test-project",
+      debug: true,
+    }) as Plugin[];
+
+    expect(Array.isArray(plugins)).toBe(true);
+
+    const pluginNames = plugins.map((plugin) => plugin.name);
+
+    expect(pluginNames).toEqual([
+      "sentry-telemetry-plugin",
+      "sentry-rollup-release-injection-plugin",
+      "sentry-rollup-debug-id-injection-plugin",
+      "sentry-file-deletion-plugin",
+    ]);
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Running in development mode. Will not create release.")
+    );
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Running in development mode. Will not upload sourcemaps.")
+    );
+
+    process.env["NODE_ENV"] = originalNodeEnv;
   });
 });

--- a/packages/vite-plugin/test/public-api.test.ts
+++ b/packages/vite-plugin/test/public-api.test.ts
@@ -7,6 +7,10 @@ test("Vite plugin should exist", () => {
 });
 
 describe("sentryVitePlugin", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it("returns an array of Vite plugins", () => {
     const plugins = sentryVitePlugin({
       authToken: "test-token",
@@ -26,5 +30,42 @@ describe("sentryVitePlugin", () => {
       "sentry-vite-debug-id-upload-plugin",
       "sentry-file-deletion-plugin",
     ]);
+  });
+
+  it("doesn't include release management and debug id upload plugins if NODE_ENV is 'development'", () => {
+    const originalNodeEnv = process.env["NODE_ENV"];
+    process.env["NODE_ENV"] = "development";
+
+    const consoleSpy = jest.spyOn(console, "debug").mockImplementation(() => {
+      /* avoid test output pollution */
+    });
+
+    const plugins = sentryVitePlugin({
+      authToken: "test-token",
+      org: "test-org",
+      project: "test-project",
+      debug: true,
+    }) as VitePlugin[];
+
+    expect(Array.isArray(plugins)).toBe(true);
+
+    const pluginNames = plugins.map((plugin) => plugin.name);
+
+    expect(pluginNames).toEqual([
+      "sentry-telemetry-plugin",
+      "sentry-vite-release-injection-plugin",
+      "sentry-vite-debug-id-injection-plugin",
+      "sentry-file-deletion-plugin",
+    ]);
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Running in development mode. Will not create release.")
+    );
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Running in development mode. Will not upload sourcemaps.")
+    );
+
+    process.env["NODE_ENV"] = originalNodeEnv;
   });
 });


### PR DESCRIPTION
perfect PR id 😈 

This PR improves the check for if the plugin is called in dev/watch mode or for a production build. In case of the former, we return a no-op plugin. This was already the [expected behaviour](https://docs.sentry.io/platforms/javascript/sourcemaps/uploading/vite/#configuration) previously but due to the unplugin meta context only holding the `watchmode` flag in theory but not in practise, we'd always return the actual plugins.

This should also remove the log output in dev mode.

closes https://github.com/getsentry/sentry-javascript-bundler-plugins/issues/344
probably also closes https://github.com/getsentry/sentry-javascript-bundler-plugins/issues/520 (I'll leave a reply to get confirmation)

cc @cleptric 