### PR TITLE
chore(publish): Use `workspaces` option in Craft NPM target

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -18,4 +18,3 @@ targets:
     workspaces: true
     excludeWorkspaces: /^@sentry-internal\//
     includeWorkspaces: /^@sentry\//
-    includeNames: /^sentry-.*.tgz$/


### PR DESCRIPTION
Makes use of craft's new feature to detect npm packages in topological order. This makes our publishing process slightly more robust since previously, we didn't specify an explicit order. This is also a trial run for the sentry-javascript repo, so that we can test the craft option on a smaller monorepo like this one.

```
> volta run --node 20.18.2 npx @sentry/craft@latest targets
[info] Discovered 6 publishable yarn workspace packages
[
    "github",
    "npm[@sentry/babel-plugin-component-annotate]",
    "npm[@sentry/bundler-plugin-core]",
    "npm[@sentry/webpack-plugin]",
    "npm[@sentry/vite-plugin]",
    "npm[@sentry/rollup-plugin]",
    "npm[@sentry/esbuild-plugin]"
]
```
