### PR TITLE
fix: propagate the debug option to the cli

### DIFF
--- a/packages/bundler-plugin-core/src/build-plugin-manager.ts
+++ b/packages/bundler-plugin-core/src/build-plugin-manager.ts
@@ -221,7 +221,8 @@ export function createSentryBuildPluginManager(
   ] = `${bundlerPluginMetaContext.buildTool}-plugin/${__PACKAGE_VERSION__}`;
 
   // Propagate debug flag to Sentry CLI via environment variable
-  if (options.debug) {
+  // Only set if not already defined to respect user's explicit configuration
+  if (options.debug && !process.env["SENTRY_LOG_LEVEL"]) {
     process.env["SENTRY_LOG_LEVEL"] = "debug";
   }
 

--- a/packages/bundler-plugin-core/test/build-plugin-manager.test.ts
+++ b/packages/bundler-plugin-core/test/build-plugin-manager.test.ts
@@ -66,6 +66,27 @@ describe("createSentryBuildPluginManager", () => {
       expect(process.env["SENTRY_LOG_LEVEL"]).toBe("debug");
     });
 
+    it("should NOT override existing SENTRY_LOG_LEVEL even when debug is true", () => {
+      // User explicitly set SENTRY_LOG_LEVEL to "info"
+      process.env["SENTRY_LOG_LEVEL"] = "info";
+
+      createSentryBuildPluginManager(
+        {
+          authToken: "test-token",
+          org: "test-org",
+          project: "test-project",
+          debug: true,
+        },
+        {
+          buildTool: "webpack",
+          loggerPrefix: "[sentry-webpack-plugin]",
+        }
+      );
+
+      // Should respect the user's explicit setting
+      expect(process.env["SENTRY_LOG_LEVEL"]).toBe("info");
+    });
+
     it("should not set SENTRY_LOG_LEVEL environment variable when debug is false", () => {
       createSentryBuildPluginManager(
         {


### PR DESCRIPTION
This pull request adds logic to ensure we are properly passing the debug flag to the Sentry CLI via an environment variable by setting it on the `process.env` similar to other flags.

closes #673 