### PR TITLE
ci: Bump craft for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
           token: ${{ steps.token.outputs.token }}
           fetch-depth: 0
       - name: Prepare release
-        uses: getsentry/craft@c6e2f04939b6ee67030588afbb5af76b127d8203 # v2
+        uses: getsentry/craft@beea4aba589c66381258cbd131c5551ae8245b82 # v2.20.1
         env:
           GITHUB_TOKEN: ${{ steps.token.outputs.token }}
         with:


### PR DESCRIPTION
Bumping this because I ran into `Error:  Auto-versioning requires minVersion >= 2.14.0 in .craft.yml. Please update your configuration or specify the version explicitly.` in https://github.com/getsentry/sentry-javascript-bundler-plugins/actions/runs/21586327641