### PR TITLE
feat(core): Extend deploy option to allow opting out of automatic deploy creation

### DIFF
--- a/packages/bundler-plugin-core/src/options-mapping.ts
+++ b/packages/bundler-plugin-core/src/options-mapping.ts
@@ -51,7 +51,7 @@ export type NormalizedOptions = {
       time?: number;
       name?: string;
       url?: string;
-    };
+    } | false;
     uploadLegacySourcemaps?: string | IncludeEntry | Array<string | IncludeEntry>;
   };
   bundleSizeOptimizations:
@@ -195,7 +195,7 @@ export function validateOptions(options: NormalizedOptions, logger: Logger): boo
     }
   }
 
-  if (options.release?.deploy && !options.release?.deploy.env) {
+  if (options.release?.deploy && typeof options.release.deploy === "object" && !options.release.deploy.env) {
     logger.error(
       "The `deploy` option was specified but is missing the required `env` property.",
       "Please set the `env` property."

--- a/packages/bundler-plugin-core/src/options-mapping.ts
+++ b/packages/bundler-plugin-core/src/options-mapping.ts
@@ -44,14 +44,16 @@ export type NormalizedOptions = {
       | false
       | undefined;
     dist?: string;
-    deploy?: {
-      env: string;
-      started?: number | string;
-      finished?: number | string;
-      time?: number;
-      name?: string;
-      url?: string;
-    } | false;
+    deploy?:
+      | {
+          env: string;
+          started?: number | string;
+          finished?: number | string;
+          time?: number;
+          name?: string;
+          url?: string;
+        }
+      | false;
     uploadLegacySourcemaps?: string | IncludeEntry | Array<string | IncludeEntry>;
   };
   bundleSizeOptimizations:
@@ -195,7 +197,11 @@ export function validateOptions(options: NormalizedOptions, logger: Logger): boo
     }
   }
 
-  if (options.release?.deploy && typeof options.release.deploy === "object" && !options.release.deploy.env) {
+  if (
+    options.release?.deploy &&
+    typeof options.release.deploy === "object" &&
+    !options.release.deploy.env
+  ) {
     logger.error(
       "The `deploy` option was specified but is missing the required `env` property.",
       "Please set the `env` property."

--- a/packages/bundler-plugin-core/src/types.ts
+++ b/packages/bundler-plugin-core/src/types.ts
@@ -239,7 +239,7 @@ export interface Options {
 
     /**
      * Configuration for adding deployment information to the release in Sentry.
-     * 
+     *
      * Set to `false` to disable automatic deployment detection and creation.
      */
     deploy?: DeployOptions | false;

--- a/packages/bundler-plugin-core/src/types.ts
+++ b/packages/bundler-plugin-core/src/types.ts
@@ -239,8 +239,10 @@ export interface Options {
 
     /**
      * Configuration for adding deployment information to the release in Sentry.
+     * 
+     * Set to `false` to disable automatic deployment detection and creation.
      */
-    deploy?: DeployOptions;
+    deploy?: DeployOptions | false;
 
     /**
      * Legacy method of uploading source maps. (not recommended unless necessary)

--- a/packages/bundler-plugin-core/test/option-mappings.test.ts
+++ b/packages/bundler-plugin-core/test/option-mappings.test.ts
@@ -135,7 +135,7 @@ describe("normalizeUserOptions()", () => {
       };
 
       const normalizedOptions = normalizeUserOptions(userOptions);
-      
+
       expect(normalizedOptions.release.deploy).toEqual({
         env: "vercel-production",
         url: "https://my-app.vercel.app",
@@ -155,7 +155,7 @@ describe("normalizeUserOptions()", () => {
       };
 
       const normalizedOptions = normalizeUserOptions(userOptions);
-      
+
       expect(normalizedOptions.release.deploy).toBe(false);
     });
 
@@ -173,7 +173,7 @@ describe("normalizeUserOptions()", () => {
       };
 
       const normalizedOptions = normalizeUserOptions(userOptions);
-      
+
       expect(normalizedOptions.release.deploy).toEqual(manualDeployConfig);
     });
 
@@ -186,7 +186,7 @@ describe("normalizeUserOptions()", () => {
       };
 
       const normalizedOptions = normalizeUserOptions(userOptions);
-      
+
       expect(normalizedOptions.release.deploy).toBeUndefined();
     });
   });

--- a/packages/dev-utils/src/generate-documentation-table.ts
+++ b/packages/dev-utils/src/generate-documentation-table.ts
@@ -221,8 +221,9 @@ Use the \`debug\` option to print information about source map resolution.
       },
       {
         name: "deploy",
+        type: "DeployOptions | false",
         fullDescription:
-          "Configuration for adding deployment information to the release in Sentry.",
+          "Configuration for adding deployment information to the release in Sentry.\n\nSet to `false` to disable automatic deployment detection and creation (e.g., when deploying on Vercel).",
         children: [
           {
             name: "env",


### PR DESCRIPTION
Setting `release: { deploy: false }` now opts out of automatic deploy creation (currently done only for Vercel).

Closes: #799