### PR TITLE
chore: Set `v2` NPM tag when publishing v2 releases

### DIFF
--- a/packages/babel-plugin-component-annotate/package.json
+++ b/packages/babel-plugin-component-annotate/package.json
@@ -16,7 +16,8 @@
     "annotate"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v2"
   },
   "files": [
     "dist"

--- a/packages/bundler-plugin-core/package.json
+++ b/packages/bundler-plugin-core/package.json
@@ -7,7 +7,8 @@
   "author": "Sentry",
   "license": "MIT",
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v2"
   },
   "files": [
     "dist",

--- a/packages/esbuild-plugin/package.json
+++ b/packages/esbuild-plugin/package.json
@@ -13,7 +13,8 @@
     "plugin"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v2"
   },
   "files": [
     "dist"

--- a/packages/rollup-plugin/package.json
+++ b/packages/rollup-plugin/package.json
@@ -14,7 +14,8 @@
     "plugin"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v2"
   },
   "files": [
     "dist"

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -13,7 +13,8 @@
     "plugin"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v2"
   },
   "files": [
     "dist"

--- a/packages/webpack-plugin/package.json
+++ b/packages/webpack-plugin/package.json
@@ -13,7 +13,8 @@
     "plugin"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v2"
   },
   "files": [
     "dist"


### PR DESCRIPTION
Release 2.23.1 was marked as `latest` on NPM. We're already releasing a new 4.0.2 release, to ensure that `latest` again points to 4.x. 

However, for the next time, this PR ensures we directly assign the `v2` tag instead of `latest` (see https://github.com/getsentry/sentry-javascript/pull/12047 in the JS SDK repo)

oh, also:
<img width="275" height="183" alt="image" src="https://github.com/user-attachments/assets/da41d463-b2b5-48d9-8791-563dd482ecef" />
