### PR TITLE
perf: use premove for build clean

### DIFF
--- a/packages/babel-plugin-component-annotate/package.json
+++ b/packages/babel-plugin-component-annotate/package.json
@@ -32,7 +32,7 @@
   "module": "dist/esm/index.mjs",
   "types": "dist/types/index.d.ts",
   "scripts": {
-    "build": "rimraf ./out && run-p build:rollup build:types",
+    "build": "premove ./out && run-p build:rollup build:types",
     "build:watch": "run-p build:rollup:watch build:types:watch",
     "build:rollup": "rollup --config rollup.config.js",
     "build:rollup:watch": "rollup --config rollup.config.js --watch --no-watch.clearScreen",
@@ -44,8 +44,8 @@
     "check:types:test": "tsc --project ./test/tsconfig.json --noEmit",
     "clean": "run-s clean:build",
     "clean:all": "run-p clean clean:deps",
-    "clean:build": "rimraf ./dist *.tgz",
-    "clean:deps": "rimraf node_modules",
+    "clean:build": "premove ./dist *.tgz",
+    "clean:deps": "premove node_modules",
     "test": "jest",
     "lint": "eslint ./src ./test"
   },
@@ -65,7 +65,7 @@
     "@types/uuid": "^9.0.1",
     "eslint": "^8.18.0",
     "jest": "^28.1.1",
-    "rimraf": "^3.0.2",
+    "premove": "^4.0.0",
     "rollup": "2.75.7",
     "ts-node": "^10.9.1",
     "typescript": "^4.7.4"

--- a/packages/bundler-plugin-core/package.json
+++ b/packages/bundler-plugin-core/package.json
@@ -33,7 +33,7 @@
   "module": "dist/esm/index.mjs",
   "types": "dist/types/index.d.ts",
   "scripts": {
-    "build": "rimraf ./out && run-p build:rollup build:types",
+    "build": "premove ./out && run-p build:rollup build:types",
     "build:watch": "run-p build:rollup:watch build:types:watch",
     "build:rollup": "rollup --config rollup.config.js",
     "build:rollup:watch": "rollup --config rollup.config.js --watch --no-watch.clearScreen",
@@ -45,8 +45,8 @@
     "check:types:test": "tsc --project ./test/tsconfig.json --noEmit",
     "clean": "run-s clean:build",
     "clean:all": "run-p clean clean:deps",
-    "clean:build": "rimraf ./dist *.tgz",
-    "clean:deps": "rimraf node_modules",
+    "clean:build": "premove ./dist *.tgz",
+    "clean:deps": "premove node_modules",
     "test": "jest",
     "lint": "eslint ./src ./test",
     "fix": "eslint ./src ./test --format stylish --fix"
@@ -79,7 +79,7 @@
     "@types/node": "^18.6.3",
     "eslint": "^8.18.0",
     "jest": "^28.1.1",
-    "rimraf": "^3.0.2",
+    "premove": "^4.0.0",
     "rollup": "2.75.7",
     "typescript": "^4.7.4"
   },

--- a/packages/e2e-tests/package.json
+++ b/packages/e2e-tests/package.json
@@ -10,8 +10,8 @@
     "check:types": "tsc --project ./tsconfig.json --noEmit",
     "clean": "run-s clean:build",
     "clean:all": "run-p clean clean:deps",
-    "clean:build": "rimraf ./scenarios/*/out",
-    "clean:deps": "rimraf node_modules",
+    "clean:build": "premove ./scenarios/*/out",
+    "clean:deps": "premove node_modules",
     "lint": "eslint ."
   },
   "dependencies": {
@@ -33,6 +33,7 @@
     "eslint": "^8.18.0",
     "glob": "8.0.3",
     "jest": "^28.1.3",
+    "premove": "^4.0.0",
     "rollup": "2.77.0",
     "ts-node": "^10.9.1",
     "vite": "3.0.0",

--- a/packages/esbuild-plugin/package.json
+++ b/packages/esbuild-plugin/package.json
@@ -29,7 +29,7 @@
   "module": "dist/esm/index.mjs",
   "types": "dist/types/index.d.ts",
   "scripts": {
-    "build": "rimraf ./out && run-p build:rollup build:types",
+    "build": "premove ./out && run-p build:rollup build:types",
     "build:watch": "run-p build:rollup:watch build:types:watch",
     "build:rollup": "rollup --config rollup.config.js",
     "build:rollup:watch": "rollup --config rollup.config.js --watch --no-watch.clearScreen",
@@ -41,8 +41,8 @@
     "check:types:test": "tsc --project ./test/tsconfig.json --noEmit",
     "clean": "run-s clean:build",
     "clean:all": "run-p clean clean:deps",
-    "clean:build": "rimraf ./dist *.tgz",
-    "clean:deps": "rimraf node_modules",
+    "clean:build": "premove ./dist *.tgz",
+    "clean:deps": "premove node_modules",
     "test": "jest",
     "lint": "eslint ./src ./test",
     "prepack": "ts-node ./src/prepack.ts"
@@ -67,7 +67,7 @@
     "@types/uuid": "^9.0.1",
     "eslint": "^8.18.0",
     "jest": "^28.1.1",
-    "rimraf": "^3.0.2",
+    "premove": "^4.0.0",
     "rollup": "2.75.7",
     "ts-node": "^10.9.1",
     "typescript": "^4.7.4"

--- a/packages/eslint-configs/package.json
+++ b/packages/eslint-configs/package.json
@@ -15,11 +15,12 @@
     "eslint-plugin-react-hooks": "^4.4.0"
   },
   "devDependencies": {
-    "eslint": "^8.14.0"
+    "eslint": "^8.14.0",
+    "premove": "^4.0.0"
   },
   "scripts": {
     "clean:all": "run-s clean:deps",
-    "clean:deps": "rimraf node_modules"
+    "clean:deps": "premove node_modules"
   },
   "volta": {
     "extends": "../../package.json"

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -11,8 +11,8 @@
     "check:types": "tsc --project ./tsconfig.json --noEmit",
     "clean": "run-s clean:build",
     "clean:all": "run-p clean clean:deps",
-    "clean:build": "rimraf ./fixtures/*/out",
-    "clean:deps": "rimraf node_modules"
+    "clean:build": "premove ./fixtures/*/out",
+    "clean:deps": "premove node_modules"
   },
   "dependencies": {
     "@babel/preset-react": "^7.23.3",
@@ -43,6 +43,9 @@
     "vite": "3.0.0",
     "webpack4": "npm:webpack@^4",
     "webpack5": "npm:webpack@5.74.0"
+  },
+  "devDependencies": {
+    "premove": "^4.0.0"
   },
   "volta": {
     "extends": "../../package.json"

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -13,8 +13,8 @@
     "build:smallNodeApp": "vite build --config vite.config.smallNodeApp.js",
     "clean": "run-s clean:build",
     "clean:all": "run-p clean:deps",
-    "clean:build": "rimraf ./out",
-    "clean:deps": "rimraf node_modules",
+    "clean:build": "premove ./out",
+    "clean:deps": "premove node_modules",
     "start:proxyLogger": "ts-node scripts/request-logger-proxy.ts"
   },
   "dependencies": {
@@ -30,6 +30,9 @@
     "vite": "3.0.0",
     "webpack4": "npm:webpack@4.46.0",
     "webpack5": "npm:webpack@5"
+  },
+  "devDependencies": {
+    "premove": "^4.0.0"
   },
   "volta": {
     "extends": "../../package.json"

--- a/packages/rollup-plugin/package.json
+++ b/packages/rollup-plugin/package.json
@@ -30,7 +30,7 @@
   "module": "dist/esm/index.mjs",
   "types": "dist/types/index.d.ts",
   "scripts": {
-    "build": "rimraf ./out && run-p build:rollup build:types",
+    "build": "premove ./out && run-p build:rollup build:types",
     "build:watch": "run-p build:rollup:watch build:types:watch",
     "build:rollup": "rollup --config rollup.config.js",
     "build:rollup:watch": "rollup --config rollup.config.js --watch --no-watch.clearScreen",
@@ -42,8 +42,8 @@
     "check:types:test": "tsc --project ./test/tsconfig.json --noEmit",
     "clean": "run-s clean:build",
     "clean:all": "run-p clean clean:deps",
-    "clean:build": "rimraf ./dist *.tgz",
-    "clean:deps": "rimraf node_modules",
+    "clean:build": "premove ./dist *.tgz",
+    "clean:deps": "premove node_modules",
     "test": "jest",
     "lint": "eslint ./src ./test",
     "prepack": "ts-node ./src/prepack.ts"
@@ -69,7 +69,7 @@
     "@types/node": "^18.6.3",
     "eslint": "^8.18.0",
     "jest": "^28.1.1",
-    "rimraf": "^3.0.2",
+    "premove": "^4.0.0",
     "rollup": "2.75.7",
     "ts-node": "^10.9.1",
     "typescript": "^4.7.4"

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -29,7 +29,7 @@
   "module": "dist/esm/index.mjs",
   "types": "dist/types/index.d.ts",
   "scripts": {
-    "build": "rimraf ./out && run-p build:rollup build:types",
+    "build": "premove ./out && run-p build:rollup build:types",
     "build:watch": "run-p build:rollup:watch build:types:watch",
     "build:rollup": "rollup --config rollup.config.js",
     "build:rollup:watch": "rollup --config rollup.config.js --watch --no-watch.clearScreen",
@@ -41,8 +41,8 @@
     "check:types:test": "tsc --project ./test/tsconfig.json --noEmit",
     "clean": "run-s clean:build",
     "clean:all": "run-p clean clean:deps",
-    "clean:build": "rimraf ./dist *.tgz",
-    "clean:deps": "rimraf node_modules",
+    "clean:build": "premove ./dist *.tgz",
+    "clean:deps": "premove node_modules",
     "test": "jest",
     "lint": "eslint ./src ./test",
     "prepack": "ts-node ./src/prepack.ts"
@@ -65,7 +65,7 @@
     "@types/node": "^18.6.3",
     "eslint": "^8.18.0",
     "jest": "^28.1.1",
-    "rimraf": "^3.0.2",
+    "premove": "^4.0.0",
     "rollup": "2.75.7",
     "ts-node": "^10.9.1",
     "typescript": "^4.7.4"

--- a/packages/webpack-plugin/package.json
+++ b/packages/webpack-plugin/package.json
@@ -34,7 +34,7 @@
   "module": "dist/esm/index.mjs",
   "types": "dist/types/index.d.ts",
   "scripts": {
-    "build": "rimraf ./dist && run-p build:rollup build:types",
+    "build": "premove ./dist && run-p build:rollup build:types",
     "build:watch": "run-p build:rollup:watch build:types:watch",
     "build:rollup": "rollup --config rollup.config.js",
     "build:rollup:watch": "rollup --config rollup.config.js --watch --no-watch.clearScreen",
@@ -46,8 +46,8 @@
     "build:npm": "npm pack",
     "clean": "run-s clean:build",
     "clean:all": "run-p clean clean:deps",
-    "clean:build": "rimraf ./dist *.tgz",
-    "clean:deps": "rimraf node_modules",
+    "clean:build": "premove ./dist *.tgz",
+    "clean:deps": "premove node_modules",
     "test": "jest",
     "lint": "eslint ./src ./test",
     "prepack": "ts-node ./src/prepack.ts"
@@ -73,7 +73,7 @@
     "@types/webpack": "npm:@types/webpack@^4",
     "eslint": "^8.18.0",
     "jest": "^28.1.1",
-    "rimraf": "^3.0.2",
+    "premove": "^4.0.0",
     "rollup": "2.79.2",
     "ts-node": "^10.9.1",
     "typescript": "^4.7.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3334,7 +3334,19 @@
     "@types/source-list-map" "*"
     source-map "^0.7.3"
 
-"@types/webpack4@npm:@types/webpack@^4", "@types/webpack@npm:@types/webpack@^4":
+"@types/webpack4@npm:@types/webpack@^4":
+  version "4.41.33"
+  resolved "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.33.tgz#16164845a5be6a306bcbe554a8e67f9cac215ffc"
+  integrity sha512-PPajH64Ft2vWevkerISMtnZ8rTs4YmRbs+23c402J0INmxDKCrhZNvwZYtzx96gY2wAtXdrK1BS2fiC8MlLr3g==
+  dependencies:
+    "@types/node" "*"
+    "@types/tapable" "^1"
+    "@types/uglify-js" "*"
+    "@types/webpack-sources" "*"
+    anymatch "^3.0.0"
+    source-map "^0.6.0"
+
+"@types/webpack@npm:@types/webpack@^4":
   version "4.41.33"
   resolved "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.33.tgz#16164845a5be6a306bcbe554a8e67f9cac215ffc"
   integrity sha512-PPajH64Ft2vWevkerISMtnZ8rTs4YmRbs+23c402J0INmxDKCrhZNvwZYtzx96gY2wAtXdrK1BS2fiC8MlLr3g==
@@ -10846,6 +10858,11 @@ prelude-ls@~1.1.2:
   resolved "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==
 
+premove@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/premove/-/premove-4.0.0.tgz#813a87462dca591946e60ebd97c95092f0743aee"
+  integrity sha512-zim/Hr4+FVdCIM7zL9b9Z0Wfd5Ya3mnKtiuDv7L5lzYzanSq6cOcVJ7EFcgK4I0pt28l8H0jX/x3nyog380XgQ==
+
 prettier@^2.7.1:
   version "2.8.8"
   resolved "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
@@ -12072,7 +12089,16 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -12154,7 +12180,14 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -13086,7 +13119,7 @@ webpack-virtual-modules@^0.5.0:
   resolved "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.5.0.tgz#362f14738a56dae107937ab98ea7062e8bdd3b6c"
   integrity sha512-kyDivFZ7ZM0BVOUteVbDFhlRt7Ah/CSPwJdi8hBpkK7QLumUqdLtVfm/PX/hkcnrvr0i77fO5+TjZ94Pe+C9iw==
 
-"webpack4@npm:webpack@4.46.0", "webpack4@npm:webpack@^4", "webpack@npm:webpack@^4":
+"webpack4@npm:webpack@4.46.0", "webpack4@npm:webpack@^4":
   version "4.46.0"
   resolved "https://registry.npmjs.org/webpack/-/webpack-4.46.0.tgz#bf9b4404ea20a073605e0a011d188d77cb6ad542"
   integrity sha512-6jJuJjg8znb/xRItk7bkT0+Q7AHCYjjFnvKIWQPkNIOyRqoCGvkOs0ipeQzrqz4l5FtN5ZI/ukEHroeX/o1/5Q==
@@ -13174,6 +13207,35 @@ webpack-virtual-modules@^0.5.0:
     terser-webpack-plugin "^5.1.3"
     watchpack "^2.4.0"
     webpack-sources "^3.2.3"
+
+"webpack@npm:webpack@^4":
+  version "4.46.0"
+  resolved "https://registry.npmjs.org/webpack/-/webpack-4.46.0.tgz#bf9b4404ea20a073605e0a011d188d77cb6ad542"
+  integrity sha512-6jJuJjg8znb/xRItk7bkT0+Q7AHCYjjFnvKIWQPkNIOyRqoCGvkOs0ipeQzrqz4l5FtN5ZI/ukEHroeX/o1/5Q==
+  dependencies:
+    "@webassemblyjs/ast" "1.9.0"
+    "@webassemblyjs/helper-module-context" "1.9.0"
+    "@webassemblyjs/wasm-edit" "1.9.0"
+    "@webassemblyjs/wasm-parser" "1.9.0"
+    acorn "^6.4.1"
+    ajv "^6.10.2"
+    ajv-keywords "^3.4.1"
+    chrome-trace-event "^1.0.2"
+    enhanced-resolve "^4.5.0"
+    eslint-scope "^4.0.3"
+    json-parse-better-errors "^1.0.2"
+    loader-runner "^2.4.0"
+    loader-utils "^1.2.3"
+    memory-fs "^0.4.1"
+    micromatch "^3.1.10"
+    mkdirp "^0.5.3"
+    neo-async "^2.6.1"
+    node-libs-browser "^2.2.1"
+    schema-utils "^1.0.0"
+    tapable "^1.1.3"
+    terser-webpack-plugin "^1.4.3"
+    watchpack "^1.7.4"
+    webpack-sources "^1.4.1"
 
 whatwg-encoding@^1.0.5:
   version "1.0.5"
@@ -13272,7 +13334,16 @@ worker-farm@^1.7.0:
   dependencies:
     errno "~0.1.7"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
rimraf has grown rather large these days. We can now use `premove`, a much smaller utility.

Alternatively, we can just `fs.rm` in a script if we don't care for a CLI anymore.