### PR TITLE
fix(webpack): Await source map deletion before signaling build completion

### DIFF
--- a/packages/webpack-plugin/src/webpack4and5.ts
+++ b/packages/webpack-plugin/src/webpack4and5.ts
@@ -281,9 +281,9 @@ export function sentryWebpackPluginFactory({
             const freeGlobalDependencyOnBuildArtifacts = createDependencyOnBuildArtifacts();
             const upload = createDebugIdUploadFunction({ sentryBuildPluginManager });
 
-            sentryBuildPluginManager
-              .createRelease()
-              .then(async () => {
+            const run = async (): Promise<void> => {
+              try {
+                await sentryBuildPluginManager.createRelease();
                 if (sourcemapsEnabled && options.sourcemaps?.disable !== "disable-upload") {
                   const outputPath = compilation.outputOptions.path ?? path.resolve();
                   const buildArtifacts = Object.keys(compilation.assets).map((asset) =>
@@ -291,15 +291,16 @@ export function sentryWebpackPluginFactory({
                   );
                   await upload(buildArtifacts);
                 }
-              })
-              .finally(async () => {
+              } finally {
                 freeGlobalDependencyOnBuildArtifacts();
                 await sentryBuildPluginManager.deleteArtifacts();
-              })
-              .then(
-                () => callback(),
-                (err: Error) => callback(err)
-              );
+              }
+            };
+
+            run().then(
+              () => callback(),
+              (err: Error) => callback(err)
+            );
           }
         );
 

--- a/packages/webpack-plugin/src/webpack4and5.ts
+++ b/packages/webpack-plugin/src/webpack4and5.ts
@@ -277,11 +277,11 @@ export function sentryWebpackPluginFactory({
 
         compiler.hooks.afterEmit.tapAsync(
           "sentry-webpack-plugin",
-          (compilation: WebpackCompilation, callback: () => void) => {
+          (compilation: WebpackCompilation, callback: (err?: Error) => void) => {
             const freeGlobalDependencyOnBuildArtifacts = createDependencyOnBuildArtifacts();
             const upload = createDebugIdUploadFunction({ sentryBuildPluginManager });
 
-            void sentryBuildPluginManager
+            sentryBuildPluginManager
               .createRelease()
               .then(async () => {
                 if (sourcemapsEnabled && options.sourcemaps?.disable !== "disable-upload") {
@@ -292,13 +292,14 @@ export function sentryWebpackPluginFactory({
                   await upload(buildArtifacts);
                 }
               })
-              .then(() => {
-                callback();
-              })
-              .finally(() => {
+              .finally(async () => {
                 freeGlobalDependencyOnBuildArtifacts();
-                void sentryBuildPluginManager.deleteArtifacts();
-              });
+                await sentryBuildPluginManager.deleteArtifacts();
+              })
+              .then(
+                () => callback(),
+                (err: Error) => callback(err)
+              );
           }
         );
 


### PR DESCRIPTION
This PR reworks the webpack plugin to await the source map deletion before moving on. This matches the behavior of the rollup and esbuild plugins.

Additionally, it does not swallow potential errors and passes them to to passed-in callback handler.