### PR TITLE
fix(e2e-tests): Pin axios to 1.13.5 to avoid compromised 1.14.1

### DIFF
--- a/packages/e2e-tests/package.json
+++ b/packages/e2e-tests/package.json
@@ -19,7 +19,7 @@
     "@sentry/rollup-plugin": "5.1.1",
     "@sentry/vite-plugin": "5.1.1",
     "@sentry/webpack-plugin": "5.1.1",
-    "axios": "^1.1.3"
+    "axios": "1.13.5"
   },
   "devDependencies": {
     "@sentry-internal/eslint-config": "5.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2394,7 +2394,7 @@ available-typed-arrays@^1.0.5:
   resolved "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz#92f95616501069d07d10edb2fc37d3e1c65123b7"
   integrity sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==
 
-axios@*, axios@^1.1.3:
+axios@*:
   version "1.4.0"
   resolved "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz#38a7bf1224cd308de271146038b551d725f0be1f"
   integrity sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==
@@ -2403,7 +2403,7 @@ axios@*, axios@^1.1.3:
     form-data "^4.0.0"
     proxy-from-env "^1.1.0"
 
-axios@^1.12.0:
+axios@1.13.5, axios@^1.12.0:
   version "1.13.5"
   resolved "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz#5e464688fa127e11a660a2c49441c009f6567a43"
   integrity sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==


### PR DESCRIPTION
axios 1.14.1 contains a supply chain attack via the plain-crypto-js dependency. Pin to 1.13.5 to prevent accidental upgrades.

See: https://x.com/feross/status/2038807290422370479