### PR TITLE
fix: Strip query strings from asset paths

### DIFF
--- a/packages/bundler-plugin-core/src/debug-id-upload.ts
+++ b/packages/bundler-plugin-core/src/debug-id-upload.ts
@@ -15,7 +15,10 @@ export function createDebugIdUploadFunction({
   sentryBuildPluginManager,
 }: DebugIdUploadPluginOptions) {
   return async (buildArtifactPaths: string[]) => {
-    await sentryBuildPluginManager.uploadSourcemaps(buildArtifactPaths);
+    // Webpack and perhaps other bundlers allow you to append query strings to
+    // filenames for cache busting purposes. We should strip these before upload.
+    const cleanedPaths = buildArtifactPaths.map((p) => p.split("?")[0] || p);
+    await sentryBuildPluginManager.uploadSourcemaps(cleanedPaths);
   };
 }
 

--- a/packages/integration-tests/utils/create-cjs-bundles.ts
+++ b/packages/integration-tests/utils/create-cjs-bundles.ts
@@ -77,6 +77,7 @@ export function createCjsBundles(
         output: {
           path: path.join(outFolder, "webpack4"),
           libraryTarget: "commonjs",
+          filename: "[name].js?[contenthash]",
         },
         target: "node", // needed for webpack 4 so we can access node api
         plugins: [sentryWebpackPlugin(sentryUnpluginOptions)],


### PR DESCRIPTION
- Closes #737

