### PR TITLE
chore: Suggest putting `SENTRY_AUTH_TOKEN`, `SENTRY_ORG` and `SENTRY_PROJECT` in `passThroughEnv` when using Turborepo

### DIFF
--- a/packages/bundler-plugin-core/src/index.ts
+++ b/packages/bundler-plugin-core/src/index.ts
@@ -319,7 +319,11 @@ export function sentryUnpluginFactory({
       const injectionCode = generateModuleMetadataInjectorCode(metadata);
       plugins.push(moduleMetadataInjectionPlugin(injectionCode));
     }
-
+    // https://turbo.build/repo/docs/reference/system-environment-variables#environment-variables-in-tasks
+    const isRunningInTurboRepo = Boolean(process.env["TURBO_HASH"]);
+    const TUROBOREPO_PASSTHROUGH_TOKEN_MSG = isRunningInTurboRepo
+      ? "\nYou seem to be using Truborepo, did you forget to put `SENTRY_AUTH_TOKEN` in `passThroughEnv`? https://turbo.build/repo/docs/reference/configuration#passthroughenv"
+      : "";
     if (!options.release.name) {
       logger.debug(
         "No release name provided. Will not create release. Please set the `release.name` option to identify your release."
@@ -328,7 +332,8 @@ export function sentryUnpluginFactory({
       logger.debug("Running in development mode. Will not create release.");
     } else if (!options.authToken) {
       logger.warn(
-        "No auth token provided. Will not create release. Please set the `authToken` option. You can find information on how to generate a Sentry auth token here: https://docs.sentry.io/api/auth/"
+        "No auth token provided. Will not create release. Please set the `authToken` option. You can find information on how to generate a Sentry auth token here: https://docs.sentry.io/api/auth/" +
+          TUROBOREPO_PASSTHROUGH_TOKEN_MSG
       );
     } else if (!options.org && !options.authToken.startsWith("sntrys_")) {
       logger.warn(
@@ -378,7 +383,8 @@ export function sentryUnpluginFactory({
       logger.debug("Running in development mode. Will not upload sourcemaps.");
     } else if (!options.authToken) {
       logger.warn(
-        "No auth token provided. Will not upload source maps. Please set the `authToken` option. You can find information on how to generate a Sentry auth token here: https://docs.sentry.io/api/auth/"
+        "No auth token provided. Will not upload source maps. Please set the `authToken` option. You can find information on how to generate a Sentry auth token here: https://docs.sentry.io/api/auth/" +
+          TUROBOREPO_PASSTHROUGH_TOKEN_MSG
       );
     } else if (!options.org && !options.authToken.startsWith("sntrys_")) {
       logger.warn(

--- a/packages/bundler-plugin-core/src/index.ts
+++ b/packages/bundler-plugin-core/src/index.ts
@@ -321,9 +321,10 @@ export function sentryUnpluginFactory({
     }
     // https://turbo.build/repo/docs/reference/system-environment-variables#environment-variables-in-tasks
     const isRunningInTurboRepo = Boolean(process.env["TURBO_HASH"]);
-    const TUROBOREPO_PASSTHROUGH_TOKEN_MSG = isRunningInTurboRepo
-      ? "\nYou seem to be using Truborepo, did you forget to put `SENTRY_AUTH_TOKEN` in `passThroughEnv`? https://turbo.build/repo/docs/reference/configuration#passthroughenv"
-      : "";
+    const getTruboRepoEnvPassthroughWarning = (envVarName: string) =>
+      isRunningInTurboRepo
+        ? `\nYou seem to be using Truborepo, did you forget to put ${envVarName} in \`passThroughEnv\`? https://turbo.build/repo/docs/reference/configuration#passthroughenv`
+        : "";
     if (!options.release.name) {
       logger.debug(
         "No release name provided. Will not create release. Please set the `release.name` option to identify your release."
@@ -333,15 +334,17 @@ export function sentryUnpluginFactory({
     } else if (!options.authToken) {
       logger.warn(
         "No auth token provided. Will not create release. Please set the `authToken` option. You can find information on how to generate a Sentry auth token here: https://docs.sentry.io/api/auth/" +
-          TUROBOREPO_PASSTHROUGH_TOKEN_MSG
+          getTruboRepoEnvPassthroughWarning("SENTRY_AUTH_TOKEN")
       );
     } else if (!options.org && !options.authToken.startsWith("sntrys_")) {
       logger.warn(
-        "No organization slug provided. Will not create release. Please set the `org` option to your Sentry organization slug."
+        "No organization slug provided. Will not create release. Please set the `org` option to your Sentry organization slug." +
+          getTruboRepoEnvPassthroughWarning("SENTRY_ORG")
       );
     } else if (!options.project) {
       logger.warn(
-        "No project provided. Will not create release. Please set the `project` option to your Sentry project slug."
+        "No project provided. Will not create release. Please set the `project` option to your Sentry project slug." +
+          getTruboRepoEnvPassthroughWarning("SENTRY_PROJECT")
       );
     } else {
       plugins.push(
@@ -384,7 +387,7 @@ export function sentryUnpluginFactory({
     } else if (!options.authToken) {
       logger.warn(
         "No auth token provided. Will not upload source maps. Please set the `authToken` option. You can find information on how to generate a Sentry auth token here: https://docs.sentry.io/api/auth/" +
-          TUROBOREPO_PASSTHROUGH_TOKEN_MSG
+          getTruboRepoEnvPassthroughWarning
       );
     } else if (!options.org && !options.authToken.startsWith("sntrys_")) {
       logger.warn(

--- a/packages/bundler-plugin-core/src/index.ts
+++ b/packages/bundler-plugin-core/src/index.ts
@@ -391,11 +391,13 @@ export function sentryUnpluginFactory({
       );
     } else if (!options.org && !options.authToken.startsWith("sntrys_")) {
       logger.warn(
-        "No org provided. Will not upload source maps. Please set the `org` option to your Sentry organization slug."
+        "No org provided. Will not upload source maps. Please set the `org` option to your Sentry organization slug." +
+          getTruboRepoEnvPassthroughWarning("SENTRY_ORG")
       );
     } else if (!options.project) {
       logger.warn(
-        "No project provided. Will not upload source maps. Please set the `project` option to your Sentry project slug."
+        "No project provided. Will not upload source maps. Please set the `project` option to your Sentry project slug." +
+          getTruboRepoEnvPassthroughWarning("SENTRY_PROJECT")
       );
     } else {
       // This option is only strongly typed for the webpack plugin, where it is used. It has no effect on other plugins

--- a/packages/bundler-plugin-core/src/index.ts
+++ b/packages/bundler-plugin-core/src/index.ts
@@ -387,7 +387,7 @@ export function sentryUnpluginFactory({
     } else if (!options.authToken) {
       logger.warn(
         "No auth token provided. Will not upload source maps. Please set the `authToken` option. You can find information on how to generate a Sentry auth token here: https://docs.sentry.io/api/auth/" +
-          getTruboRepoEnvPassthroughWarning
+          getTruboRepoEnvPassthroughWarning("SENTRY_AUTH_TOKEN")
       );
     } else if (!options.org && !options.authToken.startsWith("sntrys_")) {
       logger.warn(


### PR DESCRIPTION

closes #674