### PR TITLE
feat: Ignore `Fragment` components by default for react component annotation

### DIFF
--- a/packages/babel-plugin-component-annotate/src/index.ts
+++ b/packages/babel-plugin-component-annotate/src/index.ts
@@ -57,6 +57,8 @@ interface AnnotationPluginPass extends PluginPass {
 
 type AnnotationPlugin = PluginObj<AnnotationPluginPass>;
 
+const DEFAULT_IGNORED_REACT_COMPONENTS = ["Fragment"];
+
 // We must export the plugin as default, otherwise the Babel loader will not be able to resolve it when configured using its string identifier
 export default function componentNameAnnotatePlugin({ types: t }: typeof Babel): AnnotationPlugin {
   return {
@@ -69,6 +71,13 @@ export default function componentNameAnnotatePlugin({ types: t }: typeof Babel):
           return;
         }
 
+        const ignoredComponents = [
+          ...new Set([
+            ...(state.opts.ignoredComponents ?? []),
+            ...DEFAULT_IGNORED_REACT_COMPONENTS,
+          ]),
+        ];
+
         functionBodyPushAttributes(
           state.opts["annotate-fragments"] === true,
           t,
@@ -76,7 +85,7 @@ export default function componentNameAnnotatePlugin({ types: t }: typeof Babel):
           path.node.id.name,
           sourceFileNameFromState(state),
           attributeNamesFromState(state),
-          state.opts.ignoredComponents ?? []
+          ignoredComponents
         );
       },
       ArrowFunctionExpression(path, state) {
@@ -97,6 +106,13 @@ export default function componentNameAnnotatePlugin({ types: t }: typeof Babel):
           return;
         }
 
+        const ignoredComponents = [
+          ...new Set([
+            ...(state.opts.ignoredComponents ?? []),
+            ...DEFAULT_IGNORED_REACT_COMPONENTS,
+          ]),
+        ];
+
         functionBodyPushAttributes(
           state.opts["annotate-fragments"] === true,
           t,
@@ -104,7 +120,7 @@ export default function componentNameAnnotatePlugin({ types: t }: typeof Babel):
           parent.id.name,
           sourceFileNameFromState(state),
           attributeNamesFromState(state),
-          state.opts.ignoredComponents ?? []
+          ignoredComponents
         );
       },
       ClassDeclaration(path, state) {
@@ -118,7 +134,12 @@ export default function componentNameAnnotatePlugin({ types: t }: typeof Babel):
           return;
         }
 
-        const ignoredComponents = state.opts.ignoredComponents ?? [];
+        const ignoredComponents = [
+          ...new Set([
+            ...(state.opts.ignoredComponents ?? []),
+            ...DEFAULT_IGNORED_REACT_COMPONENTS,
+          ]),
+        ];
 
         render.traverse({
           ReturnStatement(returnStatement) {

--- a/packages/babel-plugin-component-annotate/src/tsconfig.json
+++ b/packages/babel-plugin-component-annotate/src/tsconfig.json
@@ -3,6 +3,7 @@
   "extends": "@sentry-internal/sentry-bundler-plugin-tsconfig/base-config.json",
   "include": ["./**/*", "../package.json"],
   "compilerOptions": {
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "target": "ES2020" // es2020 needed for "new Set()"
   }
 }

--- a/packages/bundler-plugin-core/src/index.ts
+++ b/packages/bundler-plugin-core/src/index.ts
@@ -438,7 +438,7 @@ export function sentryUnpluginFactory({
     if (options.reactComponentAnnotation) {
       if (!options.reactComponentAnnotation.enabled) {
         logger.debug(
-          "The component name annotate plugin is currently disabled. Skipping component name annotations."
+          "The component name annotate plugin is disabled. Skipping component name annotations."
         );
       } else if (options.reactComponentAnnotation.enabled && !componentNameAnnotatePlugin) {
         logger.warn(

--- a/packages/bundler-plugin-core/src/options-mapping.ts
+++ b/packages/bundler-plugin-core/src/options-mapping.ts
@@ -6,6 +6,8 @@ export type NormalizedOptions = ReturnType<typeof normalizeUserOptions>;
 
 export const SENTRY_SAAS_URL = "https://sentry.io";
 
+const DEFAULT_IGNORED_REACT_COMPONENTS = ["Fragment"];
+
 export function normalizeUserOptions(userOptions: UserOptions) {
   const options = {
     org: userOptions.org ?? process.env["SENTRY_ORG"],
@@ -28,7 +30,17 @@ export function normalizeUserOptions(userOptions: UserOptions) {
       vcsRemote: userOptions.release?.vcsRemote ?? process.env["SENTRY_VSC_REMOTE"] ?? "origin",
     },
     bundleSizeOptimizations: userOptions.bundleSizeOptimizations,
-    reactComponentAnnotation: userOptions.reactComponentAnnotation,
+    reactComponentAnnotation: userOptions.reactComponentAnnotation
+      ? {
+          enabled: userOptions.reactComponentAnnotation?.enabled ?? false,
+          ignoredComponents: [
+            ...new Set([
+              ...(userOptions.reactComponentAnnotation?.ignoredComponents ?? []),
+              ...DEFAULT_IGNORED_REACT_COMPONENTS,
+            ]),
+          ],
+        }
+      : undefined,
     _metaOptions: {
       telemetry: {
         metaFramework: userOptions._metaOptions?.telemetry?.metaFramework,

--- a/packages/bundler-plugin-core/src/options-mapping.ts
+++ b/packages/bundler-plugin-core/src/options-mapping.ts
@@ -6,8 +6,6 @@ export type NormalizedOptions = ReturnType<typeof normalizeUserOptions>;
 
 export const SENTRY_SAAS_URL = "https://sentry.io";
 
-const DEFAULT_IGNORED_REACT_COMPONENTS = ["Fragment"];
-
 export function normalizeUserOptions(userOptions: UserOptions) {
   const options = {
     org: userOptions.org ?? process.env["SENTRY_ORG"],
@@ -30,17 +28,7 @@ export function normalizeUserOptions(userOptions: UserOptions) {
       vcsRemote: userOptions.release?.vcsRemote ?? process.env["SENTRY_VSC_REMOTE"] ?? "origin",
     },
     bundleSizeOptimizations: userOptions.bundleSizeOptimizations,
-    reactComponentAnnotation: userOptions.reactComponentAnnotation
-      ? {
-          enabled: userOptions.reactComponentAnnotation?.enabled ?? false,
-          ignoredComponents: [
-            ...new Set([
-              ...(userOptions.reactComponentAnnotation?.ignoredComponents ?? []),
-              ...DEFAULT_IGNORED_REACT_COMPONENTS,
-            ]),
-          ],
-        }
-      : undefined,
+    reactComponentAnnotation: userOptions.reactComponentAnnotation,
     _metaOptions: {
       telemetry: {
         metaFramework: userOptions._metaOptions?.telemetry?.metaFramework,


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript-bundler-plugins/issues/686

I think there are like 0 cases where we would actually want to annotate fragments as they do not manifest in dom elements in any case.