### PR TITLE
fix: Add missing webpack5 entrypoint in webpack-plugin

### DIFF
--- a/packages/webpack-plugin/rollup.config.mjs
+++ b/packages/webpack-plugin/rollup.config.mjs
@@ -3,7 +3,7 @@ import modulePackage from "module";
 
 export default {
   platform: "node",
-  input: ["src/index.ts", "src/component-annotation-transform.ts"],
+  input: ["src/index.ts", "src/webpack5.ts", "src/component-annotation-transform.ts"],
   external: [...Object.keys(packageJson.dependencies), ...modulePackage.builtinModules, "webpack"],
   output: [
     {


### PR DESCRIPTION
Apparently removed in #872.