### PR TITLE
feat(core): Expose method for injecting debug Ids from plugin manager

### DIFF
--- a/packages/bundler-plugin-core/test/build-plugin-manager.test.ts
+++ b/packages/bundler-plugin-core/test/build-plugin-manager.test.ts
@@ -1,6 +1,30 @@
 import { createSentryBuildPluginManager } from "../src/build-plugin-manager";
 
+const mockCliExecute = jest.fn();
+jest.mock("@sentry/cli", () => {
+  return jest.fn().mockImplementation(() => ({
+    execute: mockCliExecute,
+  }));
+});
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-return
+jest.mock("../src/sentry/telemetry", () => ({
+  ...jest.requireActual("../src/sentry/telemetry"),
+  safeFlushTelemetry: jest.fn(),
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-return
+jest.mock("@sentry/core", () => ({
+  ...jest.requireActual("@sentry/core"),
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-return
+  startSpan: jest.fn((options, callback) => callback()),
+}));
+
 describe("createSentryBuildPluginManager", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   describe("when disabled", () => {
     it("initializes a no-op build plugin manager", () => {
       const buildPluginManager = createSentryBuildPluginManager(
@@ -46,6 +70,57 @@ describe("createSentryBuildPluginManager", () => {
       expect(debugSpy).not.toHaveBeenCalled();
       expect(warnSpy).not.toHaveBeenCalled();
       expect(errorSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("injectDebugIds", () => {
+    it("should call CLI with correct sourcemaps inject command", async () => {
+      mockCliExecute.mockResolvedValue(undefined);
+
+      const buildPluginManager = createSentryBuildPluginManager(
+        {
+          authToken: "test-token",
+          org: "test-org",
+          project: "test-project",
+        },
+        {
+          buildTool: "webpack",
+          loggerPrefix: "[sentry-webpack-plugin]",
+        }
+      );
+
+      const buildArtifactPaths = ["/path/to/1", "/path/to/2"];
+      await buildPluginManager.injectDebugIds(buildArtifactPaths);
+
+      expect(mockCliExecute).toHaveBeenCalledWith(
+        ["sourcemaps", "inject", "/path/to/1", "/path/to/2"],
+        false
+      );
+    });
+
+    it("should pass debug flag when options.debug is true", async () => {
+      mockCliExecute.mockResolvedValue(undefined);
+
+      const buildPluginManager = createSentryBuildPluginManager(
+        {
+          authToken: "test-token",
+          org: "test-org",
+          project: "test-project",
+          debug: true,
+        },
+        {
+          buildTool: "webpack",
+          loggerPrefix: "[sentry-webpack-plugin]",
+        }
+      );
+
+      const buildArtifactPaths = ["/path/to/bundle"];
+      await buildPluginManager.injectDebugIds(buildArtifactPaths);
+
+      expect(mockCliExecute).toHaveBeenCalledWith(
+        ["sourcemaps", "inject", "/path/to/bundle"],
+        true
+      );
     });
   });
 });


### PR DESCRIPTION
Adds a new method injectDebugIds for whenever the plugin manager is used without any specific bundler plugin.
This will be useful for every `buildEnd`-like  hook where we need to inject debugIds manually