### PR TITLE
fix: Inject component annotations into HTML elements rather than React components 

### DIFF
--- a/packages/babel-plugin-component-annotate/src/constants.ts
+++ b/packages/babel-plugin-component-annotate/src/constants.ts
@@ -30,6 +30,29 @@ export const KNOWN_INCOMPATIBLE_PLUGINS = [
   "@react-navigation",
 ];
 
+export const REACT_NATIVE_ELEMENTS: string[] = [
+  "Image",
+  "Text",
+  "View",
+  "ScrollView",
+  "TextInput",
+  "TouchableOpacity",
+  "TouchableHighlight",
+  "TouchableWithoutFeedback",
+  "FlatList",
+  "SectionList",
+  "ActivityIndicator",
+  "Button",
+  "Switch",
+  "Modal",
+  "SafeAreaView",
+  "StatusBar",
+  "KeyboardAvoidingView",
+  "RefreshControl",
+  "Picker",
+  "Slider",
+];
+
 export const DEFAULT_IGNORED_ELEMENTS = [
   "a",
   "abbr",

--- a/packages/bundler-plugin-core/src/index.ts
+++ b/packages/bundler-plugin-core/src/index.ts
@@ -33,7 +33,10 @@ type LegacyPlugins = {
 
 interface SentryUnpluginFactoryOptions {
   injectionPlugin: InjectionPlugin | LegacyPlugins;
-  componentNameAnnotatePlugin?: (ignoredComponents?: string[]) => UnpluginOptions;
+  componentNameAnnotatePlugin?: (
+    injectIntoHtml: boolean,
+    ignoredComponents?: string[]
+  ) => UnpluginOptions;
   debugIdUploadPlugin: (
     upload: (buildArtifacts: string[]) => Promise<void>,
     logger: Logger,
@@ -190,7 +193,10 @@ export function sentryUnpluginFactory({
       } else {
         componentNameAnnotatePlugin &&
           plugins.push(
-            componentNameAnnotatePlugin(options.reactComponentAnnotation.ignoredComponents)
+            componentNameAnnotatePlugin(
+              options.reactComponentAnnotation.injectIntoHtml,
+              options.reactComponentAnnotation.ignoredComponents
+            )
           );
       }
     }
@@ -391,7 +397,10 @@ export function createRollupDebugIdUploadHooks(
   };
 }
 
-export function createComponentNameAnnotateHooks(ignoredComponents?: string[]): {
+export function createComponentNameAnnotateHooks(
+  injectIntoHtml: boolean,
+  ignoredComponents?: string[]
+): {
   transform: UnpluginOptions["transform"];
 } {
   type ParserPlugins = NonNullable<
@@ -421,7 +430,7 @@ export function createComponentNameAnnotateHooks(ignoredComponents?: string[]): 
 
       try {
         const result = await transformAsync(code, {
-          plugins: [[componentNameAnnotatePlugin, { ignoredComponents }]],
+          plugins: [[componentNameAnnotatePlugin, { injectIntoHtml, ignoredComponents }]],
           filename: id,
           parserOpts: {
             sourceType: "module",

--- a/packages/bundler-plugin-core/src/options-mapping.ts
+++ b/packages/bundler-plugin-core/src/options-mapping.ts
@@ -70,6 +70,7 @@ export type NormalizedOptions = {
     | {
         enabled?: boolean;
         ignoredComponents?: string[];
+        injectIntoHtml: boolean;
       }
     | undefined;
   _metaOptions: {
@@ -116,7 +117,10 @@ export function normalizeUserOptions(userOptions: UserOptions): NormalizedOption
         | undefined,
     },
     bundleSizeOptimizations: userOptions.bundleSizeOptimizations,
-    reactComponentAnnotation: userOptions.reactComponentAnnotation,
+    reactComponentAnnotation: {
+      ...userOptions.reactComponentAnnotation,
+      injectIntoHtml: !!userOptions.reactComponentAnnotation?._experimentalInjectIntoHtml,
+    },
     _metaOptions: {
       telemetry: {
         metaFramework: userOptions._metaOptions?.telemetry?.metaFramework,

--- a/packages/bundler-plugin-core/src/types.ts
+++ b/packages/bundler-plugin-core/src/types.ts
@@ -354,6 +354,13 @@ export interface Options {
      * A list of strings representing the names of components to ignore. The plugin will not apply `data-sentry` annotations on the DOM element for these components.
      */
     ignoredComponents?: string[];
+    /**
+     * If set to true, the plugin will inject attributes into any HTML elements
+     * inside React fragments at the root level.
+     *
+     * Defaults to `false`.
+     */
+    _experimentalInjectIntoHtml?: boolean;
   };
 
   /**

--- a/packages/bundler-plugin-core/test/option-mappings.test.ts
+++ b/packages/bundler-plugin-core/test/option-mappings.test.ts
@@ -16,6 +16,9 @@ describe("normalizeUserOptions()", () => {
       project: "my-project",
       debug: false,
       disable: false,
+      reactComponentAnnotation: {
+        injectIntoHtml: false,
+      },
       release: {
         name: "my-release",
         finalize: true,
@@ -66,6 +69,9 @@ describe("normalizeUserOptions()", () => {
       project: "my-project",
       debug: false,
       disable: false,
+      reactComponentAnnotation: {
+        injectIntoHtml: false,
+      },
       release: {
         name: "my-release",
         vcsRemote: "origin",

--- a/packages/rollup-plugin/src/index.ts
+++ b/packages/rollup-plugin/src/index.ts
@@ -10,10 +10,13 @@ import {
 } from "@sentry/bundler-plugin-core";
 import type { UnpluginOptions } from "unplugin";
 
-function rollupComponentNameAnnotatePlugin(ignoredComponents?: string[]): UnpluginOptions {
+function rollupComponentNameAnnotatePlugin(
+  injectIntoHtml: boolean,
+  ignoredComponents?: string[]
+): UnpluginOptions {
   return {
     name: "sentry-rollup-component-name-annotate-plugin",
-    rollup: createComponentNameAnnotateHooks(ignoredComponents),
+    rollup: createComponentNameAnnotateHooks(injectIntoHtml, ignoredComponents),
   };
 }
 

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -20,11 +20,14 @@ function viteInjectionPlugin(injectionCode: string, debugIds: boolean): Unplugin
   };
 }
 
-function viteComponentNameAnnotatePlugin(ignoredComponents?: string[]): UnpluginOptions {
+function viteComponentNameAnnotatePlugin(
+  injectIntoHtml: boolean,
+  ignoredComponents?: string[]
+): UnpluginOptions {
   return {
     name: "sentry-vite-component-name-annotate-plugin",
     enforce: "pre" as const,
-    vite: createComponentNameAnnotateHooks(ignoredComponents),
+    vite: createComponentNameAnnotateHooks(injectIntoHtml, ignoredComponents),
   };
 }
 

--- a/packages/webpack-plugin/src/webpack4and5.ts
+++ b/packages/webpack-plugin/src/webpack4and5.ts
@@ -69,15 +69,18 @@ function webpackInjectionPlugin(
   });
 }
 
-function webpackComponentNameAnnotatePlugin(): (ignoredComponents?: string[]) => UnpluginOptions {
-  return (ignoredComponents?: string[]) => ({
+function webpackComponentNameAnnotatePlugin(): (
+  injectIntoHtml: boolean,
+  ignoredComponents?: string[]
+) => UnpluginOptions {
+  return (injectIntoHtml: boolean, ignoredComponents?: string[]) => ({
     name: "sentry-webpack-component-name-annotate-plugin",
     enforce: "pre",
     // Webpack needs this hook for loader logic, so the plugin is not run on unsupported file types
     transformInclude(id) {
       return id.endsWith(".tsx") || id.endsWith(".jsx");
     },
-    transform: createComponentNameAnnotateHooks(ignoredComponents).transform,
+    transform: createComponentNameAnnotateHooks(injectIntoHtml, ignoredComponents).transform,
   });
 }
 


### PR DESCRIPTION
- Closes #492

Rather than inject attributes into React components which can cause incompatibilities with props, this PR changes the plugin to instead inject attributes into every HTML element in the component root.

## Downsides

Potentially larger bundle sizes because the attributes will get injected into more elements.