### PR TITLE
fix(core): Avoid showing success message if upload was disabled or nothing was uploaded

### DIFF
--- a/packages/bundler-plugin-core/src/build-plugin-manager.ts
+++ b/packages/bundler-plugin-core/src/build-plugin-manager.ts
@@ -728,22 +728,26 @@ function canUploadSourceMaps(
       "Source map upload was disabled. Will not upload sourcemaps using debug ID process."
     );
     return false;
-  } else if (isDevMode) {
+  }
+  if (isDevMode) {
     logger.debug("Running in development mode. Will not upload sourcemaps.");
     return false;
-  } else if (!options.authToken) {
+  }
+  if (!options.authToken) {
     logger.warn(
       "No auth token provided. Will not upload source maps. Please set the `authToken` option. You can find information on how to generate a Sentry auth token here: https://docs.sentry.io/api/auth/" +
         getTurborepoEnvPassthroughWarning("SENTRY_AUTH_TOKEN")
     );
     return false;
-  } else if (!options.org && !options.authToken.startsWith("sntrys_")) {
+  }
+  if (!options.org && !options.authToken.startsWith("sntrys_")) {
     logger.warn(
       "No org provided. Will not upload source maps. Please set the `org` option to your Sentry organization slug." +
         getTurborepoEnvPassthroughWarning("SENTRY_ORG")
     );
     return false;
-  } else if (!options.project) {
+  }
+  if (!options.project) {
     logger.warn(
       "No project provided. Will not upload source maps. Please set the `project` option to your Sentry project slug." +
         getTurborepoEnvPassthroughWarning("SENTRY_PROJECT")

--- a/packages/bundler-plugin-core/src/build-plugin-manager.ts
+++ b/packages/bundler-plugin-core/src/build-plugin-manager.ts
@@ -503,27 +503,8 @@ export function createSentryBuildPluginManager(
      * Uploads sourcemaps using the "Debug ID" method. This function takes a list of build artifact paths that will be uploaded
      */
     async uploadSourcemaps(buildArtifactPaths: string[]) {
-      if (options.sourcemaps?.disable) {
-        logger.debug(
-          "Source map upload was disabled. Will not upload sourcemaps using debug ID process."
-        );
-      } else if (isDevMode) {
-        logger.debug("Running in development mode. Will not upload sourcemaps.");
-      } else if (!options.authToken) {
-        logger.warn(
-          "No auth token provided. Will not upload source maps. Please set the `authToken` option. You can find information on how to generate a Sentry auth token here: https://docs.sentry.io/api/auth/" +
-            getTurborepoEnvPassthroughWarning("SENTRY_AUTH_TOKEN")
-        );
-      } else if (!options.org && !options.authToken.startsWith("sntrys_")) {
-        logger.warn(
-          "No org provided. Will not upload source maps. Please set the `org` option to your Sentry organization slug." +
-            getTurborepoEnvPassthroughWarning("SENTRY_ORG")
-        );
-      } else if (!options.project) {
-        logger.warn(
-          "No project provided. Will not upload source maps. Please set the `project` option to your Sentry project slug." +
-            getTurborepoEnvPassthroughWarning("SENTRY_PROJECT")
-        );
+      if (!canUploadSourceMaps(options, logger, isDevMode)) {
+        return;
       }
 
       await startSpan(
@@ -589,7 +570,7 @@ export function createSentryBuildPluginManager(
                 "Didn't find any matching sources for debug ID upload. Please check the `sourcemaps.assets` option."
               );
             } else {
-              await startSpan(
+              const numUploadedFiles = await startSpan(
                 { name: "prepare-bundles", scope: sentryScope },
                 async (prepBundlesSpan) => {
                   // Preparing the bundles can be a lot of work and doing it all at once has the potential of nuking the heap so
@@ -664,10 +645,14 @@ export function createSentryBuildPluginManager(
                       }
                     );
                   });
+
+                  return files.length;
                 }
               );
 
-              logger.info("Successfully uploaded source maps to Sentry");
+              if (numUploadedFiles > 0) {
+                logger.info("Successfully uploaded source maps to Sentry");
+              }
             }
           } catch (e) {
             sentryScope.captureException('Error in "debugIdUploadPlugin" writeBundle hook');
@@ -731,4 +716,40 @@ export function createSentryBuildPluginManager(
     },
     createDependencyOnBuildArtifacts,
   };
+}
+
+function canUploadSourceMaps(
+  options: NormalizedOptions,
+  logger: Logger,
+  isDevMode: boolean
+): boolean {
+  if (options.sourcemaps?.disable) {
+    logger.debug(
+      "Source map upload was disabled. Will not upload sourcemaps using debug ID process."
+    );
+    return false;
+  } else if (isDevMode) {
+    logger.debug("Running in development mode. Will not upload sourcemaps.");
+    return false;
+  } else if (!options.authToken) {
+    logger.warn(
+      "No auth token provided. Will not upload source maps. Please set the `authToken` option. You can find information on how to generate a Sentry auth token here: https://docs.sentry.io/api/auth/" +
+        getTurborepoEnvPassthroughWarning("SENTRY_AUTH_TOKEN")
+    );
+    return false;
+  } else if (!options.org && !options.authToken.startsWith("sntrys_")) {
+    logger.warn(
+      "No org provided. Will not upload source maps. Please set the `org` option to your Sentry organization slug." +
+        getTurborepoEnvPassthroughWarning("SENTRY_ORG")
+    );
+    return false;
+  } else if (!options.project) {
+    logger.warn(
+      "No project provided. Will not upload source maps. Please set the `project` option to your Sentry project slug." +
+        getTurborepoEnvPassthroughWarning("SENTRY_PROJECT")
+    );
+    return false;
+  }
+
+  return true;
 }

--- a/packages/integration-tests/fixtures/debug-ids-already-injected/input/rollup4/rollup.config.js
+++ b/packages/integration-tests/fixtures/debug-ids-already-injected/input/rollup4/rollup.config.js
@@ -11,5 +11,12 @@ export default defineConfig({
     sourcemap: true,
     sourcemapDebugIds: true,
   },
-  plugins: [sentryRollupPlugin({ telemetry: false })],
+  plugins: [
+    sentryRollupPlugin({
+      telemetry: false,
+      authToken: "fake-auth",
+      org: "fake-org",
+      project: "fake-project",
+    }),
+  ],
 });

--- a/packages/integration-tests/fixtures/debug-ids-already-injected/input/vite6/vite.config.js
+++ b/packages/integration-tests/fixtures/debug-ids-already-injected/input/vite6/vite.config.js
@@ -17,5 +17,12 @@ export default defineConfig({
       },
     },
   },
-  plugins: [sentryVitePlugin({ telemetry: false })],
+  plugins: [
+    sentryVitePlugin({
+      telemetry: false,
+      authToken: "fake-auth",
+      org: "fake-org",
+      project: "fake-project",
+    }),
+  ],
 });

--- a/packages/integration-tests/fixtures/debug-ids-already-injected/input/webpack5/webpack.config.js
+++ b/packages/integration-tests/fixtures/debug-ids-already-injected/input/webpack5/webpack.config.js
@@ -14,5 +14,12 @@ export default {
     },
   },
   mode: "production",
-  plugins: [sentryWebpackPlugin({ telemetry: false })],
+  plugins: [
+    sentryWebpackPlugin({
+      telemetry: false,
+      authToken: "fake-auth",
+      org: "fake-org",
+      project: "fake-project",
+    }),
+  ],
 };


### PR DESCRIPTION
This bugged me and many users for a while: Because of a weird control flow in the debugID source maps upload plugin, we'd print the "Successfully uploaded source maps to Sentry" message if

- a bunch of important preconditions for uploading were not met (e.g. missing auth token). 
  - I think this was actually a pretty bad bug because it would cause Sentry CLI to do validation when it was called although we could have avoided this entirely.
- we didn't upload anything (i.e. we found 0 assets)

This PR fixes both cases.

closes https://github.com/getsentry/sentry-javascript-bundler-plugins/issues/670