### PR TITLE
fix(webpack-plugin): forward headers option to sentry-cli

### DIFF
--- a/packages/bundler-plugin-core/src/build-plugin-manager.ts
+++ b/packages/bundler-plugin-core/src/build-plugin-manager.ts
@@ -100,6 +100,7 @@ function createCliInstance(options: NormalizedOptions): SentryCli {
     vcsRemote: options.release.vcsRemote,
     headers: {
       ...getTraceData(),
+      ...options.headers,
     },
   });
 }


### PR DESCRIPTION
Closes #796 
- Problem: The `headers` option is ignored in the `sentryWebpackPlugin`.
- Solution: Pass `options.headers` to `SentryCli` in `createCliInstance` method.
- Impact: Enables use of custom custom headers