### PR TITLE
fix(webpack5): Ensure all `esm` files have `.mjs` postfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - "You know what they say ‘Fool me once, strike one, but fool me twice… strike three.’" — Michael Scott
 
+## 3.3.1
+
+- fix(webpack5): All `esm` files must have `.mjs` postfix (#721)
+
 ## 3.3.0
 
 - feat(webpack): Add `@sentry/webpack-plugin/webpack5` export for webpack 5.1+ and compatible environments (#715)

--- a/packages/webpack-plugin/rollup.config.js
+++ b/packages/webpack-plugin/rollup.config.js
@@ -45,6 +45,8 @@ export default {
       format: "cjs",
       exports: "named",
       sourcemap: true,
+      entryFileNames: "[name].js",
+      chunkFileNames: "[name].js",
     },
   ],
 };

--- a/packages/webpack-plugin/rollup.config.js
+++ b/packages/webpack-plugin/rollup.config.js
@@ -38,6 +38,7 @@ export default {
       exports: "named",
       sourcemap: true,
       entryFileNames: "[name].mjs",
+      chunkFileNames: "[name].mjs",
     },
     {
       dir: "./dist/cjs",


### PR DESCRIPTION
Before:
<img width="287" alt="Screenshot 2025-04-04 at 10 33 38" src="https://github.com/user-attachments/assets/38809c39-fb01-4f9a-85e0-41edc2a3b885" />


After:
<img width="242" alt="Screenshot 2025-04-04 at 10 32 51" src="https://github.com/user-attachments/assets/cbc1c55b-7080-4402-8355-15d2fd72c8b7" />
