### PR TITLE
docs: Add react component name to feature list

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The Sentry Bundler Plugins take care of Sentry-related tasks at build time of yo
 - Release creation in Sentry
 - Automatic release name discovery (based on CI environment - Vercel, AWS, Heroku, CircleCI, or current Git SHA)
 - Automatically associate errors with releases (Release injection)
+- [React component names instead of selectors.](https://docs.sentry.io/platforms/javascript/guides/react/features/component-names/)
 
 ### More information
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The Sentry Bundler Plugins take care of Sentry-related tasks at build time of yo
 - Release creation in Sentry
 - Automatic release name discovery (based on CI environment - Vercel, AWS, Heroku, CircleCI, or current Git SHA)
 - Automatically associate errors with releases (Release injection)
-- [React component names instead of selectors.](https://docs.sentry.io/platforms/javascript/guides/react/features/component-names/)
+- [Show React component display names for breadcrumbs and Session Replays.](https://docs.sentry.io/platforms/javascript/guides/react/features/component-names/)
 
 ### More information
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The Sentry Bundler Plugins take care of Sentry-related tasks at build time of yo
 - Release creation in Sentry
 - Automatic release name discovery (based on CI environment - Vercel, AWS, Heroku, CircleCI, or current Git SHA)
 - Automatically associate errors with releases (Release injection)
-- [Show React component display names for breadcrumbs and Session Replays.](https://docs.sentry.io/platforms/javascript/guides/react/features/component-names/)
+- [Show React component display names for breadcrumbs and Session Replays](https://docs.sentry.io/platforms/javascript/guides/react/features/component-names/)
 
 ### More information
 


### PR DESCRIPTION
The docs for RCN point to this plugin, so adding that functionality to the list of features