### PR TITLE
fix(v2/core): Make moduleMetadata injection code ES5-compliant

### DIFF
--- a/packages/bundler-plugin-core/src/utils.ts
+++ b/packages/bundler-plugin-core/src/utils.ts
@@ -343,44 +343,9 @@ export function generateModuleMetadataInjectorCode(metadata: any) {
   // The code below is mostly ternary operators because it saves bundle size.
   // The checks are to support as many environments as possible. (Node.js, Browser, webworkers, etc.)
   // We are merging the metadata objects in case modules are bundled twice with the plugin
-  return `{
-  var _sentryModuleMetadataGlobal =
-    typeof window !== "undefined"
-      ? window
-      : typeof global !== "undefined"
-      ? global
-      : typeof globalThis !== "undefined"
-      ? globalThis
-      : typeof self !== "undefined"
-      ? self
-      : {};
-
-  _sentryModuleMetadataGlobal._sentryModuleMetadata =
-    _sentryModuleMetadataGlobal._sentryModuleMetadata || {};
-
-  (function () {
-    var key,
-      stackKey = new _sentryModuleMetadataGlobal.Error().stack;
-    var existing = _sentryModuleMetadataGlobal._sentryModuleMetadata[stackKey] || {};
-    var newData = ${JSON.stringify(metadata)};
-    var merged = {};
-
-    for (key in existing) {
-      if (existing.hasOwnProperty(key)) {
-        merged[key] = existing[key];
-      }
-    }
-
-    for (key in newData) {
-      if (newData.hasOwnProperty(key)) {
-        merged[key] = newData[key];
-      }
-    }
-
-    _sentryModuleMetadataGlobal._sentryModuleMetadata[stackKey] = merged;
-  })();
-}
-`;
+  return `!function(){var e="undefined"!=typeof window?window:"undefined"!=typeof global?global:"undefined"!=typeof globalThis?globalThis:"undefined"!=typeof self?self:{};e._sentryModuleMetadata=e._sentryModuleMetadata||{},function(){var n,t=(new e.Error).stack,a=e._sentryModuleMetadata[t]||{},o=${JSON.stringify(
+    metadata
+  )},d={};for(n in a)a.hasOwnProperty(n)&&(d[n]=a[n]);for(n in o)o.hasOwnProperty(n)&&(d[n]=o[n]);e._sentryModuleMetadata[t]=d}()}();`;
 }
 
 function getBuildInformation() {

--- a/packages/bundler-plugin-core/test/__snapshots__/utils.test.ts.snap
+++ b/packages/bundler-plugin-core/test/__snapshots__/utils.test.ts.snap
@@ -1,0 +1,5 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`generateModuleMetadataInjectorCode generates code with empty metadata object 1`] = `"!function(){var e=\\"undefined\\"!=typeof window?window:\\"undefined\\"!=typeof global?global:\\"undefined\\"!=typeof globalThis?globalThis:\\"undefined\\"!=typeof self?self:{};e._sentryModuleMetadata=e._sentryModuleMetadata||{},function(){var n,t=(new e.Error).stack,a=e._sentryModuleMetadata[t]||{},o={},d={};for(n in a)a.hasOwnProperty(n)&&(d[n]=a[n]);for(n in o)o.hasOwnProperty(n)&&(d[n]=o[n]);e._sentryModuleMetadata[t]=d}()}();"`;
+
+exports[`generateModuleMetadataInjectorCode generates code with metadata object 1`] = `"!function(){var e=\\"undefined\\"!=typeof window?window:\\"undefined\\"!=typeof global?global:\\"undefined\\"!=typeof globalThis?globalThis:\\"undefined\\"!=typeof self?self:{};e._sentryModuleMetadata=e._sentryModuleMetadata||{},function(){var n,t=(new e.Error).stack,a=e._sentryModuleMetadata[t]||{},o={\\"file1.js\\":{\\"foo\\":\\"bar\\"},\\"file2.js\\":{\\"bar\\":\\"baz\\"}},d={};for(n in a)a.hasOwnProperty(n)&&(d[n]=a[n]);for(n in o)o.hasOwnProperty(n)&&(d[n]=o[n]);e._sentryModuleMetadata[t]=d}()}();"`;

--- a/packages/bundler-plugin-core/test/utils.test.ts
+++ b/packages/bundler-plugin-core/test/utils.test.ts
@@ -219,30 +219,7 @@ if (false && true) {
 describe("generateModuleMetadataInjectorCode", () => {
   it("generates code with empty metadata object", () => {
     const generatedCode = generateModuleMetadataInjectorCode({});
-    expect(generatedCode).toMatchInlineSnapshot(`
-      "{
-        var _sentryModuleMetadataGlobal =
-          typeof window !== \\"undefined\\"
-            ? window
-            : typeof global !== \\"undefined\\"
-            ? global
-            : typeof globalThis !== \\"undefined\\"
-            ? globalThis
-            : typeof self !== \\"undefined\\"
-            ? self
-            : {};
-
-        _sentryModuleMetadataGlobal._sentryModuleMetadata =
-          _sentryModuleMetadataGlobal._sentryModuleMetadata || {};
-
-        _sentryModuleMetadataGlobal._sentryModuleMetadata[new _sentryModuleMetadataGlobal.Error().stack] =
-          Object.assign(
-            {},
-            _sentryModuleMetadataGlobal._sentryModuleMetadata[new _sentryModuleMetadataGlobal.Error().stack],
-            {}
-          );
-      }"
-    `);
+    expect(generatedCode).toMatchSnapshot();
   });
 
   it("generates code with metadata object", () => {
@@ -254,29 +231,6 @@ describe("generateModuleMetadataInjectorCode", () => {
         bar: "baz",
       },
     });
-    expect(generatedCode).toMatchInlineSnapshot(`
-      "{
-        var _sentryModuleMetadataGlobal =
-          typeof window !== \\"undefined\\"
-            ? window
-            : typeof global !== \\"undefined\\"
-            ? global
-            : typeof globalThis !== \\"undefined\\"
-            ? globalThis
-            : typeof self !== \\"undefined\\"
-            ? self
-            : {};
-
-        _sentryModuleMetadataGlobal._sentryModuleMetadata =
-          _sentryModuleMetadataGlobal._sentryModuleMetadata || {};
-
-        _sentryModuleMetadataGlobal._sentryModuleMetadata[new _sentryModuleMetadataGlobal.Error().stack] =
-          Object.assign(
-            {},
-            _sentryModuleMetadataGlobal._sentryModuleMetadata[new _sentryModuleMetadataGlobal.Error().stack],
-            {\\"file1.js\\":{\\"foo\\":\\"bar\\"},\\"file2.js\\":{\\"bar\\":\\"baz\\"}}
-          );
-      }"
-    `);
+    expect(generatedCode).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
This PR makes the v2 `moduleMetadata` code snippet ES5-compliant by replacing the `Object.assign` merge strategy of the module with a pure ES5 merge strategy: iterating over the object property of both objects to merge to the final object.
Obviously, this increases the bundle size footpring but I think we need to prioritize correctness.

Reviewers can check [62321e2](https://github.com/getsentry/sentry-javascript-bundler-plugins/pull/773/commits/62321e23e0181c708a9fa0f10a8f4f44e540f9b8) which shows the new merge strategy prior to minification.

I also took the opportunity to minify the code and further isolate the `var`-declared variables by wrapping the code in an IIFE. Adjusted to the tests to also use `toMatchSnapshot`, since the inline snapshots would no longer be readable. Worth noting, we also have integration tests that actually check the behaviour, so I'm confident that the minified code still works correctly. 

I'll also open a similar PR to v4, since we decided to provide full ES5 compatibility again. 

closes https://github.com/getsentry/sentry-javascript-bundler-plugins/issues/768