### PR TITLE
feat: Default to automatically setting commits on release

### DIFF
--- a/packages/bundler-plugin-core/src/index.ts
+++ b/packages/bundler-plugin-core/src/index.ts
@@ -370,7 +370,9 @@ export function sentryUnpluginFactory({
           shouldCreateRelease: options.release.create,
           shouldFinalizeRelease: options.release.finalize,
           include: options.release.uploadLegacySourcemaps,
-          setCommitsOption: options.release.setCommits,
+          // setCommits has a default defined by the options mappings
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          setCommitsOption: options.release.setCommits!,
           deployOptions: options.release.deploy,
           dist: options.release.dist,
           handleRecoverableError: handleRecoverableError,

--- a/packages/bundler-plugin-core/src/options-mapping.ts
+++ b/packages/bundler-plugin-core/src/options-mapping.ts
@@ -26,11 +26,7 @@ export function normalizeUserOptions(userOptions: UserOptions) {
       create: userOptions.release?.create ?? true,
       finalize: userOptions.release?.finalize ?? true,
       vcsRemote: userOptions.release?.vcsRemote ?? process.env["SENTRY_VSC_REMOTE"] ?? "origin",
-      setCommits: userOptions.release?.setCommits ?? {
-        auto: true,
-        isDefault: true,
-        repo: undefined, // Just to please type narrowing
-      },
+      setCommits: userOptions.release?.setCommits,
     },
     bundleSizeOptimizations: userOptions.bundleSizeOptimizations,
     reactComponentAnnotation: userOptions.reactComponentAnnotation,
@@ -43,6 +39,14 @@ export function normalizeUserOptions(userOptions: UserOptions) {
     moduleMetadata: userOptions.moduleMetadata,
     _experiments: userOptions._experiments ?? {},
   };
+
+  if (options.release.setCommits === undefined) {
+    options.release.setCommits = {
+      // @ts-expect-error This is fine
+      auto: true,
+      isDefault: true,
+    };
+  }
 
   return options;
 }

--- a/packages/bundler-plugin-core/src/options-mapping.ts
+++ b/packages/bundler-plugin-core/src/options-mapping.ts
@@ -26,6 +26,11 @@ export function normalizeUserOptions(userOptions: UserOptions) {
       create: userOptions.release?.create ?? true,
       finalize: userOptions.release?.finalize ?? true,
       vcsRemote: userOptions.release?.vcsRemote ?? process.env["SENTRY_VSC_REMOTE"] ?? "origin",
+      setCommits: userOptions.release?.setCommits ?? {
+        auto: true,
+        isDefault: true,
+        repo: undefined, // Just to please type narrowing
+      },
     },
     bundleSizeOptimizations: userOptions.bundleSizeOptimizations,
     reactComponentAnnotation: userOptions.reactComponentAnnotation,

--- a/packages/bundler-plugin-core/src/plugins/release-management.ts
+++ b/packages/bundler-plugin-core/src/plugins/release-management.ts
@@ -96,7 +96,7 @@ export function releaseManagementPlugin({
               throw e;
             } else {
               logger.debug(
-                "An error occurred setting commits on release (this message can be ignored unless you commits on release are desired):",
+                "An error occurred setting commits on release (this message can be ignored unless your commits on release are desired):",
                 e
               );
             }

--- a/packages/bundler-plugin-core/src/types.ts
+++ b/packages/bundler-plugin-core/src/types.ts
@@ -200,8 +200,10 @@ export interface Options {
 
     /**
      * Associates the release with its commits in Sentry.
+     *
+     * Defaults to `{ auto: true }`. Set to `false` to disable commit association.
      */
-    setCommits?: SetCommitsOptions;
+    setCommits?: SetCommitsOptions | false;
 
     /**
      * Adds deployment information to the release in Sentry.

--- a/packages/bundler-plugin-core/test/option-mappings.test.ts
+++ b/packages/bundler-plugin-core/test/option-mappings.test.ts
@@ -23,6 +23,10 @@ describe("normalizeUserOptions()", () => {
         create: true,
         vcsRemote: "origin",
         uploadLegacySourcemaps: "./out",
+        setCommits: {
+          auto: true,
+          isDefault: true,
+        },
       },
       silent: false,
       telemetry: true,
@@ -73,6 +77,10 @@ describe("normalizeUserOptions()", () => {
           rewrite: true,
           sourceMapReference: false,
           stripCommonPrefix: true,
+        },
+        setCommits: {
+          auto: true,
+          isDefault: true,
         },
       },
       silent: false,

--- a/packages/dev-utils/src/generate-documentation-table.ts
+++ b/packages/dev-utils/src/generate-documentation-table.ts
@@ -154,7 +154,8 @@ errorHandler: (err) => {
       },
       {
         name: "setCommits",
-        fullDescription: "Option to associate the created release with its commits in Sentry.",
+        fullDescription:
+          "Option to associate the created release with its commits in Sentry. Defaults to `{ auto: true }`. Set to `false` to disable.",
         children: [
           {
             name: "previousCommit",

--- a/packages/integration-tests/fixtures/telemetry/telemetry.test.ts
+++ b/packages/integration-tests/fixtures/telemetry/telemetry.test.ts
@@ -101,7 +101,7 @@ test("rollup bundle telemetry", async () => {
               "upload-legacy-sourcemaps": false,
               "module-metadata": false,
               "inject-build-information": false,
-              "set-commits": "undefined",
+              "set-commits": "auto",
               "finalize-release": true,
               "deploy-options": false,
               "custom-error-handler": false,


### PR DESCRIPTION
It's just way better UX if we default to automatically setting commits on releases if Sentry CLI is able to detect them.

We just have to jump through some hoops to not throw by default but throw if people manually configured stuff.