### PR TITLE
fix: Align `engines` with Node support

### DIFF
--- a/packages/babel-plugin-component-annotate/package.json
+++ b/packages/babel-plugin-component-annotate/package.json
@@ -70,6 +70,6 @@
     "extends": "../../package.json"
   },
   "engines": {
-    "node": ">= 14"
+    "node": ">= 18"
   }
 }

--- a/packages/bundler-plugin-core/package.json
+++ b/packages/bundler-plugin-core/package.json
@@ -82,7 +82,7 @@
     "extends": "../../package.json"
   },
   "engines": {
-    "node": ">= 14"
+    "node": ">= 18"
   },
   "sideEffects": [
     "./sentry-release-injection-file.js",

--- a/packages/esbuild-plugin/package.json
+++ b/packages/esbuild-plugin/package.json
@@ -70,6 +70,6 @@
     "extends": "../../package.json"
   },
   "engines": {
-    "node": ">= 14"
+    "node": ">= 18"
   }
 }

--- a/packages/rollup-plugin/package.json
+++ b/packages/rollup-plugin/package.json
@@ -73,6 +73,6 @@
     "extends": "../../package.json"
   },
   "engines": {
-    "node": ">= 14"
+    "node": ">= 18"
   }
 }

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -69,6 +69,6 @@
     "extends": "../../package.json"
   },
   "engines": {
-    "node": ">= 14"
+    "node": ">= 18"
   }
 }

--- a/packages/webpack-plugin/package.json
+++ b/packages/webpack-plugin/package.json
@@ -80,6 +80,6 @@
     "extends": "../../package.json"
   },
   "engines": {
-    "node": ">= 14"
+    "node": ">= 18"
   }
 }


### PR DESCRIPTION
I missed this when we bumped our Node support to >= v18.