### PR TITLE
feat: Use Rolldown native `MagicString`

### DIFF
--- a/packages/bundler-plugin-core/src/index.ts
+++ b/packages/bundler-plugin-core/src/index.ts
@@ -341,6 +341,7 @@ export function createRollupInjectionHooks(
       }
 
       // Rolldown can pass a native MagicString instance in meta.magicString
+      // https://rolldown.rs/in-depth/native-magic-string#usage-examples
       if (ms?.constructor?.name === "BindingMagicString") {
         // Rolldown docs say to return the magic string instance directly in this case
         return { code: ms as unknown as string };


### PR DESCRIPTION
- Ref #748

Once [these features](https://github.com/rolldown/rolldown/pull/7943#issuecomment-3765006913) make it into a Rolldow release, it looks like the changes in this PR will improve sourcemap generation for Rolldown without affecting Rollup.


With an [example app of 10k modules](https://github.com/rolldown/benchmarks) and 10MB output file:
|  | Time  |
|---|---|
| Rolldown | 900ms |
| Rolldown + Sentry Rollup plugin | 4.5s |
| Rolldown + Sentry Rollup plugin + Combine injection plugins | 1.8s |
| Rolldown + Sentry Rollup plugin + Combine injection plugins + native `MagicString` | 1s |

 