### PR TITLE
feat(core): Accept and await a promise in `sourcemaps.filesToDeleteAfterUpload`

### DIFF
--- a/packages/bundler-plugin-core/src/plugins/sourcemap-deletion.ts
+++ b/packages/bundler-plugin-core/src/plugins/sourcemap-deletion.ts
@@ -11,7 +11,7 @@ interface FileDeletionPlugin {
   waitUntilSourcemapFileDependenciesAreFreed: () => Promise<void>;
   sentryScope: Scope;
   sentryClient: Client;
-  filesToDeleteAfterUpload: string | string[] | Promise<string | string[]> | undefined;
+  filesToDeleteAfterUpload: string | string[] | Promise<string | string[] | undefined> | undefined;
   logger: Logger;
 }
 
@@ -27,9 +27,8 @@ export function fileDeletionPlugin({
     name: "sentry-file-deletion-plugin",
     async writeBundle() {
       try {
-        if (filesToDeleteAfterUpload !== undefined) {
-          const filesToDelete = await filesToDeleteAfterUpload;
-
+        const filesToDelete = await filesToDeleteAfterUpload;
+        if (filesToDelete !== undefined) {
           const filePathsToDelete = await glob(filesToDelete, {
             absolute: true,
             nodir: true,

--- a/packages/bundler-plugin-core/src/plugins/sourcemap-deletion.ts
+++ b/packages/bundler-plugin-core/src/plugins/sourcemap-deletion.ts
@@ -11,7 +11,7 @@ interface FileDeletionPlugin {
   waitUntilSourcemapFileDependenciesAreFreed: () => Promise<void>;
   sentryScope: Scope;
   sentryClient: Client;
-  filesToDeleteAfterUpload: string | string[] | undefined;
+  filesToDeleteAfterUpload: string | string[] | Promise<string | string[]> | undefined;
   logger: Logger;
 }
 
@@ -28,7 +28,9 @@ export function fileDeletionPlugin({
     async writeBundle() {
       try {
         if (filesToDeleteAfterUpload !== undefined) {
-          const filePathsToDelete = await glob(filesToDeleteAfterUpload, {
+          const filesToDelete = await filesToDeleteAfterUpload;
+
+          const filePathsToDelete = await glob(filesToDelete, {
             absolute: true,
             nodir: true,
           });

--- a/packages/bundler-plugin-core/src/types.ts
+++ b/packages/bundler-plugin-core/src/types.ts
@@ -132,9 +132,13 @@ export interface Options {
      *
      * The globbing patterns follow the implementation of the `glob` package. (https://www.npmjs.com/package/glob)
      *
+     * Note: If you pass in a promise that resolves to a string or array, the plugin will await the promise and use
+     * the resolved value globs. This is useful if you need to dynamically determine the files to delete. Some
+     * higher-level Sentry SDKs or options use this feature (e.g. SvelteKit).
+     *
      * Use the `debug` option to print information about which files end up being deleted.
      */
-    filesToDeleteAfterUpload?: string | string[];
+    filesToDeleteAfterUpload?: string | string[] | Promise<string | string[]>;
   };
 
   /**

--- a/packages/bundler-plugin-core/src/types.ts
+++ b/packages/bundler-plugin-core/src/types.ts
@@ -138,7 +138,7 @@ export interface Options {
      *
      * Use the `debug` option to print information about which files end up being deleted.
      */
-    filesToDeleteAfterUpload?: string | string[] | Promise<string | string[]>;
+    filesToDeleteAfterUpload?: string | string[] | Promise<string | string[] | undefined>;
   };
 
   /**

--- a/packages/dev-utils/src/generate-documentation-table.ts
+++ b/packages/dev-utils/src/generate-documentation-table.ts
@@ -98,9 +98,9 @@ errorHandler: (err) => {
       },
       {
         name: "filesToDeleteAfterUpload",
-        type: "string | string[]",
+        type: "string | string[] | Promise<string | string[]>",
         fullDescription:
-          "A glob or an array of globs that specifies the build artifacts that should be deleted after the artifact upload to Sentry has been completed.\n\nThe globbing patterns follow the implementation of the `glob` package. (https://www.npmjs.com/package/glob)\n\nUse the `debug` option to print information about which files end up being deleted.",
+          "A glob, an array of globs or a promise resolving a glob or array of globs that specifies the build artifacts that should be deleted after the artifact upload to Sentry has been completed.\n\nThe globbing patterns follow the implementation of the `glob` package. (https://www.npmjs.com/package/glob)\n\nUse the `debug` option to print information about which files end up being deleted.",
       },
       {
         name: "disable",

--- a/packages/integration-tests/fixtures/after-upload-deletion-promise/after-upload-deletion.test.ts
+++ b/packages/integration-tests/fixtures/after-upload-deletion-promise/after-upload-deletion.test.ts
@@ -1,0 +1,27 @@
+/* eslint-disable jest/no-standalone-expect */
+/* eslint-disable jest/expect-expect */
+import path from "path";
+import fs from "fs";
+import { testIfNodeMajorVersionIsLessThan18 } from "../../utils/testIf";
+
+describe("Deletes files with `filesToDeleteAfterUpload` set to a promise", () => {
+  testIfNodeMajorVersionIsLessThan18("webpack 4 bundle", () => {
+    expect(fs.existsSync(path.join(__dirname, "out", "webpack4", "bundle.js.map"))).toBe(false);
+  });
+
+  test("webpack 5 bundle", () => {
+    expect(fs.existsSync(path.join(__dirname, "out", "webpack5", "bundle.js.map"))).toBe(false);
+  });
+
+  test("esbuild bundle", () => {
+    expect(fs.existsSync(path.join(__dirname, "out", "esbuild", "bundle.js.map"))).toBe(false);
+  });
+
+  test("rollup bundle", () => {
+    expect(fs.existsSync(path.join(__dirname, "out", "rollup", "bundle.js.map"))).toBe(false);
+  });
+
+  test("vite bundle", () => {
+    expect(fs.existsSync(path.join(__dirname, "out", "vite", "bundle.js.map"))).toBe(false);
+  });
+});

--- a/packages/integration-tests/fixtures/after-upload-deletion-promise/input/bundle.js
+++ b/packages/integration-tests/fixtures/after-upload-deletion-promise/input/bundle.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line no-console
+console.log("whatever");

--- a/packages/integration-tests/fixtures/after-upload-deletion-promise/setup.ts
+++ b/packages/integration-tests/fixtures/after-upload-deletion-promise/setup.ts
@@ -1,0 +1,25 @@
+import * as path from "path";
+import { createCjsBundles } from "../../utils/create-cjs-bundles";
+
+const outputDir = path.resolve(__dirname, "out");
+
+["webpack4", "webpack5", "esbuild", "rollup", "vite"].forEach((bundler) => {
+  const fileDeletionGlobPromise = new Promise<string[]>((resolve) => {
+    setTimeout(() => {
+      resolve([path.join(__dirname, "out", bundler, "bundle.js.map")]);
+    }, 1000);
+  });
+
+  createCjsBundles(
+    {
+      bundle: path.resolve(__dirname, "input", "bundle.js"),
+    },
+    outputDir,
+    {
+      sourcemaps: {
+        filesToDeleteAfterUpload: fileDeletionGlobPromise,
+      },
+    },
+    [bundler]
+  );
+});


### PR DESCRIPTION
Some framework SDKs require us to lazily set a "fallback" `filesToDeleteAfterSourcemaps` option that we don't yet know at plugin creation time. This PR widens the accepted type for `filesToDeleteAfterSourcemaps` to also allow us (as well as users) to pass in a `Promise<string | string[]>` to do so. This promise can resolve whenever we know what to set.

Necessary for SvelteKit 

ref https://github.com/getsentry/sentry-javascript/issues/15414