### PR TITLE
fix(webpack): make plugin inject ES5-friendly code

### DIFF
--- a/packages/bundler-plugin-core/src/index.ts
+++ b/packages/bundler-plugin-core/src/index.ts
@@ -456,7 +456,7 @@ export function createComponentNameAnnotateHooks(ignoredComponents?: string[]): 
 }
 
 export function getDebugIdSnippet(debugId: string): string {
-  return `;{try{let e="undefined"!=typeof window?window:"undefined"!=typeof global?global:"undefined"!=typeof globalThis?globalThis:"undefined"!=typeof self?self:{},n=(new e.Error).stack;n&&(e._sentryDebugIds=e._sentryDebugIds||{},e._sentryDebugIds[n]="${debugId}",e._sentryDebugIdIdentifier="sentry-dbid-${debugId}")}catch(e){}};`;
+  return `;{try{(function(){var e="undefined"!=typeof window?window:"undefined"!=typeof global?global:"undefined"!=typeof globalThis?globalThis:"undefined"!=typeof self?self:{},n=(new e.Error).stack;n&&(e._sentryDebugIds=e._sentryDebugIds||{},e._sentryDebugIds[n]="${debugId}",e._sentryDebugIdIdentifier="sentry-dbid-${debugId}");})();}catch(e){}};`;
 }
 
 export type { Logger } from "./logger";

--- a/packages/bundler-plugin-core/src/utils.ts
+++ b/packages/bundler-plugin-core/src/utils.ts
@@ -314,8 +314,8 @@ export function generateGlobalInjectorCode({
 }): string {
   // The code below is mostly ternary operators because it saves bundle size.
   // The checks are to support as many environments as possible. (Node.js, Browser, webworkers, etc.)
-  let code = `{
-    let _global =
+  let code = `(function(){
+    var _global =
       typeof window !== 'undefined' ?
         window :
         typeof global !== 'undefined' ?
@@ -335,7 +335,7 @@ export function generateGlobalInjectorCode({
       _global.SENTRY_BUILD_INFO=${JSON.stringify(buildInfo)};`;
   }
 
-  code += "}";
+  code += "})();";
 
   return code;
 }
@@ -345,8 +345,8 @@ export function generateModuleMetadataInjectorCode(metadata: any): string {
   // The code below is mostly ternary operators because it saves bundle size.
   // The checks are to support as many environments as possible. (Node.js, Browser, webworkers, etc.)
   // We are merging the metadata objects in case modules are bundled twice with the plugin
-  return `{
-  let _sentryModuleMetadataGlobal =
+  return `(function(){
+  var _sentryModuleMetadataGlobal =
     typeof window !== "undefined"
       ? window
       : typeof global !== "undefined"
@@ -366,7 +366,7 @@ export function generateModuleMetadataInjectorCode(metadata: any): string {
       _sentryModuleMetadataGlobal._sentryModuleMetadata[new _sentryModuleMetadataGlobal.Error().stack],
       ${JSON.stringify(metadata)}
     );
-}`;
+})();`;
 }
 
 export function getBuildInformation(): {

--- a/packages/bundler-plugin-core/test/index.test.ts
+++ b/packages/bundler-plugin-core/test/index.test.ts
@@ -4,7 +4,7 @@ describe("getDebugIdSnippet", () => {
   it("returns the debugId injection snippet for a passed debugId", () => {
     const snippet = getDebugIdSnippet("1234");
     expect(snippet).toMatchInlineSnapshot(
-      `";{try{let e=\\"undefined\\"!=typeof window?window:\\"undefined\\"!=typeof global?global:\\"undefined\\"!=typeof globalThis?globalThis:\\"undefined\\"!=typeof self?self:{},n=(new e.Error).stack;n&&(e._sentryDebugIds=e._sentryDebugIds||{},e._sentryDebugIds[n]=\\"1234\\",e._sentryDebugIdIdentifier=\\"sentry-dbid-1234\\")}catch(e){}};"`
+      `";{try{(function(){var e=\\"undefined\\"!=typeof window?window:\\"undefined\\"!=typeof global?global:\\"undefined\\"!=typeof globalThis?globalThis:\\"undefined\\"!=typeof self?self:{},n=(new e.Error).stack;n&&(e._sentryDebugIds=e._sentryDebugIds||{},e._sentryDebugIds[n]=\\"1234\\",e._sentryDebugIdIdentifier=\\"sentry-dbid-1234\\");})();}catch(e){}};"`
     );
   });
 });

--- a/packages/bundler-plugin-core/test/utils.test.ts
+++ b/packages/bundler-plugin-core/test/utils.test.ts
@@ -220,8 +220,8 @@ describe("generateModuleMetadataInjectorCode", () => {
   it("generates code with empty metadata object", () => {
     const generatedCode = generateModuleMetadataInjectorCode({});
     expect(generatedCode).toMatchInlineSnapshot(`
-      "{
-        let _sentryModuleMetadataGlobal =
+      "(function(){
+        var _sentryModuleMetadataGlobal =
           typeof window !== \\"undefined\\"
             ? window
             : typeof global !== \\"undefined\\"
@@ -241,7 +241,7 @@ describe("generateModuleMetadataInjectorCode", () => {
             _sentryModuleMetadataGlobal._sentryModuleMetadata[new _sentryModuleMetadataGlobal.Error().stack],
             {}
           );
-      }"
+      })();"
     `);
   });
 
@@ -255,8 +255,8 @@ describe("generateModuleMetadataInjectorCode", () => {
       },
     });
     expect(generatedCode).toMatchInlineSnapshot(`
-      "{
-        let _sentryModuleMetadataGlobal =
+      "(function(){
+        var _sentryModuleMetadataGlobal =
           typeof window !== \\"undefined\\"
             ? window
             : typeof global !== \\"undefined\\"
@@ -276,7 +276,7 @@ describe("generateModuleMetadataInjectorCode", () => {
             _sentryModuleMetadataGlobal._sentryModuleMetadata[new _sentryModuleMetadataGlobal.Error().stack],
             {\\"file1.js\\":{\\"foo\\":\\"bar\\"},\\"file2.js\\":{\\"bar\\":\\"baz\\"}}
           );
-      }"
+      })();"
     `);
   });
 });


### PR DESCRIPTION
This PR fixes #769.

Sentry webpack plugin injects code that includes `let` keyword that was introduced with ES2015. [`let` syntax](https://caniuse.com/let) is not supported by some old browsers which are still relevant in certain cases.

The code is injected by the plugin at the final stages of bundling when webpack loaders that downgrade the syntax to the target environment (ES5) have already finished the processing. Therefore, `let` is kept in the bundle.

Changes:
* Substitute `let` for `var`.
* Wrap `var` variable declarations with an IIFE to keep the same scope as it was with `let`.