### PR TITLE
meta: Add Changelog entry for 2.23.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - "You know what they say ‘Fool me once, strike one, but fool me twice… strike three.’" — Michael Scott
 
+## 2.23.1
+
+- fix(v2/core): Make `moduleMetadata` injection code ES5-compliant (#773)
+
 ## 2.23.0
 
 - chore(deps): bump nanoid from 3.3.6 to 3.3.8 (#641)

--- a/packages/bundler-plugin-core/src/utils.ts
+++ b/packages/bundler-plugin-core/src/utils.ts
@@ -343,28 +343,9 @@ export function generateModuleMetadataInjectorCode(metadata: any) {
   // The code below is mostly ternary operators because it saves bundle size.
   // The checks are to support as many environments as possible. (Node.js, Browser, webworkers, etc.)
   // We are merging the metadata objects in case modules are bundled twice with the plugin
-  return `{
-  var _sentryModuleMetadataGlobal =
-    typeof window !== "undefined"
-      ? window
-      : typeof global !== "undefined"
-      ? global
-      : typeof globalThis !== "undefined"
-      ? globalThis
-      : typeof self !== "undefined"
-      ? self
-      : {};
-
-  _sentryModuleMetadataGlobal._sentryModuleMetadata =
-    _sentryModuleMetadataGlobal._sentryModuleMetadata || {};
-
-  _sentryModuleMetadataGlobal._sentryModuleMetadata[new _sentryModuleMetadataGlobal.Error().stack] =
-    Object.assign(
-      {},
-      _sentryModuleMetadataGlobal._sentryModuleMetadata[new _sentryModuleMetadataGlobal.Error().stack],
-      ${JSON.stringify(metadata)}
-    );
-}`;
+  return `!function(){var e="undefined"!=typeof window?window:"undefined"!=typeof global?global:"undefined"!=typeof globalThis?globalThis:"undefined"!=typeof self?self:{};e._sentryModuleMetadata=e._sentryModuleMetadata||{},function(){var n,t=(new e.Error).stack,a=e._sentryModuleMetadata[t]||{},o=${JSON.stringify(
+    metadata
+  )},d={};for(n in a)a.hasOwnProperty(n)&&(d[n]=a[n]);for(n in o)o.hasOwnProperty(n)&&(d[n]=o[n]);e._sentryModuleMetadata[t]=d}()}();`;
 }
 
 function getBuildInformation() {

--- a/packages/bundler-plugin-core/test/__snapshots__/utils.test.ts.snap
+++ b/packages/bundler-plugin-core/test/__snapshots__/utils.test.ts.snap
@@ -1,0 +1,5 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`generateModuleMetadataInjectorCode generates code with empty metadata object 1`] = `"!function(){var e=\\"undefined\\"!=typeof window?window:\\"undefined\\"!=typeof global?global:\\"undefined\\"!=typeof globalThis?globalThis:\\"undefined\\"!=typeof self?self:{};e._sentryModuleMetadata=e._sentryModuleMetadata||{},function(){var n,t=(new e.Error).stack,a=e._sentryModuleMetadata[t]||{},o={},d={};for(n in a)a.hasOwnProperty(n)&&(d[n]=a[n]);for(n in o)o.hasOwnProperty(n)&&(d[n]=o[n]);e._sentryModuleMetadata[t]=d}()}();"`;
+
+exports[`generateModuleMetadataInjectorCode generates code with metadata object 1`] = `"!function(){var e=\\"undefined\\"!=typeof window?window:\\"undefined\\"!=typeof global?global:\\"undefined\\"!=typeof globalThis?globalThis:\\"undefined\\"!=typeof self?self:{};e._sentryModuleMetadata=e._sentryModuleMetadata||{},function(){var n,t=(new e.Error).stack,a=e._sentryModuleMetadata[t]||{},o={\\"file1.js\\":{\\"foo\\":\\"bar\\"},\\"file2.js\\":{\\"bar\\":\\"baz\\"}},d={};for(n in a)a.hasOwnProperty(n)&&(d[n]=a[n]);for(n in o)o.hasOwnProperty(n)&&(d[n]=o[n]);e._sentryModuleMetadata[t]=d}()}();"`;

--- a/packages/bundler-plugin-core/test/utils.test.ts
+++ b/packages/bundler-plugin-core/test/utils.test.ts
@@ -219,30 +219,7 @@ if (false && true) {
 describe("generateModuleMetadataInjectorCode", () => {
   it("generates code with empty metadata object", () => {
     const generatedCode = generateModuleMetadataInjectorCode({});
-    expect(generatedCode).toMatchInlineSnapshot(`
-      "{
-        var _sentryModuleMetadataGlobal =
-          typeof window !== \\"undefined\\"
-            ? window
-            : typeof global !== \\"undefined\\"
-            ? global
-            : typeof globalThis !== \\"undefined\\"
-            ? globalThis
-            : typeof self !== \\"undefined\\"
-            ? self
-            : {};
-
-        _sentryModuleMetadataGlobal._sentryModuleMetadata =
-          _sentryModuleMetadataGlobal._sentryModuleMetadata || {};
-
-        _sentryModuleMetadataGlobal._sentryModuleMetadata[new _sentryModuleMetadataGlobal.Error().stack] =
-          Object.assign(
-            {},
-            _sentryModuleMetadataGlobal._sentryModuleMetadata[new _sentryModuleMetadataGlobal.Error().stack],
-            {}
-          );
-      }"
-    `);
+    expect(generatedCode).toMatchSnapshot();
   });
 
   it("generates code with metadata object", () => {
@@ -254,29 +231,6 @@ describe("generateModuleMetadataInjectorCode", () => {
         bar: "baz",
       },
     });
-    expect(generatedCode).toMatchInlineSnapshot(`
-      "{
-        var _sentryModuleMetadataGlobal =
-          typeof window !== \\"undefined\\"
-            ? window
-            : typeof global !== \\"undefined\\"
-            ? global
-            : typeof globalThis !== \\"undefined\\"
-            ? globalThis
-            : typeof self !== \\"undefined\\"
-            ? self
-            : {};
-
-        _sentryModuleMetadataGlobal._sentryModuleMetadata =
-          _sentryModuleMetadataGlobal._sentryModuleMetadata || {};
-
-        _sentryModuleMetadataGlobal._sentryModuleMetadata[new _sentryModuleMetadataGlobal.Error().stack] =
-          Object.assign(
-            {},
-            _sentryModuleMetadataGlobal._sentryModuleMetadata[new _sentryModuleMetadataGlobal.Error().stack],
-            {\\"file1.js\\":{\\"foo\\":\\"bar\\"},\\"file2.js\\":{\\"bar\\":\\"baz\\"}}
-          );
-      }"
-    `);
+    expect(generatedCode).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
- **fix(v2/core): Make `moduleMetadata` injection code ES5-compliant (#773)**
- **meta: Add Changelog entry for 2.23.1**
