### PR TITLE
fix(core): Stop awaiting build start telemetry to avoid breaking module federation builds

### DIFF
--- a/packages/bundler-plugin-core/src/index.ts
+++ b/packages/bundler-plugin-core/src/index.ts
@@ -83,7 +83,7 @@ export function sentryUnpluginFactory({
         // We cannot await the flush here because it would block the build start
         // which in turn would break module federation builds, see
         // https://github.com/getsentry/sentry-javascript-bundler-plugins/issues/816
-        sentryBuildPluginManager.telemetry.emitBundlerPluginExecutionSignal().catch(() => {
+        void sentryBuildPluginManager.telemetry.emitBundlerPluginExecutionSignal().catch(() => {
           // Nothing for the users to do here. If telemetry fails it's acceptable.
         });
       },


### PR DESCRIPTION
Prior to this fix, we would create a span when the build starts and await flushing it before proceeding with the build. This breaks when using module federation builds as outlined in #816.

This fix removes the blocking await and optimistically fires off the span. This **should** be fine as we definitely care more about not breaking user builds than telemetry arriving. It could lead to us potentially missing this span sometimes when builds run very fast and finish before the span flushes out, however given that the build process usually takes longer (especially when sourcemaps and uploading sourcemaps is involved) it should be fine most of the time.

Closes: #816