### PR TITLE
fix(rollup): Prevent double-injection of debug ID

### DIFF
--- a/packages/bundler-plugin-core/src/index.ts
+++ b/packages/bundler-plugin-core/src/index.ts
@@ -270,7 +270,7 @@ export function createRollupDebugIdInjectionHooks(): {
         )
       ) {
         // Check if a debug ID has already been injected to avoid duplicate injection (e.g. by another plugin or Sentry CLI)
-        const chunkStartSnippet = code.slice(0, 2000);
+        const chunkStartSnippet = code.slice(0, 6000);
         const chunkEndSnippet = code.slice(-500);
 
         if (

--- a/packages/bundler-plugin-core/test/index.test.ts
+++ b/packages/bundler-plugin-core/test/index.test.ts
@@ -84,12 +84,12 @@ describe("createRollupDebugIdInjectionHooks", () => {
     });
 
     it("should only check boundaries for performance (not entire file)", () => {
-      // Inline format beyond first 2KB boundary
-      const codeWithInlineBeyond2KB =
-        "a".repeat(2100) +
+      // Inline format beyond first 6KB boundary
+      const codeWithInlineBeyond6KB =
+        "a".repeat(6100) +
         ';{try{(function(){var e="undefined"!=typeof window?window:e._sentryDebugIdIdentifier="sentry-dbid-existing-id");})();}catch(e){}};';
 
-      expect(hooks.renderChunk(codeWithInlineBeyond2KB, { fileName: "bundle.js" })).not.toBeNull();
+      expect(hooks.renderChunk(codeWithInlineBeyond6KB, { fileName: "bundle.js" })).not.toBeNull();
 
       // Comment format beyond last 500 bytes boundary
       const codeWithCommentBeyond500B =


### PR DESCRIPTION
The plugin just injects the debug ID, but doesn't check if it is already in the file. Injecting multiple debug IDs result in problems (like the linked issue below):
https://github.com/getsentry/sentry-javascript/issues/18519


This PR checks the beginning and end of the file for debug ID content. The numbers for that are a best estimate, so we don't need to read the whole file (potentially resource-intense).
