### PR TITLE
chore: Add changelog generation script

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "build:watch": "nx run-many --target=build:watch --all",
     "build:graph": "nx graph",
     "build:npm": "nx run-many --target=build:npm --all",
+    "changelog": "ts-node ./scripts/get-commit-list.ts",
     "check:types": "nx run-many --target=check:types --all",
     "clean": "nx run-many --target=clean --all",
     "clean:all": "nx run-many --target=clean:all --all && yarn",
@@ -32,7 +33,8 @@
     "nx": "14.5.10",
     "prettier": "^2.7.1",
     "pretty-quick": "^3.1.3",
-    "npm-run-all": "^4.1.5"
+    "npm-run-all": "^4.1.5",
+    "ts-node": "^10.9.2"
   },
   "volta": {
     "node": "14.21.2",

--- a/scripts/get-commit-list.ts
+++ b/scripts/get-commit-list.ts
@@ -1,0 +1,36 @@
+import { execSync } from "child_process";
+
+function run(): void {
+  const commits = execSync('git log --format="- %s"').toString().split("\n");
+
+  const lastReleasePos = commits.findIndex((commit) => /- meta(.*)changelog/i.test(commit));
+
+  const newCommits = commits.splice(0, lastReleasePos).filter((commit) => {
+    // Filter out merge commits
+    if (/Merge pull request/.test(commit)) {
+      return false;
+    }
+    // Filter release branch merged
+    if (/Merge branch/.test(commit)) {
+      return false;
+    }
+    // Filter release commit itself
+    if (/release:/.test(commit)) {
+      return false;
+    }
+
+    return true;
+  });
+
+  newCommits.sort((a, b) => a.localeCompare(b));
+
+  const issueUrl = "https://github.com/getsentry/sentry-javascript-bundler-plugins/pull/";
+  const newCommitsWithLink = newCommits.map((commit) =>
+    commit.replace(/#(\d+)/, `[#$1](${issueUrl}$1)`)
+  );
+
+  // eslint-disable-next-line no-console
+  console.log(newCommitsWithLink.join("\n"));
+}
+
+run();

--- a/yarn.lock
+++ b/yarn.lock
@@ -11500,6 +11500,13 @@ rollup@2.77.0:
   optionalDependencies:
     fsevents "~2.3.2"
 
+rollup@2.79.2:
+  version "2.79.2"
+  resolved "https://registry.npmjs.org/rollup/-/rollup-2.79.2.tgz#f150e4a5db4b121a21a747d762f701e5e9f49090"
+  integrity sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==
+  optionalDependencies:
+    fsevents "~2.3.2"
+
 rollup@3.2.0:
   version "3.2.0"
   resolved "https://registry.npmjs.org/rollup/-/rollup-3.2.0.tgz#a6f44074418e55217967c8eca622f9638d396388"
@@ -12502,6 +12509,25 @@ ts-node@^10.9.1:
   version "10.9.1"
   resolved "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz#e73de9102958af9e1f0b168a6ff320e25adcff4b"
   integrity sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==
+  dependencies:
+    "@cspotcode/source-map-support" "^0.8.0"
+    "@tsconfig/node10" "^1.0.7"
+    "@tsconfig/node12" "^1.0.7"
+    "@tsconfig/node14" "^1.0.0"
+    "@tsconfig/node16" "^1.0.2"
+    acorn "^8.4.1"
+    acorn-walk "^8.1.1"
+    arg "^4.1.0"
+    create-require "^1.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    v8-compile-cache-lib "^3.0.1"
+    yn "3.1.1"
+
+ts-node@^10.9.2:
+  version "10.9.2"
+  resolved "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz#70f021c9e185bccdca820e26dc413805c101c71f"
+  integrity sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==
   dependencies:
     "@cspotcode/source-map-support" "^0.8.0"
     "@tsconfig/node10" "^1.0.7"


### PR DESCRIPTION
Adds the same `yarn changelog` script as in the `sentry-javascript` repo to extract a pre-formatted commit list we can easily insert into our CHANGELOG entries. Trialed in #743  