### PR TITLE
fix: Fix file detection when uploading files with debug IDs

### DIFF
--- a/packages/bundler-plugin-core/src/debug-id-upload.ts
+++ b/packages/bundler-plugin-core/src/debug-id-upload.ts
@@ -172,9 +172,10 @@ export function createDebugIdUploadFunction({
                     {
                       include: [
                         {
-                          paths: [tmpUploadFolder],
+                          paths: [path.join(tmpUploadFolder, "**")],
                           rewrite: false,
                           dist: dist,
+                          stripCommonPrefix: false,
                         },
                       ],
                     }


### PR DESCRIPTION
Sentry CLI didn't upload recursively all folders when we changed to unflatten files in #700.