### PR TITLE
test: Ensure correct bundlers are resolved

### DIFF
--- a/packages/integration-tests-next/fixtures/rolldown/utils.ts
+++ b/packages/integration-tests-next/fixtures/rolldown/utils.ts
@@ -39,7 +39,7 @@ export function test(url: string, callback: TestCallback) {
         outDir,
         runBundler: (env) =>
           runBundler(
-            `rolldown --config ${testName}${configExt}`,
+            `pnpm rolldown --config ${testName}${configExt}`,
             {
               cwd,
               env: {

--- a/packages/integration-tests-next/fixtures/rollup3/utils.ts
+++ b/packages/integration-tests-next/fixtures/rollup3/utils.ts
@@ -33,7 +33,7 @@ export function test(url: string, callback: TestCallback) {
       outDir,
       runBundler: (env) =>
         runBundler(
-          `rollup --config ${testName}${configExt}`,
+          `pnpm rollup --config ${testName}${configExt}`,
           {
             cwd,
             env: {

--- a/packages/integration-tests-next/fixtures/rollup4/utils.ts
+++ b/packages/integration-tests-next/fixtures/rollup4/utils.ts
@@ -33,7 +33,7 @@ export function test(url: string, callback: TestCallback) {
       outDir,
       runBundler: (env) =>
         runBundler(
-          `rollup --config ${testName}${configExt}`,
+          `pnpm rollup --config ${testName}${configExt}`,
           {
             cwd,
             env: {

--- a/packages/integration-tests-next/fixtures/utils.ts
+++ b/packages/integration-tests-next/fixtures/utils.ts
@@ -46,7 +46,8 @@ export function readAllFiles(
           .replaceAll(/"nodeVersion":\d+/g, `"nodeVersion":"NODE_VERSION"`)
           .replaceAll(/"nodeVersion": \d+/g, `"nodeVersion":"NODE_VERSION"`)
           .replaceAll(/nodeVersion:\d+/g, `nodeVersion:"NODE_VERSION"`)
-          .replaceAll(/nodeVersion: \d+/g, `nodeVersion:"NODE_VERSION"`);
+          .replaceAll(/nodeVersion: \d+/g, `nodeVersion:"NODE_VERSION"`)
+          .replaceAll(process.cwd(), "");
 
         if (customReplacer) {
           contents = customReplacer(contents);

--- a/packages/integration-tests-next/fixtures/utils.ts
+++ b/packages/integration-tests-next/fixtures/utils.ts
@@ -47,7 +47,7 @@ export function readAllFiles(
           .replaceAll(/"nodeVersion": \d+/g, `"nodeVersion":"NODE_VERSION"`)
           .replaceAll(/nodeVersion:\d+/g, `nodeVersion:"NODE_VERSION"`)
           .replaceAll(/nodeVersion: \d+/g, `nodeVersion:"NODE_VERSION"`)
-          .replaceAll(process.cwd(), "");
+          .replaceAll(process.cwd().replace(/\\/g, "/"), "");
 
         if (customReplacer) {
           contents = customReplacer(contents);

--- a/packages/integration-tests-next/fixtures/vite4/after-upload-deletion.test.ts
+++ b/packages/integration-tests-next/fixtures/vite4/after-upload-deletion.test.ts
@@ -5,7 +5,7 @@ test(import.meta.url, ({ runBundler, readOutputFiles, runFileInNode }) => {
   runBundler();
   expect(readOutputFiles()).toMatchInlineSnapshot(`
     {
-      "basic.js": "!(function() {
+      "basic.js": "!function() {
       try {
         var e = "undefined" != typeof window ? window : "undefined" != typeof global ? global : "undefined" != typeof globalThis ? globalThis : "undefined" != typeof self ? self : {};
         e.SENTRY_RELEASE = { id: "CURRENT_SHA" };
@@ -13,7 +13,7 @@ test(import.meta.url, ({ runBundler, readOutputFiles, runFileInNode }) => {
         n && (e._sentryDebugIds = e._sentryDebugIds || {}, e._sentryDebugIds[n] = "00000000-0000-0000-0000-000000000000", e._sentryDebugIdIdentifier = "sentry-dbid-00000000-0000-0000-0000-000000000000");
       } catch (e2) {
       }
-    })();
+    }();
     console.log("hello world");
     //# sourceMappingURL=basic.js.map
     ",

--- a/packages/integration-tests-next/fixtures/vite4/application-key.test.ts
+++ b/packages/integration-tests-next/fixtures/vite4/application-key.test.ts
@@ -5,22 +5,24 @@ test(import.meta.url, ({ runBundler, readOutputFiles }) => {
   runBundler();
   expect(readOutputFiles()).toMatchInlineSnapshot(`
     {
-      "basic.js": "!(function() {
+      "basic.js": "!function() {
       try {
         var e = "undefined" != typeof window ? window : "undefined" != typeof global ? global : "undefined" != typeof globalThis ? globalThis : "undefined" != typeof self ? self : {};
         e.SENTRY_RELEASE = { id: "CURRENT_SHA" };
-        e._sentryModuleMetadata = e._sentryModuleMetadata || {}, e._sentryModuleMetadata[new e.Error().stack] = (function(e2) {
+        e._sentryModuleMetadata = e._sentryModuleMetadata || {}, e._sentryModuleMetadata[new e.Error().stack] = function(e2) {
           for (var n2 = 1; n2 < arguments.length; n2++) {
             var a = arguments[n2];
-            if (null != a) for (var t in a) a.hasOwnProperty(t) && (e2[t] = a[t]);
+            if (null != a)
+              for (var t in a)
+                a.hasOwnProperty(t) && (e2[t] = a[t]);
           }
           return e2;
-        })({}, e._sentryModuleMetadata[new e.Error().stack], { "_sentryBundlerPluginAppKey:1234567890abcdef": true });
+        }({}, e._sentryModuleMetadata[new e.Error().stack], { "_sentryBundlerPluginAppKey:1234567890abcdef": true });
         var n = new e.Error().stack;
         n && (e._sentryDebugIds = e._sentryDebugIds || {}, e._sentryDebugIds[n] = "00000000-0000-0000-0000-000000000000", e._sentryDebugIdIdentifier = "sentry-dbid-00000000-0000-0000-0000-000000000000");
       } catch (e2) {
       }
-    })();
+    }();
     console.log("hello world");
     ",
     }

--- a/packages/integration-tests-next/fixtures/vite4/basic-cjs.test.ts
+++ b/packages/integration-tests-next/fixtures/vite4/basic-cjs.test.ts
@@ -5,7 +5,7 @@ test(import.meta.url, ({ runBundler, readOutputFiles, runFileInNode }) => {
   runBundler();
   expect(readOutputFiles()).toMatchInlineSnapshot(`
     {
-      "basic.js": "!(function() {
+      "basic.js": "!function() {
       try {
         var e = "undefined" != typeof window ? window : "undefined" != typeof global ? global : "undefined" != typeof globalThis ? globalThis : "undefined" != typeof self ? self : {};
         e.SENTRY_RELEASE = { id: "CURRENT_SHA" };
@@ -13,7 +13,7 @@ test(import.meta.url, ({ runBundler, readOutputFiles, runFileInNode }) => {
         n && (e._sentryDebugIds = e._sentryDebugIds || {}, e._sentryDebugIds[n] = "00000000-0000-0000-0000-000000000000", e._sentryDebugIdIdentifier = "sentry-dbid-00000000-0000-0000-0000-000000000000");
       } catch (e2) {
       }
-    })();
+    }();
     console.log("hello world");
     ",
       "sentry-cli-mock.json": "["releases","new","CURRENT_SHA"],

--- a/packages/integration-tests-next/fixtures/vite4/basic-release-disabled.test.ts
+++ b/packages/integration-tests-next/fixtures/vite4/basic-release-disabled.test.ts
@@ -5,14 +5,14 @@ test(import.meta.url, ({ runBundler, readOutputFiles }) => {
   runBundler();
   expect(readOutputFiles()).toMatchInlineSnapshot(`
     {
-      "basic.js": "!(function() {
+      "basic.js": "!function() {
       try {
         var e = "undefined" != typeof window ? window : "undefined" != typeof global ? global : "undefined" != typeof globalThis ? globalThis : "undefined" != typeof self ? self : {};
         var n = new e.Error().stack;
         n && (e._sentryDebugIds = e._sentryDebugIds || {}, e._sentryDebugIds[n] = "00000000-0000-0000-0000-000000000000", e._sentryDebugIdIdentifier = "sentry-dbid-00000000-0000-0000-0000-000000000000");
       } catch (e2) {
       }
-    })();
+    }();
     console.log("hello world");
     ",
     }

--- a/packages/integration-tests-next/fixtures/vite4/basic-sourcemaps.test.ts
+++ b/packages/integration-tests-next/fixtures/vite4/basic-sourcemaps.test.ts
@@ -5,7 +5,7 @@ test(import.meta.url, ({ runBundler, readOutputFiles, runFileInNode }) => {
   runBundler();
   expect(readOutputFiles()).toMatchInlineSnapshot(`
     {
-      "basic.js": "!(function() {
+      "basic.js": "!function() {
       try {
         var e = "undefined" != typeof window ? window : "undefined" != typeof global ? global : "undefined" != typeof globalThis ? globalThis : "undefined" != typeof self ? self : {};
         e.SENTRY_RELEASE = { id: "CURRENT_SHA" };
@@ -13,7 +13,7 @@ test(import.meta.url, ({ runBundler, readOutputFiles, runFileInNode }) => {
         n && (e._sentryDebugIds = e._sentryDebugIds || {}, e._sentryDebugIds[n] = "00000000-0000-0000-0000-000000000000", e._sentryDebugIdIdentifier = "sentry-dbid-00000000-0000-0000-0000-000000000000");
       } catch (e2) {
       }
-    })();
+    }();
     console.log("hello world");
     //# sourceMappingURL=basic.js.map
     ",

--- a/packages/integration-tests-next/fixtures/vite4/basic.test.ts
+++ b/packages/integration-tests-next/fixtures/vite4/basic.test.ts
@@ -5,7 +5,7 @@ test(import.meta.url, ({ runBundler, readOutputFiles, runFileInNode }) => {
   runBundler();
   expect(readOutputFiles()).toMatchInlineSnapshot(`
     {
-      "basic.js": "!(function() {
+      "basic.js": "!function() {
       try {
         var e = "undefined" != typeof window ? window : "undefined" != typeof global ? global : "undefined" != typeof globalThis ? globalThis : "undefined" != typeof self ? self : {};
         e.SENTRY_RELEASE = { id: "CURRENT_SHA" };
@@ -13,7 +13,7 @@ test(import.meta.url, ({ runBundler, readOutputFiles, runFileInNode }) => {
         n && (e._sentryDebugIds = e._sentryDebugIds || {}, e._sentryDebugIds[n] = "00000000-0000-0000-0000-000000000000", e._sentryDebugIdIdentifier = "sentry-dbid-00000000-0000-0000-0000-000000000000");
       } catch (e2) {
       }
-    })();
+    }();
     console.log("hello world");
     ",
       "sentry-cli-mock.json": "["releases","new","CURRENT_SHA"],

--- a/packages/integration-tests-next/fixtures/vite4/build-info.test.ts
+++ b/packages/integration-tests-next/fixtures/vite4/build-info.test.ts
@@ -5,7 +5,7 @@ test(import.meta.url, ({ runBundler, readOutputFiles }) => {
   runBundler();
   expect(readOutputFiles()).toMatchInlineSnapshot(`
     {
-      "basic.js": "!(function() {
+      "basic.js": "!function() {
       try {
         var e = "undefined" != typeof window ? window : "undefined" != typeof global ? global : "undefined" != typeof globalThis ? globalThis : "undefined" != typeof self ? self : {};
         e.SENTRY_RELEASE = { id: "build-information-injection-test" };
@@ -14,7 +14,7 @@ test(import.meta.url, ({ runBundler, readOutputFiles }) => {
         n && (e._sentryDebugIds = e._sentryDebugIds || {}, e._sentryDebugIds[n] = "00000000-0000-0000-0000-000000000000", e._sentryDebugIdIdentifier = "sentry-dbid-00000000-0000-0000-0000-000000000000");
       } catch (e2) {
       }
-    })();
+    }();
     console.log("hello world");
     ",
     }

--- a/packages/integration-tests-next/fixtures/vite4/bundle-size-optimizations.test.ts
+++ b/packages/integration-tests-next/fixtures/vite4/bundle-size-optimizations.test.ts
@@ -5,7 +5,7 @@ test(import.meta.url, ({ runBundler, readOutputFiles, runFileInNode }) => {
   runBundler();
   expect(readOutputFiles()).toMatchInlineSnapshot(`
     {
-      "bundle.js": "!(function() {
+      "bundle.js": "!function() {
       try {
         var e = "undefined" != typeof window ? window : "undefined" != typeof global ? global : "undefined" != typeof globalThis ? globalThis : "undefined" != typeof self ? self : {};
         e.SENTRY_RELEASE = { id: "CURRENT_SHA" };
@@ -13,7 +13,7 @@ test(import.meta.url, ({ runBundler, readOutputFiles, runFileInNode }) => {
         n && (e._sentryDebugIds = e._sentryDebugIds || {}, e._sentryDebugIds[n] = "00000000-0000-0000-0000-000000000000", e._sentryDebugIdIdentifier = "sentry-dbid-00000000-0000-0000-0000-000000000000");
       } catch (e2) {
       }
-    })();
+    }();
     console.log(
       JSON.stringify({
         debug: "b",

--- a/packages/integration-tests-next/fixtures/vite4/component-annotation-disabled.test.ts
+++ b/packages/integration-tests-next/fixtures/vite4/component-annotation-disabled.test.ts
@@ -5,7 +5,7 @@ test(import.meta.url, ({ runBundler, readOutputFiles }) => {
   runBundler();
   expect(readOutputFiles()).toMatchInlineSnapshot(`
     {
-      "app.js": "!(function() {
+      "app.js": "!function() {
       try {
         var e = "undefined" != typeof window ? window : "undefined" != typeof global ? global : "undefined" != typeof globalThis ? globalThis : "undefined" != typeof self ? self : {};
         e.SENTRY_RELEASE = { id: "CURRENT_SHA" };
@@ -13,7 +13,7 @@ test(import.meta.url, ({ runBundler, readOutputFiles }) => {
         n && (e._sentryDebugIds = e._sentryDebugIds || {}, e._sentryDebugIds[n] = "00000000-0000-0000-0000-000000000000", e._sentryDebugIdIdentifier = "sentry-dbid-00000000-0000-0000-0000-000000000000");
       } catch (e2) {
       }
-    })();
+    }();
     import { jsx, jsxs } from "../node_modules/.pnpm/react@19.2.4/node_modules/react/jsx-runtime.js";
     function ComponentA() {
       return /* @__PURE__ */ jsx("span", { children: "Component A" });

--- a/packages/integration-tests-next/fixtures/vite4/component-annotation-next.test.ts
+++ b/packages/integration-tests-next/fixtures/vite4/component-annotation-next.test.ts
@@ -5,7 +5,7 @@ test(import.meta.url, ({ runBundler, readOutputFiles }) => {
   runBundler();
   expect(readOutputFiles()).toMatchInlineSnapshot(`
     {
-      "app.js": "!(function() {
+      "app.js": "!function() {
       try {
         var e = "undefined" != typeof window ? window : "undefined" != typeof global ? global : "undefined" != typeof globalThis ? globalThis : "undefined" != typeof self ? self : {};
         e.SENTRY_RELEASE = { id: "CURRENT_SHA" };
@@ -13,7 +13,7 @@ test(import.meta.url, ({ runBundler, readOutputFiles }) => {
         n && (e._sentryDebugIds = e._sentryDebugIds || {}, e._sentryDebugIds[n] = "00000000-0000-0000-0000-000000000000", e._sentryDebugIdIdentifier = "sentry-dbid-00000000-0000-0000-0000-000000000000");
       } catch (e2) {
       }
-    })();
+    }();
     import { jsx, jsxs } from "../node_modules/.pnpm/react@19.2.4/node_modules/react/jsx-runtime.js";
     function ComponentA() {
       return /* @__PURE__ */ jsx("span", { "data-sentry-component": "ComponentA", children: "Component A" });

--- a/packages/integration-tests-next/fixtures/vite4/component-annotation.test.ts
+++ b/packages/integration-tests-next/fixtures/vite4/component-annotation.test.ts
@@ -5,7 +5,7 @@ test(import.meta.url, ({ runBundler, readOutputFiles }) => {
   runBundler();
   expect(readOutputFiles()).toMatchInlineSnapshot(`
     {
-      "app.js": "!(function() {
+      "app.js": "!function() {
       try {
         var e = "undefined" != typeof window ? window : "undefined" != typeof global ? global : "undefined" != typeof globalThis ? globalThis : "undefined" != typeof self ? self : {};
         e.SENTRY_RELEASE = { id: "CURRENT_SHA" };
@@ -13,7 +13,7 @@ test(import.meta.url, ({ runBundler, readOutputFiles }) => {
         n && (e._sentryDebugIds = e._sentryDebugIds || {}, e._sentryDebugIds[n] = "00000000-0000-0000-0000-000000000000", e._sentryDebugIdIdentifier = "sentry-dbid-00000000-0000-0000-0000-000000000000");
       } catch (e2) {
       }
-    })();
+    }();
     import { jsx, jsxs } from "../node_modules/.pnpm/react@19.2.4/node_modules/react/jsx-runtime.js";
     function ComponentA() {
       return /* @__PURE__ */ jsx("span", { "data-sentry-component": "ComponentA", "data-sentry-source-file": "component-a.jsx", children: "Component A" });

--- a/packages/integration-tests-next/fixtures/vite4/dont-mess-up-user-code.test.ts
+++ b/packages/integration-tests-next/fixtures/vite4/dont-mess-up-user-code.test.ts
@@ -5,7 +5,7 @@ test(import.meta.url, ({ runBundler, readOutputFiles, runFileInNode }) => {
   runBundler();
   expect(readOutputFiles()).toMatchInlineSnapshot(`
     {
-      "index.js": "!(function() {
+      "index.js": "!function() {
       try {
         var e = "undefined" != typeof window ? window : "undefined" != typeof global ? global : "undefined" != typeof globalThis ? globalThis : "undefined" != typeof self ? self : {};
         e.SENTRY_RELEASE = { id: "I am release!" };
@@ -13,7 +13,7 @@ test(import.meta.url, ({ runBundler, readOutputFiles, runFileInNode }) => {
         n && (e._sentryDebugIds = e._sentryDebugIds || {}, e._sentryDebugIds[n] = "00000000-0000-0000-0000-000000000000", e._sentryDebugIdIdentifier = "sentry-dbid-00000000-0000-0000-0000-000000000000");
       } catch (e2) {
       }
-    })();
+    }();
     console.log("I am import!");
     console.log("I am index!");
     //# sourceMappingURL=index.js.map

--- a/packages/integration-tests-next/fixtures/vite4/module-metadata.test.ts
+++ b/packages/integration-tests-next/fixtures/vite4/module-metadata.test.ts
@@ -5,22 +5,24 @@ test(import.meta.url, ({ runBundler, readOutputFiles, runFileInNode }) => {
   runBundler();
   expect(readOutputFiles()).toMatchInlineSnapshot(`
     {
-      "basic.js": "!(function() {
+      "basic.js": "!function() {
       try {
         var e = "undefined" != typeof window ? window : "undefined" != typeof global ? global : "undefined" != typeof globalThis ? globalThis : "undefined" != typeof self ? self : {};
         e.SENTRY_RELEASE = { id: "CURRENT_SHA" };
-        e._sentryModuleMetadata = e._sentryModuleMetadata || {}, e._sentryModuleMetadata[new e.Error().stack] = (function(e2) {
+        e._sentryModuleMetadata = e._sentryModuleMetadata || {}, e._sentryModuleMetadata[new e.Error().stack] = function(e2) {
           for (var n2 = 1; n2 < arguments.length; n2++) {
             var a = arguments[n2];
-            if (null != a) for (var t in a) a.hasOwnProperty(t) && (e2[t] = a[t]);
+            if (null != a)
+              for (var t in a)
+                a.hasOwnProperty(t) && (e2[t] = a[t]);
           }
           return e2;
-        })({}, e._sentryModuleMetadata[new e.Error().stack], { "something": "value", "another": 999 });
+        }({}, e._sentryModuleMetadata[new e.Error().stack], { "something": "value", "another": 999 });
         var n = new e.Error().stack;
         n && (e._sentryDebugIds = e._sentryDebugIds || {}, e._sentryDebugIds[n] = "00000000-0000-0000-0000-000000000000", e._sentryDebugIdIdentifier = "sentry-dbid-00000000-0000-0000-0000-000000000000");
       } catch (e2) {
       }
-    })();
+    }();
     console.log("hello world");
     ",
     }

--- a/packages/integration-tests-next/fixtures/vite4/multiple-entry-points.test.ts
+++ b/packages/integration-tests-next/fixtures/vite4/multiple-entry-points.test.ts
@@ -5,14 +5,14 @@ test(import.meta.url, ({ runBundler, readOutputFiles, runFileInNode }) => {
   runBundler();
   expect(readOutputFiles()).toMatchInlineSnapshot(`
     {
-      "common.js": "!(function() {
+      "common.js": "!function() {
       try {
         var e = "undefined" != typeof window ? window : "undefined" != typeof global ? global : "undefined" != typeof globalThis ? globalThis : "undefined" != typeof self ? self : {};
         var n = new e.Error().stack;
         n && (e._sentryDebugIds = e._sentryDebugIds || {}, e._sentryDebugIds[n] = "00000000-0000-0000-0000-000000000000", e._sentryDebugIdIdentifier = "sentry-dbid-00000000-0000-0000-0000-000000000000");
       } catch (e2) {
       }
-    })();
+    }();
     function add(a, b) {
       return a + b;
     }
@@ -20,25 +20,25 @@ test(import.meta.url, ({ runBundler, readOutputFiles, runFileInNode }) => {
       add as a
     };
     ",
-      "entry1.js": "!(function() {
+      "entry1.js": "!function() {
       try {
         var e = "undefined" != typeof window ? window : "undefined" != typeof global ? global : "undefined" != typeof globalThis ? globalThis : "undefined" != typeof self ? self : {};
         var n = new e.Error().stack;
         n && (e._sentryDebugIds = e._sentryDebugIds || {}, e._sentryDebugIds[n] = "00000000-0000-0000-0000-000000000000", e._sentryDebugIdIdentifier = "sentry-dbid-00000000-0000-0000-0000-000000000000");
       } catch (e2) {
       }
-    })();
+    }();
     import { a as add } from "./common.js";
     console.log(add(1, 2));
     ",
-      "entry2.js": "!(function() {
+      "entry2.js": "!function() {
       try {
         var e = "undefined" != typeof window ? window : "undefined" != typeof global ? global : "undefined" != typeof globalThis ? globalThis : "undefined" != typeof self ? self : {};
         var n = new e.Error().stack;
         n && (e._sentryDebugIds = e._sentryDebugIds || {}, e._sentryDebugIds[n] = "00000000-0000-0000-0000-000000000000", e._sentryDebugIdIdentifier = "sentry-dbid-00000000-0000-0000-0000-000000000000");
       } catch (e2) {
       }
-    })();
+    }();
     import { a as add } from "./common.js";
     console.log(add(2, 4));
     ",

--- a/packages/integration-tests-next/fixtures/vite4/query-param.test.ts
+++ b/packages/integration-tests-next/fixtures/vite4/query-param.test.ts
@@ -10,7 +10,7 @@ test(import.meta.url, ({ runBundler, readOutputFiles, ctx }) => {
   runBundler();
   expect(readOutputFiles()).toMatchInlineSnapshot(`
     {
-      "common.js?seP58q4g": "!(function() {
+      "common.js?seP58q4g": "!function() {
       try {
         var e = "undefined" != typeof window ? window : "undefined" != typeof global ? global : "undefined" != typeof globalThis ? globalThis : "undefined" != typeof self ? self : {};
         e.SENTRY_RELEASE = { id: "CURRENT_SHA" };
@@ -18,7 +18,7 @@ test(import.meta.url, ({ runBundler, readOutputFiles, ctx }) => {
         n && (e._sentryDebugIds = e._sentryDebugIds || {}, e._sentryDebugIds[n] = "00000000-0000-0000-0000-000000000000", e._sentryDebugIdIdentifier = "sentry-dbid-00000000-0000-0000-0000-000000000000");
       } catch (e2) {
       }
-    })();
+    }();
     function add(a, b) {
       return a + b;
     }
@@ -26,7 +26,7 @@ test(import.meta.url, ({ runBundler, readOutputFiles, ctx }) => {
       add as a
     };
     ",
-      "entry1.js": "!(function() {
+      "entry1.js": "!function() {
       try {
         var e = "undefined" != typeof window ? window : "undefined" != typeof global ? global : "undefined" != typeof globalThis ? globalThis : "undefined" != typeof self ? self : {};
         e.SENTRY_RELEASE = { id: "CURRENT_SHA" };
@@ -34,11 +34,11 @@ test(import.meta.url, ({ runBundler, readOutputFiles, ctx }) => {
         n && (e._sentryDebugIds = e._sentryDebugIds || {}, e._sentryDebugIds[n] = "00000000-0000-0000-0000-000000000000", e._sentryDebugIdIdentifier = "sentry-dbid-00000000-0000-0000-0000-000000000000");
       } catch (e2) {
       }
-    })();
+    }();
     import { a as add } from "./common.js?seP58q4g";
     console.log(add(1, 2));
     ",
-      "entry2.js": "!(function() {
+      "entry2.js": "!function() {
       try {
         var e = "undefined" != typeof window ? window : "undefined" != typeof global ? global : "undefined" != typeof globalThis ? globalThis : "undefined" != typeof self ? self : {};
         e.SENTRY_RELEASE = { id: "CURRENT_SHA" };
@@ -46,7 +46,7 @@ test(import.meta.url, ({ runBundler, readOutputFiles, ctx }) => {
         n && (e._sentryDebugIds = e._sentryDebugIds || {}, e._sentryDebugIds[n] = "00000000-0000-0000-0000-000000000000", e._sentryDebugIdIdentifier = "sentry-dbid-00000000-0000-0000-0000-000000000000");
       } catch (e2) {
       }
-    })();
+    }();
     import { a as add } from "./common.js?seP58q4g";
     console.log(add(2, 4));
     ",

--- a/packages/integration-tests-next/fixtures/vite4/release-disabled.test.ts
+++ b/packages/integration-tests-next/fixtures/vite4/release-disabled.test.ts
@@ -5,7 +5,7 @@ test(import.meta.url, ({ runBundler, readOutputFiles }) => {
   runBundler();
   expect(readOutputFiles()).toMatchInlineSnapshot(`
     {
-      "basic.js": "!(function() {
+      "basic.js": "!function() {
       try {
         var e = "undefined" != typeof window ? window : "undefined" != typeof global ? global : "undefined" != typeof globalThis ? globalThis : "undefined" != typeof self ? self : {};
         e.SENTRY_RELEASE = { id: "CURRENT_SHA" };
@@ -13,7 +13,7 @@ test(import.meta.url, ({ runBundler, readOutputFiles }) => {
         n && (e._sentryDebugIds = e._sentryDebugIds || {}, e._sentryDebugIds[n] = "00000000-0000-0000-0000-000000000000", e._sentryDebugIdIdentifier = "sentry-dbid-00000000-0000-0000-0000-000000000000");
       } catch (e2) {
       }
-    })();
+    }();
     console.log("hello world");
     ",
       "sentry-cli-mock.json": "["releases","set-commits","CURRENT_SHA","--auto","--ignore-missing"],

--- a/packages/integration-tests-next/fixtures/vite4/telemetry.test.ts
+++ b/packages/integration-tests-next/fixtures/vite4/telemetry.test.ts
@@ -5,7 +5,7 @@ test(import.meta.url, ({ runBundler, readOutputFiles, runFileInNode }) => {
   runBundler();
   expect(readOutputFiles()).toMatchInlineSnapshot(`
     {
-      "basic.js": "!(function() {
+      "basic.js": "!function() {
       try {
         var e = "undefined" != typeof window ? window : "undefined" != typeof global ? global : "undefined" != typeof globalThis ? globalThis : "undefined" != typeof self ? self : {};
         e.SENTRY_RELEASE = { id: "CURRENT_SHA" };
@@ -13,7 +13,7 @@ test(import.meta.url, ({ runBundler, readOutputFiles, runFileInNode }) => {
         n && (e._sentryDebugIds = e._sentryDebugIds || {}, e._sentryDebugIds[n] = "00000000-0000-0000-0000-000000000000", e._sentryDebugIdIdentifier = "sentry-dbid-00000000-0000-0000-0000-000000000000");
       } catch (e2) {
       }
-    })();
+    }();
     console.log("hello world");
     ",
       "sentry-telemetry.json": "[{"sent_at":"TIMESTAMP","sdk":{"name":"sentry.javascript.node","version":"8.30.0"}},[[{"type":"session"},{"sid":"UUID","init":false,"started":"TIMESTAMP","timestamp":"TIMESTAMP","status":"exited","errors":0,"duration":DURATION,"attrs":{"release":"PLUGIN_VERSION","environment":"production"}}]]],

--- a/packages/integration-tests-next/fixtures/vite4/utils.ts
+++ b/packages/integration-tests-next/fixtures/vite4/utils.ts
@@ -33,7 +33,7 @@ export function test(url: string, callback: TestCallback) {
       outDir,
       runBundler: (env) =>
         runBundler(
-          `vite build --config ${testName}${configExt}`,
+          `pnpm vite build --config ${testName}${configExt}`,
           {
             cwd,
             env: {

--- a/packages/integration-tests-next/fixtures/vite4/vite-mpa-extra-modules.test.ts
+++ b/packages/integration-tests-next/fixtures/vite4/vite-mpa-extra-modules.test.ts
@@ -8,7 +8,7 @@ test(import.meta.url, ({ runBundler, readOutputFiles }) => {
       "index.js.map": "{"version":3,"file":"index.js","sources":[],"sourcesContent":[],"names":[],"mappings":""}",
       "page1.js.map": "{"version":3,"file":"page1.js","sources":[],"sourcesContent":[],"names":[],"mappings":";"}",
       "page2.js.map": "{"version":3,"file":"page2.js","sources":[],"sourcesContent":[],"names":[],"mappings":";"}",
-      "shared-module.js": "!(function() {
+      "shared-module.js": "!function() {
       try {
         var e = "undefined" != typeof window ? window : "undefined" != typeof global ? global : "undefined" != typeof globalThis ? globalThis : "undefined" != typeof self ? self : {};
         e.SENTRY_RELEASE = { id: "CURRENT_SHA" };
@@ -16,31 +16,43 @@ test(import.meta.url, ({ runBundler, readOutputFiles }) => {
         n && (e._sentryDebugIds = e._sentryDebugIds || {}, e._sentryDebugIds[n] = "00000000-0000-0000-0000-000000000000", e._sentryDebugIdIdentifier = "sentry-dbid-00000000-0000-0000-0000-000000000000");
       } catch (e2) {
       }
-    })();
+    }();
     (function polyfill() {
       const relList = document.createElement("link").relList;
-      if (relList && relList.supports && relList.supports("modulepreload")) return;
-      for (const link of document.querySelectorAll('link[rel="modulepreload"]')) processPreload(link);
+      if (relList && relList.supports && relList.supports("modulepreload")) {
+        return;
+      }
+      for (const link of document.querySelectorAll('link[rel="modulepreload"]')) {
+        processPreload(link);
+      }
       new MutationObserver((mutations) => {
         for (const mutation of mutations) {
-          if (mutation.type !== "childList") continue;
-          for (const node of mutation.addedNodes) if (node.tagName === "LINK" && node.rel === "modulepreload") processPreload(node);
+          if (mutation.type !== "childList") {
+            continue;
+          }
+          for (const node of mutation.addedNodes) {
+            if (node.tagName === "LINK" && node.rel === "modulepreload")
+              processPreload(node);
+          }
         }
-      }).observe(document, {
-        childList: true,
-        subtree: true
-      });
+      }).observe(document, { childList: true, subtree: true });
       function getFetchOpts(link) {
         const fetchOpts = {};
-        if (link.integrity) fetchOpts.integrity = link.integrity;
-        if (link.referrerPolicy) fetchOpts.referrerPolicy = link.referrerPolicy;
-        if (link.crossOrigin === "use-credentials") fetchOpts.credentials = "include";
-        else if (link.crossOrigin === "anonymous") fetchOpts.credentials = "omit";
-        else fetchOpts.credentials = "same-origin";
+        if (link.integrity)
+          fetchOpts.integrity = link.integrity;
+        if (link.referrerPolicy)
+          fetchOpts.referrerPolicy = link.referrerPolicy;
+        if (link.crossOrigin === "use-credentials")
+          fetchOpts.credentials = "include";
+        else if (link.crossOrigin === "anonymous")
+          fetchOpts.credentials = "omit";
+        else
+          fetchOpts.credentials = "same-origin";
         return fetchOpts;
       }
       function processPreload(link) {
-        if (link.ep) return;
+        if (link.ep)
+          return;
         link.ep = true;
         const fetchOpts = getFetchOpts(link);
         fetch(link.href, fetchOpts);
@@ -52,7 +64,7 @@ test(import.meta.url, ({ runBundler, readOutputFiles }) => {
     greet("World");
     //# sourceMappingURL=shared-module.js.map
     ",
-      "shared-module.js.map": "{"version":3,"file":"shared-module.js","sources":["../../src/shared-module.js"],"sourcesContent":["// This is a shared module that is used by multiple HTML pages\\nexport function greet(name) {\\n  // eslint-disable-next-line no-console\\n  console.log(\`Hello, \${String(name)}!\`);\\n}\\n\\nexport const VERSION = \\"1.0.0\\";\\n\\n// Side effect: greet on load\\ngreet(\\"World\\");\\n"],"names":[],"mappings":";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;AACO,SAAS,MAAM,MAAM;AAE1B,UAAQ,IAAI,UAAU,OAAO,IAAI,CAAC,GAAG;AACvC;AAKA,MAAM,OAAO;"}",
+      "shared-module.js.map": "{"version":3,"file":"shared-module.js","sources":["../../src/shared-module.js"],"sourcesContent":["// This is a shared module that is used by multiple HTML pages\\nexport function greet(name) {\\n  // eslint-disable-next-line no-console\\n  console.log(\`Hello, \${String(name)}!\`);\\n}\\n\\nexport const VERSION = \\"1.0.0\\";\\n\\n// Side effect: greet on load\\ngreet(\\"World\\");\\n"],"names":[],"mappings":";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;AACO,SAAS,MAAM,MAAM;AAE1B,UAAQ,IAAI,UAAU,OAAO,IAAI,CAAC,GAAG;AACvC;AAKA,MAAM,OAAO;"}",
       "src/vite-mpa-index.html": "<!doctype html>
     <html lang="en">
       <head>
@@ -74,6 +86,7 @@ test(import.meta.url, ({ runBundler, readOutputFiles }) => {
       </head>
       <body>
         <h1>Page 1 - With Shared Module</h1>
+        
       </body>
     </html>
     ",
@@ -86,6 +99,7 @@ test(import.meta.url, ({ runBundler, readOutputFiles }) => {
       </head>
       <body>
         <h1>Page 2 - With Shared Module</h1>
+        
       </body>
     </html>
     ",

--- a/packages/integration-tests-next/fixtures/vite7/utils.ts
+++ b/packages/integration-tests-next/fixtures/vite7/utils.ts
@@ -39,7 +39,7 @@ export function test(url: string, callback: TestCallback) {
         outDir,
         runBundler: (env) =>
           runBundler(
-            `vite build --config ${testName}${configExt}`,
+            `pnpm vite build --config ${testName}${configExt}`,
             {
               cwd,
               env: {

--- a/packages/integration-tests-next/fixtures/vite8/after-upload-deletion.test.ts
+++ b/packages/integration-tests-next/fixtures/vite8/after-upload-deletion.test.ts
@@ -5,18 +5,19 @@ test(import.meta.url, ({ runBundler, readOutputFiles, runFileInNode }) => {
   runBundler();
   expect(readOutputFiles()).toMatchInlineSnapshot(`
     {
-      "basic.js": "!(function() {
-      try {
-        var e = "undefined" != typeof window ? window : "undefined" != typeof global ? global : "undefined" != typeof globalThis ? globalThis : "undefined" != typeof self ? self : {};
-        e.SENTRY_RELEASE = { id: "CURRENT_SHA" };
-        var n = new e.Error().stack;
-        n && (e._sentryDebugIds = e._sentryDebugIds || {}, e._sentryDebugIds[n] = "00000000-0000-0000-0000-000000000000", e._sentryDebugIdIdentifier = "sentry-dbid-00000000-0000-0000-0000-000000000000");
-      } catch (e2) {
-      }
+      "basic.js": "//#region src/basic.js
+    (function() {
+    	try {
+    		var e = "undefined" != typeof window ? window : "undefined" != typeof global ? global : "undefined" != typeof globalThis ? globalThis : "undefined" != typeof self ? self : {};
+    		e.SENTRY_RELEASE = { id: "CURRENT_SHA" };
+    		var n = new e.Error().stack;
+    		n && (e._sentryDebugIds = e._sentryDebugIds || {}, e._sentryDebugIds[n] = "00000000-0000-0000-0000-000000000000", e._sentryDebugIdIdentifier = "sentry-dbid-00000000-0000-0000-0000-000000000000");
+    	} catch (e) {}
     })();
     console.log("hello world");
-    //# sourceMappingURL=basic.js.map
-    ",
+    //#endregion
+
+    //# sourceMappingURL=basic.js.map",
     }
   `);
 

--- a/packages/integration-tests-next/fixtures/vite8/application-key.test.ts
+++ b/packages/integration-tests-next/fixtures/vite8/application-key.test.ts
@@ -5,23 +5,24 @@ test(import.meta.url, ({ runBundler, readOutputFiles }) => {
   runBundler();
   expect(readOutputFiles()).toMatchInlineSnapshot(`
     {
-      "basic.js": "!(function() {
-      try {
-        var e = "undefined" != typeof window ? window : "undefined" != typeof global ? global : "undefined" != typeof globalThis ? globalThis : "undefined" != typeof self ? self : {};
-        e.SENTRY_RELEASE = { id: "CURRENT_SHA" };
-        e._sentryModuleMetadata = e._sentryModuleMetadata || {}, e._sentryModuleMetadata[new e.Error().stack] = (function(e2) {
-          for (var n2 = 1; n2 < arguments.length; n2++) {
-            var a = arguments[n2];
-            if (null != a) for (var t in a) a.hasOwnProperty(t) && (e2[t] = a[t]);
-          }
-          return e2;
-        })({}, e._sentryModuleMetadata[new e.Error().stack], { "_sentryBundlerPluginAppKey:1234567890abcdef": true });
-        var n = new e.Error().stack;
-        n && (e._sentryDebugIds = e._sentryDebugIds || {}, e._sentryDebugIds[n] = "00000000-0000-0000-0000-000000000000", e._sentryDebugIdIdentifier = "sentry-dbid-00000000-0000-0000-0000-000000000000");
-      } catch (e2) {
-      }
+      "basic.js": "//#region src/basic.js
+    (function() {
+    	try {
+    		var e = "undefined" != typeof window ? window : "undefined" != typeof global ? global : "undefined" != typeof globalThis ? globalThis : "undefined" != typeof self ? self : {};
+    		e.SENTRY_RELEASE = { id: "CURRENT_SHA" };
+    		e._sentryModuleMetadata = e._sentryModuleMetadata || {}, e._sentryModuleMetadata[new e.Error().stack] = function(e) {
+    			for (var n = 1; n < arguments.length; n++) {
+    				var a = arguments[n];
+    				if (null != a) for (var t in a) a.hasOwnProperty(t) && (e[t] = a[t]);
+    			}
+    			return e;
+    		}({}, e._sentryModuleMetadata[new e.Error().stack], { "_sentryBundlerPluginAppKey:1234567890abcdef": true });
+    		var n = new e.Error().stack;
+    		n && (e._sentryDebugIds = e._sentryDebugIds || {}, e._sentryDebugIds[n] = "00000000-0000-0000-0000-000000000000", e._sentryDebugIdIdentifier = "sentry-dbid-00000000-0000-0000-0000-000000000000");
+    	} catch (e) {}
     })();
     console.log("hello world");
+    //#endregion
     ",
     }
   `);

--- a/packages/integration-tests-next/fixtures/vite8/basic-cjs.test.ts
+++ b/packages/integration-tests-next/fixtures/vite8/basic-cjs.test.ts
@@ -5,16 +5,17 @@ test(import.meta.url, ({ runBundler, readOutputFiles, runFileInNode }) => {
   runBundler();
   expect(readOutputFiles()).toMatchInlineSnapshot(`
     {
-      "basic.js": "!(function() {
-      try {
-        var e = "undefined" != typeof window ? window : "undefined" != typeof global ? global : "undefined" != typeof globalThis ? globalThis : "undefined" != typeof self ? self : {};
-        e.SENTRY_RELEASE = { id: "CURRENT_SHA" };
-        var n = new e.Error().stack;
-        n && (e._sentryDebugIds = e._sentryDebugIds || {}, e._sentryDebugIds[n] = "00000000-0000-0000-0000-000000000000", e._sentryDebugIdIdentifier = "sentry-dbid-00000000-0000-0000-0000-000000000000");
-      } catch (e2) {
-      }
+      "basic.js": "//#region src/basic.js
+    (function() {
+    	try {
+    		var e = "undefined" != typeof window ? window : "undefined" != typeof global ? global : "undefined" != typeof globalThis ? globalThis : "undefined" != typeof self ? self : {};
+    		e.SENTRY_RELEASE = { id: "CURRENT_SHA" };
+    		var n = new e.Error().stack;
+    		n && (e._sentryDebugIds = e._sentryDebugIds || {}, e._sentryDebugIds[n] = "00000000-0000-0000-0000-000000000000", e._sentryDebugIdIdentifier = "sentry-dbid-00000000-0000-0000-0000-000000000000");
+    	} catch (e) {}
     })();
     console.log("hello world");
+    //#endregion
     ",
       "sentry-cli-mock.json": "["releases","new","CURRENT_SHA"],
     ["releases","set-commits","CURRENT_SHA","--auto","--ignore-missing"],

--- a/packages/integration-tests-next/fixtures/vite8/basic-release-disabled.test.ts
+++ b/packages/integration-tests-next/fixtures/vite8/basic-release-disabled.test.ts
@@ -5,15 +5,16 @@ test(import.meta.url, ({ runBundler, readOutputFiles }) => {
   runBundler();
   expect(readOutputFiles()).toMatchInlineSnapshot(`
     {
-      "basic.js": "!(function() {
-      try {
-        var e = "undefined" != typeof window ? window : "undefined" != typeof global ? global : "undefined" != typeof globalThis ? globalThis : "undefined" != typeof self ? self : {};
-        var n = new e.Error().stack;
-        n && (e._sentryDebugIds = e._sentryDebugIds || {}, e._sentryDebugIds[n] = "00000000-0000-0000-0000-000000000000", e._sentryDebugIdIdentifier = "sentry-dbid-00000000-0000-0000-0000-000000000000");
-      } catch (e2) {
-      }
+      "basic.js": "//#region src/basic.js
+    (function() {
+    	try {
+    		var e = "undefined" != typeof window ? window : "undefined" != typeof global ? global : "undefined" != typeof globalThis ? globalThis : "undefined" != typeof self ? self : {};
+    		var n = new e.Error().stack;
+    		n && (e._sentryDebugIds = e._sentryDebugIds || {}, e._sentryDebugIds[n] = "00000000-0000-0000-0000-000000000000", e._sentryDebugIdIdentifier = "sentry-dbid-00000000-0000-0000-0000-000000000000");
+    	} catch (e) {}
     })();
     console.log("hello world");
+    //#endregion
     ",
     }
   `);

--- a/packages/integration-tests-next/fixtures/vite8/basic-sourcemaps.test.ts
+++ b/packages/integration-tests-next/fixtures/vite8/basic-sourcemaps.test.ts
@@ -5,19 +5,20 @@ test(import.meta.url, ({ runBundler, readOutputFiles, runFileInNode }) => {
   runBundler();
   expect(readOutputFiles()).toMatchInlineSnapshot(`
     {
-      "basic.js": "!(function() {
-      try {
-        var e = "undefined" != typeof window ? window : "undefined" != typeof global ? global : "undefined" != typeof globalThis ? globalThis : "undefined" != typeof self ? self : {};
-        e.SENTRY_RELEASE = { id: "CURRENT_SHA" };
-        var n = new e.Error().stack;
-        n && (e._sentryDebugIds = e._sentryDebugIds || {}, e._sentryDebugIds[n] = "00000000-0000-0000-0000-000000000000", e._sentryDebugIdIdentifier = "sentry-dbid-00000000-0000-0000-0000-000000000000");
-      } catch (e2) {
-      }
+      "basic.js": "//#region src/basic.js
+    (function() {
+    	try {
+    		var e = "undefined" != typeof window ? window : "undefined" != typeof global ? global : "undefined" != typeof globalThis ? globalThis : "undefined" != typeof self ? self : {};
+    		e.SENTRY_RELEASE = { id: "CURRENT_SHA" };
+    		var n = new e.Error().stack;
+    		n && (e._sentryDebugIds = e._sentryDebugIds || {}, e._sentryDebugIds[n] = "00000000-0000-0000-0000-000000000000", e._sentryDebugIdIdentifier = "sentry-dbid-00000000-0000-0000-0000-000000000000");
+    	} catch (e) {}
     })();
     console.log("hello world");
-    //# sourceMappingURL=basic.js.map
-    ",
-      "basic.js.map": "{"version":3,"file":"basic.js","sources":["../../src/basic.js"],"sourcesContent":["// eslint-disable-next-line no-console\\nconsole.log(\\"hello world\\");\\n"],"names":[],"mappings":";;;;;;;;;AACA,QAAQ,IAAI,aAAa;"}",
+    //#endregion
+
+    //# sourceMappingURL=basic.js.map",
+      "basic.js.map": "{"version":3,"file":"basic.js","names":[],"sources":["../../src/basic.js"],"sourcesContent":["// eslint-disable-next-line no-console\\nconsole.log(\\"hello world\\");\\n"],"mappings":";;;;;;;;;AACA,QAAQ,IAAI,cAAc"}",
       "sentry-cli-mock.json": "["releases","new","CURRENT_SHA"],
     ["releases","set-commits","CURRENT_SHA","--auto","--ignore-missing"],
     ["releases","finalize","CURRENT_SHA"],

--- a/packages/integration-tests-next/fixtures/vite8/basic.test.ts
+++ b/packages/integration-tests-next/fixtures/vite8/basic.test.ts
@@ -5,16 +5,17 @@ test(import.meta.url, ({ runBundler, readOutputFiles, runFileInNode }) => {
   runBundler();
   expect(readOutputFiles()).toMatchInlineSnapshot(`
     {
-      "basic.js": "!(function() {
-      try {
-        var e = "undefined" != typeof window ? window : "undefined" != typeof global ? global : "undefined" != typeof globalThis ? globalThis : "undefined" != typeof self ? self : {};
-        e.SENTRY_RELEASE = { id: "CURRENT_SHA" };
-        var n = new e.Error().stack;
-        n && (e._sentryDebugIds = e._sentryDebugIds || {}, e._sentryDebugIds[n] = "00000000-0000-0000-0000-000000000000", e._sentryDebugIdIdentifier = "sentry-dbid-00000000-0000-0000-0000-000000000000");
-      } catch (e2) {
-      }
+      "basic.js": "//#region src/basic.js
+    (function() {
+    	try {
+    		var e = "undefined" != typeof window ? window : "undefined" != typeof global ? global : "undefined" != typeof globalThis ? globalThis : "undefined" != typeof self ? self : {};
+    		e.SENTRY_RELEASE = { id: "CURRENT_SHA" };
+    		var n = new e.Error().stack;
+    		n && (e._sentryDebugIds = e._sentryDebugIds || {}, e._sentryDebugIds[n] = "00000000-0000-0000-0000-000000000000", e._sentryDebugIdIdentifier = "sentry-dbid-00000000-0000-0000-0000-000000000000");
+    	} catch (e) {}
     })();
     console.log("hello world");
+    //#endregion
     ",
       "sentry-cli-mock.json": "["releases","new","CURRENT_SHA"],
     ["releases","set-commits","CURRENT_SHA","--auto","--ignore-missing"],

--- a/packages/integration-tests-next/fixtures/vite8/build-info.test.ts
+++ b/packages/integration-tests-next/fixtures/vite8/build-info.test.ts
@@ -5,17 +5,30 @@ test(import.meta.url, ({ runBundler, readOutputFiles }) => {
   runBundler();
   expect(readOutputFiles()).toMatchInlineSnapshot(`
     {
-      "basic.js": "!(function() {
-      try {
-        var e = "undefined" != typeof window ? window : "undefined" != typeof global ? global : "undefined" != typeof globalThis ? globalThis : "undefined" != typeof self ? self : {};
-        e.SENTRY_RELEASE = { id: "build-information-injection-test" };
-        e.SENTRY_BUILD_INFO = { "deps": ["@sentry/vite-plugin", "@vitejs/plugin-react", "react", "vite"], "depsVersions": { "react": 19, "vite": 8 }, "nodeVersion":"NODE_VERSION" };
-        var n = new e.Error().stack;
-        n && (e._sentryDebugIds = e._sentryDebugIds || {}, e._sentryDebugIds[n] = "00000000-0000-0000-0000-000000000000", e._sentryDebugIdIdentifier = "sentry-dbid-00000000-0000-0000-0000-000000000000");
-      } catch (e2) {
-      }
+      "basic.js": "//#region src/basic.js
+    (function() {
+    	try {
+    		var e = "undefined" != typeof window ? window : "undefined" != typeof global ? global : "undefined" != typeof globalThis ? globalThis : "undefined" != typeof self ? self : {};
+    		e.SENTRY_RELEASE = { id: "build-information-injection-test" };
+    		e.SENTRY_BUILD_INFO = {
+    			"deps": [
+    				"@sentry/vite-plugin",
+    				"@vitejs/plugin-react",
+    				"react",
+    				"vite"
+    			],
+    			"depsVersions": {
+    				"react": 19,
+    				"vite": 8
+    			},
+    			"nodeVersion":"NODE_VERSION"
+    		};
+    		var n = new e.Error().stack;
+    		n && (e._sentryDebugIds = e._sentryDebugIds || {}, e._sentryDebugIds[n] = "00000000-0000-0000-0000-000000000000", e._sentryDebugIdIdentifier = "sentry-dbid-00000000-0000-0000-0000-000000000000");
+    	} catch (e) {}
     })();
     console.log("hello world");
+    //#endregion
     ",
     }
   `);

--- a/packages/integration-tests-next/fixtures/vite8/bundle-size-optimizations.test.ts
+++ b/packages/integration-tests-next/fixtures/vite8/bundle-size-optimizations.test.ts
@@ -5,25 +5,24 @@ test(import.meta.url, ({ runBundler, readOutputFiles, runFileInNode }) => {
   runBundler();
   expect(readOutputFiles()).toMatchInlineSnapshot(`
     {
-      "bundle.js": "!(function() {
-      try {
-        var e = "undefined" != typeof window ? window : "undefined" != typeof global ? global : "undefined" != typeof globalThis ? globalThis : "undefined" != typeof self ? self : {};
-        e.SENTRY_RELEASE = { id: "CURRENT_SHA" };
-        var n = new e.Error().stack;
-        n && (e._sentryDebugIds = e._sentryDebugIds || {}, e._sentryDebugIds[n] = "00000000-0000-0000-0000-000000000000", e._sentryDebugIdIdentifier = "sentry-dbid-00000000-0000-0000-0000-000000000000");
-      } catch (e2) {
-      }
+      "bundle.js": "//#region src/bundle.js
+    (function() {
+    	try {
+    		var e = "undefined" != typeof window ? window : "undefined" != typeof global ? global : "undefined" != typeof globalThis ? globalThis : "undefined" != typeof self ? self : {};
+    		e.SENTRY_RELEASE = { id: "CURRENT_SHA" };
+    		var n = new e.Error().stack;
+    		n && (e._sentryDebugIds = e._sentryDebugIds || {}, e._sentryDebugIds[n] = "00000000-0000-0000-0000-000000000000", e._sentryDebugIdIdentifier = "sentry-dbid-00000000-0000-0000-0000-000000000000");
+    	} catch (e) {}
     })();
-    console.log(
-      JSON.stringify({
-        debug: "b",
-        trace: "b",
-        replayCanvas: "a",
-        replayIframe: "a",
-        replayShadowDom: "a",
-        replayWorker: "a"
-      })
-    );
+    console.log(JSON.stringify({
+    	debug: "b",
+    	trace: "b",
+    	replayCanvas: "a",
+    	replayIframe: "a",
+    	replayShadowDom: "a",
+    	replayWorker: "a"
+    }));
+    //#endregion
     ",
     }
   `);

--- a/packages/integration-tests-next/fixtures/vite8/component-annotation-disabled.test.ts
+++ b/packages/integration-tests-next/fixtures/vite8/component-annotation-disabled.test.ts
@@ -5,22 +5,40 @@ test(import.meta.url, ({ runBundler, readOutputFiles }) => {
   runBundler();
   expect(readOutputFiles()).toMatchInlineSnapshot(`
     {
-      "app.js": "!(function() {
-      try {
-        var e = "undefined" != typeof window ? window : "undefined" != typeof global ? global : "undefined" != typeof globalThis ? globalThis : "undefined" != typeof self ? self : {};
-        e.SENTRY_RELEASE = { id: "CURRENT_SHA" };
-        var n = new e.Error().stack;
-        n && (e._sentryDebugIds = e._sentryDebugIds || {}, e._sentryDebugIds[n] = "00000000-0000-0000-0000-000000000000", e._sentryDebugIdIdentifier = "sentry-dbid-00000000-0000-0000-0000-000000000000");
-      } catch (e2) {
-      }
+      "app.js": "(function() {
+    	try {
+    		var e = "undefined" != typeof window ? window : "undefined" != typeof global ? global : "undefined" != typeof globalThis ? globalThis : "undefined" != typeof self ? self : {};
+    		e.SENTRY_RELEASE = { id: "CURRENT_SHA" };
+    		var n = new e.Error().stack;
+    		n && (e._sentryDebugIds = e._sentryDebugIds || {}, e._sentryDebugIds[n] = "00000000-0000-0000-0000-000000000000", e._sentryDebugIdIdentifier = "sentry-dbid-00000000-0000-0000-0000-000000000000");
+    	} catch (e) {}
     })();
+    import { jsxDEV } from "../node_modules/.pnpm/react@19.2.4/node_modules/react/jsx-dev-runtime.js";
+    //#region src/component-a.jsx
+    var _jsxFileName$1 = "/Users/tim/Documents/Repositories/sentry-javascript-bundler-plugins/packages/integration-tests-next/fixtures/vite8/src/component-a.jsx";
     function ComponentA() {
-      return /* @__PURE__ */ React.createElement("span", null, "Component A");
+    	return /* @__PURE__ */ jsxDEV("span", { children: "Component A" }, void 0, false, {
+    		fileName: _jsxFileName$1,
+    		lineNumber: 2,
+    		columnNumber: 10
+    	}, this);
     }
+    //#endregion
+    //#region src/app.jsx
+    var _jsxFileName = "/Users/tim/Documents/Repositories/sentry-javascript-bundler-plugins/packages/integration-tests-next/fixtures/vite8/src/app.jsx";
     function App() {
-      return /* @__PURE__ */ React.createElement("span", null, /* @__PURE__ */ React.createElement(ComponentA, null), ";");
+    	return /* @__PURE__ */ jsxDEV("span", { children: [/* @__PURE__ */ jsxDEV(ComponentA, {}, void 0, false, {
+    		fileName: _jsxFileName,
+    		lineNumber: 6,
+    		columnNumber: 7
+    	}, this), ";"] }, void 0, true, {
+    		fileName: _jsxFileName,
+    		lineNumber: 5,
+    		columnNumber: 5
+    	}, this);
     }
     console.log(App());
+    //#endregion
     ",
     }
   `);

--- a/packages/integration-tests-next/fixtures/vite8/component-annotation-disabled.test.ts
+++ b/packages/integration-tests-next/fixtures/vite8/component-annotation-disabled.test.ts
@@ -15,7 +15,7 @@ test(import.meta.url, ({ runBundler, readOutputFiles }) => {
     })();
     import { jsxDEV } from "../node_modules/.pnpm/react@19.2.4/node_modules/react/jsx-dev-runtime.js";
     //#region src/component-a.jsx
-    var _jsxFileName$1 = "/Users/tim/Documents/Repositories/sentry-javascript-bundler-plugins/packages/integration-tests-next/fixtures/vite8/src/component-a.jsx";
+    var _jsxFileName$1 = "/fixtures/vite8/src/component-a.jsx";
     function ComponentA() {
     	return /* @__PURE__ */ jsxDEV("span", { children: "Component A" }, void 0, false, {
     		fileName: _jsxFileName$1,
@@ -25,7 +25,7 @@ test(import.meta.url, ({ runBundler, readOutputFiles }) => {
     }
     //#endregion
     //#region src/app.jsx
-    var _jsxFileName = "/Users/tim/Documents/Repositories/sentry-javascript-bundler-plugins/packages/integration-tests-next/fixtures/vite8/src/app.jsx";
+    var _jsxFileName = "/fixtures/vite8/src/app.jsx";
     function App() {
     	return /* @__PURE__ */ jsxDEV("span", { children: [/* @__PURE__ */ jsxDEV(ComponentA, {}, void 0, false, {
     		fileName: _jsxFileName,

--- a/packages/integration-tests-next/fixtures/vite8/component-annotation-next.test.ts
+++ b/packages/integration-tests-next/fixtures/vite8/component-annotation-next.test.ts
@@ -15,7 +15,7 @@ test(import.meta.url, ({ runBundler, readOutputFiles }) => {
     })();
     import { jsxDEV } from "../node_modules/.pnpm/react@19.2.4/node_modules/react/jsx-dev-runtime.js";
     //#region src/component-a.jsx
-    var _jsxFileName$1 = "/Users/tim/Documents/Repositories/sentry-javascript-bundler-plugins/packages/integration-tests-next/fixtures/vite8/src/component-a.jsx";
+    var _jsxFileName$1 = "/fixtures/vite8/src/component-a.jsx";
     function ComponentA() {
     	return /* @__PURE__ */ jsxDEV("span", {
     		"data-sentry-component": "ComponentA",
@@ -28,7 +28,7 @@ test(import.meta.url, ({ runBundler, readOutputFiles }) => {
     }
     //#endregion
     //#region src/app.jsx
-    var _jsxFileName = "/Users/tim/Documents/Repositories/sentry-javascript-bundler-plugins/packages/integration-tests-next/fixtures/vite8/src/app.jsx";
+    var _jsxFileName = "/fixtures/vite8/src/app.jsx";
     function App() {
     	return /* @__PURE__ */ jsxDEV("span", {
     		"data-sentry-component": "App",

--- a/packages/integration-tests-next/fixtures/vite8/component-annotation-next.test.ts
+++ b/packages/integration-tests-next/fixtures/vite8/component-annotation-next.test.ts
@@ -5,22 +5,46 @@ test(import.meta.url, ({ runBundler, readOutputFiles }) => {
   runBundler();
   expect(readOutputFiles()).toMatchInlineSnapshot(`
     {
-      "app.js": "!(function() {
-      try {
-        var e = "undefined" != typeof window ? window : "undefined" != typeof global ? global : "undefined" != typeof globalThis ? globalThis : "undefined" != typeof self ? self : {};
-        e.SENTRY_RELEASE = { id: "CURRENT_SHA" };
-        var n = new e.Error().stack;
-        n && (e._sentryDebugIds = e._sentryDebugIds || {}, e._sentryDebugIds[n] = "00000000-0000-0000-0000-000000000000", e._sentryDebugIdIdentifier = "sentry-dbid-00000000-0000-0000-0000-000000000000");
-      } catch (e2) {
-      }
+      "app.js": "(function() {
+    	try {
+    		var e = "undefined" != typeof window ? window : "undefined" != typeof global ? global : "undefined" != typeof globalThis ? globalThis : "undefined" != typeof self ? self : {};
+    		e.SENTRY_RELEASE = { id: "CURRENT_SHA" };
+    		var n = new e.Error().stack;
+    		n && (e._sentryDebugIds = e._sentryDebugIds || {}, e._sentryDebugIds[n] = "00000000-0000-0000-0000-000000000000", e._sentryDebugIdIdentifier = "sentry-dbid-00000000-0000-0000-0000-000000000000");
+    	} catch (e) {}
     })();
+    import { jsxDEV } from "../node_modules/.pnpm/react@19.2.4/node_modules/react/jsx-dev-runtime.js";
+    //#region src/component-a.jsx
+    var _jsxFileName$1 = "/Users/tim/Documents/Repositories/sentry-javascript-bundler-plugins/packages/integration-tests-next/fixtures/vite8/src/component-a.jsx";
     function ComponentA() {
-      return /* @__PURE__ */ React.createElement("span", { "data-sentry-component": "ComponentA" }, "Component A");
+    	return /* @__PURE__ */ jsxDEV("span", {
+    		"data-sentry-component": "ComponentA",
+    		children: "Component A"
+    	}, void 0, false, {
+    		fileName: _jsxFileName$1,
+    		lineNumber: 2,
+    		columnNumber: 10
+    	}, this);
     }
+    //#endregion
+    //#region src/app.jsx
+    var _jsxFileName = "/Users/tim/Documents/Repositories/sentry-javascript-bundler-plugins/packages/integration-tests-next/fixtures/vite8/src/app.jsx";
     function App() {
-      return /* @__PURE__ */ React.createElement("span", { "data-sentry-component": "App" }, /* @__PURE__ */ React.createElement(ComponentA, null), ";");
+    	return /* @__PURE__ */ jsxDEV("span", {
+    		"data-sentry-component": "App",
+    		children: [/* @__PURE__ */ jsxDEV(ComponentA, {}, void 0, false, {
+    			fileName: _jsxFileName,
+    			lineNumber: 4,
+    			columnNumber: 7
+    		}, this), ";"]
+    	}, void 0, true, {
+    		fileName: _jsxFileName,
+    		lineNumber: 3,
+    		columnNumber: 10
+    	}, this);
     }
     console.log(App());
+    //#endregion
     ",
     }
   `);

--- a/packages/integration-tests-next/fixtures/vite8/component-annotation.test.ts
+++ b/packages/integration-tests-next/fixtures/vite8/component-annotation.test.ts
@@ -5,22 +5,51 @@ test(import.meta.url, ({ runBundler, readOutputFiles }) => {
   runBundler();
   expect(readOutputFiles()).toMatchInlineSnapshot(`
     {
-      "app.js": "!(function() {
-      try {
-        var e = "undefined" != typeof window ? window : "undefined" != typeof global ? global : "undefined" != typeof globalThis ? globalThis : "undefined" != typeof self ? self : {};
-        e.SENTRY_RELEASE = { id: "CURRENT_SHA" };
-        var n = new e.Error().stack;
-        n && (e._sentryDebugIds = e._sentryDebugIds || {}, e._sentryDebugIds[n] = "00000000-0000-0000-0000-000000000000", e._sentryDebugIdIdentifier = "sentry-dbid-00000000-0000-0000-0000-000000000000");
-      } catch (e2) {
-      }
+      "app.js": "(function() {
+    	try {
+    		var e = "undefined" != typeof window ? window : "undefined" != typeof global ? global : "undefined" != typeof globalThis ? globalThis : "undefined" != typeof self ? self : {};
+    		e.SENTRY_RELEASE = { id: "CURRENT_SHA" };
+    		var n = new e.Error().stack;
+    		n && (e._sentryDebugIds = e._sentryDebugIds || {}, e._sentryDebugIds[n] = "00000000-0000-0000-0000-000000000000", e._sentryDebugIdIdentifier = "sentry-dbid-00000000-0000-0000-0000-000000000000");
+    	} catch (e) {}
     })();
+    import { jsxDEV } from "../node_modules/.pnpm/react@19.2.4/node_modules/react/jsx-dev-runtime.js";
+    //#region src/component-a.jsx
+    var _jsxFileName$1 = "/Users/tim/Documents/Repositories/sentry-javascript-bundler-plugins/packages/integration-tests-next/fixtures/vite8/src/component-a.jsx";
     function ComponentA() {
-      return /* @__PURE__ */ React.createElement("span", { "data-sentry-component": "ComponentA", "data-sentry-source-file": "component-a.jsx" }, "Component A");
+    	return /* @__PURE__ */ jsxDEV("span", {
+    		"data-sentry-component": "ComponentA",
+    		"data-sentry-source-file": "component-a.jsx",
+    		children: "Component A"
+    	}, void 0, false, {
+    		fileName: _jsxFileName$1,
+    		lineNumber: 2,
+    		columnNumber: 10
+    	}, this);
     }
+    //#endregion
+    //#region src/app.jsx
+    var _jsxFileName = "/Users/tim/Documents/Repositories/sentry-javascript-bundler-plugins/packages/integration-tests-next/fixtures/vite8/src/app.jsx";
     function App() {
-      return /* @__PURE__ */ React.createElement("span", { "data-sentry-component": "App", "data-sentry-source-file": "app.jsx" }, /* @__PURE__ */ React.createElement(ComponentA, { "data-sentry-element": "ComponentA", "data-sentry-source-file": "app.jsx" }), ";");
+    	return /* @__PURE__ */ jsxDEV("span", {
+    		"data-sentry-component": "App",
+    		"data-sentry-source-file": "app.jsx",
+    		children: [/* @__PURE__ */ jsxDEV(ComponentA, {
+    			"data-sentry-element": "ComponentA",
+    			"data-sentry-source-file": "app.jsx"
+    		}, void 0, false, {
+    			fileName: _jsxFileName,
+    			lineNumber: 4,
+    			columnNumber: 7
+    		}, this), ";"]
+    	}, void 0, true, {
+    		fileName: _jsxFileName,
+    		lineNumber: 3,
+    		columnNumber: 10
+    	}, this);
     }
     console.log(App());
+    //#endregion
     ",
     }
   `);

--- a/packages/integration-tests-next/fixtures/vite8/component-annotation.test.ts
+++ b/packages/integration-tests-next/fixtures/vite8/component-annotation.test.ts
@@ -15,7 +15,7 @@ test(import.meta.url, ({ runBundler, readOutputFiles }) => {
     })();
     import { jsxDEV } from "../node_modules/.pnpm/react@19.2.4/node_modules/react/jsx-dev-runtime.js";
     //#region src/component-a.jsx
-    var _jsxFileName$1 = "/Users/tim/Documents/Repositories/sentry-javascript-bundler-plugins/packages/integration-tests-next/fixtures/vite8/src/component-a.jsx";
+    var _jsxFileName$1 = "/fixtures/vite8/src/component-a.jsx";
     function ComponentA() {
     	return /* @__PURE__ */ jsxDEV("span", {
     		"data-sentry-component": "ComponentA",
@@ -29,7 +29,7 @@ test(import.meta.url, ({ runBundler, readOutputFiles }) => {
     }
     //#endregion
     //#region src/app.jsx
-    var _jsxFileName = "/Users/tim/Documents/Repositories/sentry-javascript-bundler-plugins/packages/integration-tests-next/fixtures/vite8/src/app.jsx";
+    var _jsxFileName = "/fixtures/vite8/src/app.jsx";
     function App() {
     	return /* @__PURE__ */ jsxDEV("span", {
     		"data-sentry-component": "App",

--- a/packages/integration-tests-next/fixtures/vite8/debugid-disabled.test.ts
+++ b/packages/integration-tests-next/fixtures/vite8/debugid-disabled.test.ts
@@ -5,10 +5,12 @@ test(import.meta.url, ({ runBundler, readOutputFiles }) => {
   runBundler();
   expect(readOutputFiles()).toMatchInlineSnapshot(`
     {
-      "basic.js": "console.log("hello world");
-    //# sourceMappingURL=basic.js.map
-    ",
-      "basic.js.map": "{"version":3,"file":"basic.js","sources":["../../src/basic.js"],"sourcesContent":["// eslint-disable-next-line no-console\\nconsole.log(\\"hello world\\");\\n"],"names":[],"mappings":"AACA,QAAQ,IAAI,aAAa;"}",
+      "basic.js": "//#region src/basic.js
+    console.log("hello world");
+    //#endregion
+
+    //# sourceMappingURL=basic.js.map",
+      "basic.js.map": "{"version":3,"file":"basic.js","names":[],"sources":["../../src/basic.js"],"sourcesContent":["// eslint-disable-next-line no-console\\nconsole.log(\\"hello world\\");\\n"],"mappings":";AACA,QAAQ,IAAI,cAAc"}",
     }
   `);
 });

--- a/packages/integration-tests-next/fixtures/vite8/debugids-already-injected.test.ts
+++ b/packages/integration-tests-next/fixtures/vite8/debugids-already-injected.test.ts
@@ -9,20 +9,21 @@ test(import.meta.url, ({ runBundler, createTempDir }) => {
   const files = readAllFiles(tempDir);
   expect(files).toMatchInlineSnapshot(`
     {
-      "252e0338-8927-4f52-bd57-188131defd0f-0.js": "!(function() {
-      try {
-        var e = "undefined" != typeof window ? window : "undefined" != typeof global ? global : "undefined" != typeof globalThis ? globalThis : "undefined" != typeof self ? self : {};
-        e.SENTRY_RELEASE = { id: "CURRENT_SHA" };
-        var n = new e.Error().stack;
-        n && (e._sentryDebugIds = e._sentryDebugIds || {}, e._sentryDebugIds[n] = "00000000-0000-0000-0000-000000000000", e._sentryDebugIdIdentifier = "sentry-dbid-00000000-0000-0000-0000-000000000000");
-      } catch (e2) {
-      }
+      "b699d9c1-b033-4536-aa25-233c92609b54-0.js": "//#region src/basic.js
+    (function() {
+    	try {
+    		var e = "undefined" != typeof window ? window : "undefined" != typeof global ? global : "undefined" != typeof globalThis ? globalThis : "undefined" != typeof self ? self : {};
+    		e.SENTRY_RELEASE = { id: "CURRENT_SHA" };
+    		var n = new e.Error().stack;
+    		n && (e._sentryDebugIds = e._sentryDebugIds || {}, e._sentryDebugIds[n] = "00000000-0000-0000-0000-000000000000", e._sentryDebugIdIdentifier = "sentry-dbid-00000000-0000-0000-0000-000000000000");
+    	} catch (e) {}
     })();
     console.log("hello world");
+    //#endregion
+
     //# debugId=00000000-0000-0000-0000-000000000000
-    //# sourceMappingURL=basic.js.map
-    ",
-      "252e0338-8927-4f52-bd57-188131defd0f-0.js.map": "{"version":3,"file":"basic.js","sources":["../../src/basic.js"],"sourcesContent":["// eslint-disable-next-line no-console\\nconsole.log(\\"hello world\\");\\n"],"names":[],"mappings":";;;;;;;;;AACA,QAAQ,IAAI,aAAa;","debugId":"252e0338-8927-4f52-bd57-188131defd0f","debug_id":"252e0338-8927-4f52-bd57-188131defd0f"}",
+    //# sourceMappingURL=basic.js.map",
+      "b699d9c1-b033-4536-aa25-233c92609b54-0.js.map": "{"version":3,"file":"basic.js","names":[],"sources":["../../src/basic.js"],"sourcesContent":["// eslint-disable-next-line no-console\\nconsole.log(\\"hello world\\");\\n"],"mappings":";;;;;;;;;AACA,QAAQ,IAAI,cAAc","debugId":"b699d9c1-b033-4536-aa25-233c92609b54","debug_id":"b699d9c1-b033-4536-aa25-233c92609b54"}",
     }
   `);
 });

--- a/packages/integration-tests-next/fixtures/vite8/dont-mess-up-user-code.test.ts
+++ b/packages/integration-tests-next/fixtures/vite8/dont-mess-up-user-code.test.ts
@@ -5,20 +5,23 @@ test(import.meta.url, ({ runBundler, readOutputFiles, runFileInNode }) => {
   runBundler();
   expect(readOutputFiles()).toMatchInlineSnapshot(`
     {
-      "index.js": "!(function() {
-      try {
-        var e = "undefined" != typeof window ? window : "undefined" != typeof global ? global : "undefined" != typeof globalThis ? globalThis : "undefined" != typeof self ? self : {};
-        e.SENTRY_RELEASE = { id: "I am release!" };
-        var n = new e.Error().stack;
-        n && (e._sentryDebugIds = e._sentryDebugIds || {}, e._sentryDebugIds[n] = "00000000-0000-0000-0000-000000000000", e._sentryDebugIdIdentifier = "sentry-dbid-00000000-0000-0000-0000-000000000000");
-      } catch (e2) {
-      }
+      "index.js": "//#region src/import.js
+    (function() {
+    	try {
+    		var e = "undefined" != typeof window ? window : "undefined" != typeof global ? global : "undefined" != typeof globalThis ? globalThis : "undefined" != typeof self ? self : {};
+    		e.SENTRY_RELEASE = { id: "I am release!" };
+    		var n = new e.Error().stack;
+    		n && (e._sentryDebugIds = e._sentryDebugIds || {}, e._sentryDebugIds[n] = "00000000-0000-0000-0000-000000000000", e._sentryDebugIdIdentifier = "sentry-dbid-00000000-0000-0000-0000-000000000000");
+    	} catch (e) {}
     })();
     console.log("I am import!");
+    //#endregion
+    //#region src/index.js
     console.log("I am index!");
-    //# sourceMappingURL=index.js.map
-    ",
-      "index.js.map": "{"version":3,"file":"index.js","sources":["../../src/import.js","../../src/index.js"],"sourcesContent":["// eslint-disable-next-line no-console\\nconsole.log(\\"I am import!\\");\\n\\nexport {};\\n","import \\"./import\\";\\n\\n// eslint-disable-next-line no-console\\nconsole.log(\\"I am index!\\");\\n"],"names":[],"mappings":";;;;;;;;;AACA,QAAQ,IAAI,cAAc;ACE1B,QAAQ,IAAI,aAAa;"}",
+    //#endregion
+
+    //# sourceMappingURL=index.js.map",
+      "index.js.map": "{"version":3,"file":"index.js","names":[],"sources":["../../src/import.js","../../src/index.js"],"sourcesContent":["// eslint-disable-next-line no-console\\nconsole.log(\\"I am import!\\");\\n\\nexport {};\\n","import \\"./import\\";\\n\\n// eslint-disable-next-line no-console\\nconsole.log(\\"I am index!\\");\\n"],"mappings":";;;;;;;;;AACA,QAAQ,IAAI,eAAe;;;ACE3B,QAAQ,IAAI,cAAc"}",
     }
   `);
 

--- a/packages/integration-tests-next/fixtures/vite8/module-metadata.test.ts
+++ b/packages/integration-tests-next/fixtures/vite8/module-metadata.test.ts
@@ -5,23 +5,27 @@ test(import.meta.url, ({ runBundler, readOutputFiles, runFileInNode }) => {
   runBundler();
   expect(readOutputFiles()).toMatchInlineSnapshot(`
     {
-      "basic.js": "!(function() {
-      try {
-        var e = "undefined" != typeof window ? window : "undefined" != typeof global ? global : "undefined" != typeof globalThis ? globalThis : "undefined" != typeof self ? self : {};
-        e.SENTRY_RELEASE = { id: "CURRENT_SHA" };
-        e._sentryModuleMetadata = e._sentryModuleMetadata || {}, e._sentryModuleMetadata[new e.Error().stack] = (function(e2) {
-          for (var n2 = 1; n2 < arguments.length; n2++) {
-            var a = arguments[n2];
-            if (null != a) for (var t in a) a.hasOwnProperty(t) && (e2[t] = a[t]);
-          }
-          return e2;
-        })({}, e._sentryModuleMetadata[new e.Error().stack], { "something": "value", "another": 999 });
-        var n = new e.Error().stack;
-        n && (e._sentryDebugIds = e._sentryDebugIds || {}, e._sentryDebugIds[n] = "00000000-0000-0000-0000-000000000000", e._sentryDebugIdIdentifier = "sentry-dbid-00000000-0000-0000-0000-000000000000");
-      } catch (e2) {
-      }
+      "basic.js": "//#region src/basic.js
+    (function() {
+    	try {
+    		var e = "undefined" != typeof window ? window : "undefined" != typeof global ? global : "undefined" != typeof globalThis ? globalThis : "undefined" != typeof self ? self : {};
+    		e.SENTRY_RELEASE = { id: "CURRENT_SHA" };
+    		e._sentryModuleMetadata = e._sentryModuleMetadata || {}, e._sentryModuleMetadata[new e.Error().stack] = function(e) {
+    			for (var n = 1; n < arguments.length; n++) {
+    				var a = arguments[n];
+    				if (null != a) for (var t in a) a.hasOwnProperty(t) && (e[t] = a[t]);
+    			}
+    			return e;
+    		}({}, e._sentryModuleMetadata[new e.Error().stack], {
+    			"something": "value",
+    			"another": 999
+    		});
+    		var n = new e.Error().stack;
+    		n && (e._sentryDebugIds = e._sentryDebugIds || {}, e._sentryDebugIds[n] = "00000000-0000-0000-0000-000000000000", e._sentryDebugIdIdentifier = "sentry-dbid-00000000-0000-0000-0000-000000000000");
+    	} catch (e) {}
     })();
     console.log("hello world");
+    //#endregion
     ",
     }
   `);

--- a/packages/integration-tests-next/fixtures/vite8/multiple-entry-points.test.ts
+++ b/packages/integration-tests-next/fixtures/vite8/multiple-entry-points.test.ts
@@ -5,42 +5,43 @@ test(import.meta.url, ({ runBundler, readOutputFiles, runFileInNode }) => {
   runBundler();
   expect(readOutputFiles()).toMatchInlineSnapshot(`
     {
-      "common.js": "!(function() {
-      try {
-        var e = "undefined" != typeof window ? window : "undefined" != typeof global ? global : "undefined" != typeof globalThis ? globalThis : "undefined" != typeof self ? self : {};
-        var n = new e.Error().stack;
-        n && (e._sentryDebugIds = e._sentryDebugIds || {}, e._sentryDebugIds[n] = "00000000-0000-0000-0000-000000000000", e._sentryDebugIdIdentifier = "sentry-dbid-00000000-0000-0000-0000-000000000000");
-      } catch (e2) {
-      }
+      "common.js": "//#region src/common.js
+    (function() {
+    	try {
+    		var e = "undefined" != typeof window ? window : "undefined" != typeof global ? global : "undefined" != typeof globalThis ? globalThis : "undefined" != typeof self ? self : {};
+    		var n = new e.Error().stack;
+    		n && (e._sentryDebugIds = e._sentryDebugIds || {}, e._sentryDebugIds[n] = "00000000-0000-0000-0000-000000000000", e._sentryDebugIdIdentifier = "sentry-dbid-00000000-0000-0000-0000-000000000000");
+    	} catch (e) {}
     })();
     function add(a, b) {
-      return a + b;
+    	return a + b;
     }
-    export {
-      add as a
-    };
+    //#endregion
+    export { add as t };
     ",
-      "entry1.js": "!(function() {
-      try {
-        var e = "undefined" != typeof window ? window : "undefined" != typeof global ? global : "undefined" != typeof globalThis ? globalThis : "undefined" != typeof self ? self : {};
-        var n = new e.Error().stack;
-        n && (e._sentryDebugIds = e._sentryDebugIds || {}, e._sentryDebugIds[n] = "00000000-0000-0000-0000-000000000000", e._sentryDebugIdIdentifier = "sentry-dbid-00000000-0000-0000-0000-000000000000");
-      } catch (e2) {
-      }
+      "entry1.js": "(function() {
+    	try {
+    		var e = "undefined" != typeof window ? window : "undefined" != typeof global ? global : "undefined" != typeof globalThis ? globalThis : "undefined" != typeof self ? self : {};
+    		var n = new e.Error().stack;
+    		n && (e._sentryDebugIds = e._sentryDebugIds || {}, e._sentryDebugIds[n] = "00000000-0000-0000-0000-000000000000", e._sentryDebugIdIdentifier = "sentry-dbid-00000000-0000-0000-0000-000000000000");
+    	} catch (e) {}
     })();
-    import { a as add } from "./common.js";
+    import { t as add } from "./common.js";
+    //#region src/entry1.js
     console.log(add(1, 2));
+    //#endregion
     ",
-      "entry2.js": "!(function() {
-      try {
-        var e = "undefined" != typeof window ? window : "undefined" != typeof global ? global : "undefined" != typeof globalThis ? globalThis : "undefined" != typeof self ? self : {};
-        var n = new e.Error().stack;
-        n && (e._sentryDebugIds = e._sentryDebugIds || {}, e._sentryDebugIds[n] = "00000000-0000-0000-0000-000000000000", e._sentryDebugIdIdentifier = "sentry-dbid-00000000-0000-0000-0000-000000000000");
-      } catch (e2) {
-      }
+      "entry2.js": "(function() {
+    	try {
+    		var e = "undefined" != typeof window ? window : "undefined" != typeof global ? global : "undefined" != typeof globalThis ? globalThis : "undefined" != typeof self ? self : {};
+    		var n = new e.Error().stack;
+    		n && (e._sentryDebugIds = e._sentryDebugIds || {}, e._sentryDebugIds[n] = "00000000-0000-0000-0000-000000000000", e._sentryDebugIdIdentifier = "sentry-dbid-00000000-0000-0000-0000-000000000000");
+    	} catch (e) {}
     })();
-    import { a as add } from "./common.js";
+    import { t as add } from "./common.js";
+    //#region src/entry2.js
     console.log(add(2, 4));
+    //#endregion
     ",
     }
   `);

--- a/packages/integration-tests-next/fixtures/vite8/query-param.test.ts
+++ b/packages/integration-tests-next/fixtures/vite8/query-param.test.ts
@@ -10,45 +10,46 @@ test(import.meta.url, ({ runBundler, readOutputFiles, ctx }) => {
   runBundler();
   expect(readOutputFiles()).toMatchInlineSnapshot(`
     {
-      "common.js?seP58q4g": "!(function() {
-      try {
-        var e = "undefined" != typeof window ? window : "undefined" != typeof global ? global : "undefined" != typeof globalThis ? globalThis : "undefined" != typeof self ? self : {};
-        e.SENTRY_RELEASE = { id: "CURRENT_SHA" };
-        var n = new e.Error().stack;
-        n && (e._sentryDebugIds = e._sentryDebugIds || {}, e._sentryDebugIds[n] = "00000000-0000-0000-0000-000000000000", e._sentryDebugIdIdentifier = "sentry-dbid-00000000-0000-0000-0000-000000000000");
-      } catch (e2) {
-      }
+      "common.js?seP58q4g": "//#region src/common.js
+    (function() {
+    	try {
+    		var e = "undefined" != typeof window ? window : "undefined" != typeof global ? global : "undefined" != typeof globalThis ? globalThis : "undefined" != typeof self ? self : {};
+    		e.SENTRY_RELEASE = { id: "CURRENT_SHA" };
+    		var n = new e.Error().stack;
+    		n && (e._sentryDebugIds = e._sentryDebugIds || {}, e._sentryDebugIds[n] = "00000000-0000-0000-0000-000000000000", e._sentryDebugIdIdentifier = "sentry-dbid-00000000-0000-0000-0000-000000000000");
+    	} catch (e) {}
     })();
     function add(a, b) {
-      return a + b;
+    	return a + b;
     }
-    export {
-      add as a
-    };
+    //#endregion
+    export { add as t };
     ",
-      "entry1.js": "!(function() {
-      try {
-        var e = "undefined" != typeof window ? window : "undefined" != typeof global ? global : "undefined" != typeof globalThis ? globalThis : "undefined" != typeof self ? self : {};
-        e.SENTRY_RELEASE = { id: "CURRENT_SHA" };
-        var n = new e.Error().stack;
-        n && (e._sentryDebugIds = e._sentryDebugIds || {}, e._sentryDebugIds[n] = "00000000-0000-0000-0000-000000000000", e._sentryDebugIdIdentifier = "sentry-dbid-00000000-0000-0000-0000-000000000000");
-      } catch (e2) {
-      }
+      "entry1.js": "(function() {
+    	try {
+    		var e = "undefined" != typeof window ? window : "undefined" != typeof global ? global : "undefined" != typeof globalThis ? globalThis : "undefined" != typeof self ? self : {};
+    		e.SENTRY_RELEASE = { id: "CURRENT_SHA" };
+    		var n = new e.Error().stack;
+    		n && (e._sentryDebugIds = e._sentryDebugIds || {}, e._sentryDebugIds[n] = "00000000-0000-0000-0000-000000000000", e._sentryDebugIdIdentifier = "sentry-dbid-00000000-0000-0000-0000-000000000000");
+    	} catch (e) {}
     })();
-    import { a as add } from "./common.js?seP58q4g";
+    import { t as add } from "./common.js?seP58q4g";
+    //#region src/entry1.js
     console.log(add(1, 2));
+    //#endregion
     ",
-      "entry2.js": "!(function() {
-      try {
-        var e = "undefined" != typeof window ? window : "undefined" != typeof global ? global : "undefined" != typeof globalThis ? globalThis : "undefined" != typeof self ? self : {};
-        e.SENTRY_RELEASE = { id: "CURRENT_SHA" };
-        var n = new e.Error().stack;
-        n && (e._sentryDebugIds = e._sentryDebugIds || {}, e._sentryDebugIds[n] = "00000000-0000-0000-0000-000000000000", e._sentryDebugIdIdentifier = "sentry-dbid-00000000-0000-0000-0000-000000000000");
-      } catch (e2) {
-      }
+      "entry2.js": "(function() {
+    	try {
+    		var e = "undefined" != typeof window ? window : "undefined" != typeof global ? global : "undefined" != typeof globalThis ? globalThis : "undefined" != typeof self ? self : {};
+    		e.SENTRY_RELEASE = { id: "CURRENT_SHA" };
+    		var n = new e.Error().stack;
+    		n && (e._sentryDebugIds = e._sentryDebugIds || {}, e._sentryDebugIds[n] = "00000000-0000-0000-0000-000000000000", e._sentryDebugIdIdentifier = "sentry-dbid-00000000-0000-0000-0000-000000000000");
+    	} catch (e) {}
     })();
-    import { a as add } from "./common.js?seP58q4g";
+    import { t as add } from "./common.js?seP58q4g";
+    //#region src/entry2.js
     console.log(add(2, 4));
+    //#endregion
     ",
     }
   `);

--- a/packages/integration-tests-next/fixtures/vite8/release-disabled.test.ts
+++ b/packages/integration-tests-next/fixtures/vite8/release-disabled.test.ts
@@ -5,16 +5,17 @@ test(import.meta.url, ({ runBundler, readOutputFiles }) => {
   runBundler();
   expect(readOutputFiles()).toMatchInlineSnapshot(`
     {
-      "basic.js": "!(function() {
-      try {
-        var e = "undefined" != typeof window ? window : "undefined" != typeof global ? global : "undefined" != typeof globalThis ? globalThis : "undefined" != typeof self ? self : {};
-        e.SENTRY_RELEASE = { id: "CURRENT_SHA" };
-        var n = new e.Error().stack;
-        n && (e._sentryDebugIds = e._sentryDebugIds || {}, e._sentryDebugIds[n] = "00000000-0000-0000-0000-000000000000", e._sentryDebugIdIdentifier = "sentry-dbid-00000000-0000-0000-0000-000000000000");
-      } catch (e2) {
-      }
+      "basic.js": "//#region src/basic.js
+    (function() {
+    	try {
+    		var e = "undefined" != typeof window ? window : "undefined" != typeof global ? global : "undefined" != typeof globalThis ? globalThis : "undefined" != typeof self ? self : {};
+    		e.SENTRY_RELEASE = { id: "CURRENT_SHA" };
+    		var n = new e.Error().stack;
+    		n && (e._sentryDebugIds = e._sentryDebugIds || {}, e._sentryDebugIds[n] = "00000000-0000-0000-0000-000000000000", e._sentryDebugIdIdentifier = "sentry-dbid-00000000-0000-0000-0000-000000000000");
+    	} catch (e) {}
     })();
     console.log("hello world");
+    //#endregion
     ",
       "sentry-cli-mock.json": "["releases","set-commits","CURRENT_SHA","--auto","--ignore-missing"],
     ["releases","finalize","CURRENT_SHA"],

--- a/packages/integration-tests-next/fixtures/vite8/telemetry.test.ts
+++ b/packages/integration-tests-next/fixtures/vite8/telemetry.test.ts
@@ -5,16 +5,17 @@ test(import.meta.url, ({ runBundler, readOutputFiles, runFileInNode }) => {
   runBundler();
   expect(readOutputFiles()).toMatchInlineSnapshot(`
     {
-      "basic.js": "!(function() {
-      try {
-        var e = "undefined" != typeof window ? window : "undefined" != typeof global ? global : "undefined" != typeof globalThis ? globalThis : "undefined" != typeof self ? self : {};
-        e.SENTRY_RELEASE = { id: "CURRENT_SHA" };
-        var n = new e.Error().stack;
-        n && (e._sentryDebugIds = e._sentryDebugIds || {}, e._sentryDebugIds[n] = "00000000-0000-0000-0000-000000000000", e._sentryDebugIdIdentifier = "sentry-dbid-00000000-0000-0000-0000-000000000000");
-      } catch (e2) {
-      }
+      "basic.js": "//#region src/basic.js
+    (function() {
+    	try {
+    		var e = "undefined" != typeof window ? window : "undefined" != typeof global ? global : "undefined" != typeof globalThis ? globalThis : "undefined" != typeof self ? self : {};
+    		e.SENTRY_RELEASE = { id: "CURRENT_SHA" };
+    		var n = new e.Error().stack;
+    		n && (e._sentryDebugIds = e._sentryDebugIds || {}, e._sentryDebugIds[n] = "00000000-0000-0000-0000-000000000000", e._sentryDebugIdIdentifier = "sentry-dbid-00000000-0000-0000-0000-000000000000");
+    	} catch (e) {}
     })();
     console.log("hello world");
+    //#endregion
     ",
       "sentry-telemetry.json": "[{"sent_at":"TIMESTAMP","sdk":{"name":"sentry.javascript.node","version":"8.30.0"}},[[{"type":"session"},{"sid":"UUID","init":false,"started":"TIMESTAMP","timestamp":"TIMESTAMP","status":"exited","errors":0,"duration":DURATION,"attrs":{"release":"PLUGIN_VERSION","environment":"production"}}]]],
     ",

--- a/packages/integration-tests-next/fixtures/vite8/utils.ts
+++ b/packages/integration-tests-next/fixtures/vite8/utils.ts
@@ -39,7 +39,7 @@ export function test(url: string, callback: TestCallback) {
         outDir,
         runBundler: (env) =>
           runBundler(
-            `vite build --config ${testName}${configExt}`,
+            `pnpm vite build --config ${testName}${configExt}`,
             {
               cwd,
               env: {

--- a/packages/integration-tests-next/fixtures/vite8/vite-mpa-extra-modules.test.ts
+++ b/packages/integration-tests-next/fixtures/vite8/vite-mpa-extra-modules.test.ts
@@ -5,54 +5,54 @@ test(import.meta.url, ({ runBundler, readOutputFiles }) => {
   runBundler();
   expect(readOutputFiles()).toMatchInlineSnapshot(`
     {
-      "index.js.map": "{"version":3,"file":"index.js","sources":[],"sourcesContent":[],"names":[],"mappings":""}",
-      "page1.js.map": "{"version":3,"file":"page1.js","sources":[],"sourcesContent":[],"names":[],"mappings":";"}",
-      "page2.js.map": "{"version":3,"file":"page2.js","sources":[],"sourcesContent":[],"names":[],"mappings":";"}",
-      "shared-module.js": "!(function() {
-      try {
-        var e = "undefined" != typeof window ? window : "undefined" != typeof global ? global : "undefined" != typeof globalThis ? globalThis : "undefined" != typeof self ? self : {};
-        e.SENTRY_RELEASE = { id: "CURRENT_SHA" };
-        var n = new e.Error().stack;
-        n && (e._sentryDebugIds = e._sentryDebugIds || {}, e._sentryDebugIds[n] = "00000000-0000-0000-0000-000000000000", e._sentryDebugIdIdentifier = "sentry-dbid-00000000-0000-0000-0000-000000000000");
-      } catch (e2) {
-      }
+      "shared-module.js": "//#region \\0vite/modulepreload-polyfill.js
+    (function() {
+    	try {
+    		var e = "undefined" != typeof window ? window : "undefined" != typeof global ? global : "undefined" != typeof globalThis ? globalThis : "undefined" != typeof self ? self : {};
+    		e.SENTRY_RELEASE = { id: "CURRENT_SHA" };
+    		var n = new e.Error().stack;
+    		n && (e._sentryDebugIds = e._sentryDebugIds || {}, e._sentryDebugIds[n] = "00000000-0000-0000-0000-000000000000", e._sentryDebugIdIdentifier = "sentry-dbid-00000000-0000-0000-0000-000000000000");
+    	} catch (e) {}
     })();
     (function polyfill() {
-      const relList = document.createElement("link").relList;
-      if (relList && relList.supports && relList.supports("modulepreload")) return;
-      for (const link of document.querySelectorAll('link[rel="modulepreload"]')) processPreload(link);
-      new MutationObserver((mutations) => {
-        for (const mutation of mutations) {
-          if (mutation.type !== "childList") continue;
-          for (const node of mutation.addedNodes) if (node.tagName === "LINK" && node.rel === "modulepreload") processPreload(node);
-        }
-      }).observe(document, {
-        childList: true,
-        subtree: true
-      });
-      function getFetchOpts(link) {
-        const fetchOpts = {};
-        if (link.integrity) fetchOpts.integrity = link.integrity;
-        if (link.referrerPolicy) fetchOpts.referrerPolicy = link.referrerPolicy;
-        if (link.crossOrigin === "use-credentials") fetchOpts.credentials = "include";
-        else if (link.crossOrigin === "anonymous") fetchOpts.credentials = "omit";
-        else fetchOpts.credentials = "same-origin";
-        return fetchOpts;
-      }
-      function processPreload(link) {
-        if (link.ep) return;
-        link.ep = true;
-        const fetchOpts = getFetchOpts(link);
-        fetch(link.href, fetchOpts);
-      }
+    	const relList = document.createElement("link").relList;
+    	if (relList && relList.supports && relList.supports("modulepreload")) return;
+    	for (const link of document.querySelectorAll("link[rel=\\"modulepreload\\"]")) processPreload(link);
+    	new MutationObserver((mutations) => {
+    		for (const mutation of mutations) {
+    			if (mutation.type !== "childList") continue;
+    			for (const node of mutation.addedNodes) if (node.tagName === "LINK" && node.rel === "modulepreload") processPreload(node);
+    		}
+    	}).observe(document, {
+    		childList: true,
+    		subtree: true
+    	});
+    	function getFetchOpts(link) {
+    		const fetchOpts = {};
+    		if (link.integrity) fetchOpts.integrity = link.integrity;
+    		if (link.referrerPolicy) fetchOpts.referrerPolicy = link.referrerPolicy;
+    		if (link.crossOrigin === "use-credentials") fetchOpts.credentials = "include";
+    		else if (link.crossOrigin === "anonymous") fetchOpts.credentials = "omit";
+    		else fetchOpts.credentials = "same-origin";
+    		return fetchOpts;
+    	}
+    	function processPreload(link) {
+    		if (link.ep) return;
+    		link.ep = true;
+    		const fetchOpts = getFetchOpts(link);
+    		fetch(link.href, fetchOpts);
+    	}
     })();
+    //#endregion
+    //#region src/shared-module.js
     function greet(name) {
-      console.log(\`Hello, \${String(name)}!\`);
+    	console.log(\`Hello, \${String(name)}!\`);
     }
     greet("World");
-    //# sourceMappingURL=shared-module.js.map
-    ",
-      "shared-module.js.map": "{"version":3,"file":"shared-module.js","sources":["../../src/shared-module.js"],"sourcesContent":["// This is a shared module that is used by multiple HTML pages\\nexport function greet(name) {\\n  // eslint-disable-next-line no-console\\n  console.log(\`Hello, \${String(name)}!\`);\\n}\\n\\nexport const VERSION = \\"1.0.0\\";\\n\\n// Side effect: greet on load\\ngreet(\\"World\\");\\n"],"names":[],"mappings":";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;AACO,SAAS,MAAM,MAAM;AAE1B,UAAQ,IAAI,UAAU,OAAO,IAAI,CAAC,GAAG;AACvC;AAKA,MAAM,OAAO;"}",
+    //#endregion
+
+    //# sourceMappingURL=shared-module.js.map",
+      "shared-module.js.map": "{"version":3,"file":"shared-module.js","names":[],"sources":["../../src/shared-module.js"],"sourcesContent":["// This is a shared module that is used by multiple HTML pages\\nexport function greet(name) {\\n  // eslint-disable-next-line no-console\\n  console.log(\`Hello, \${String(name)}!\`);\\n}\\n\\nexport const VERSION = \\"1.0.0\\";\\n\\n// Side effect: greet on load\\ngreet(\\"World\\");\\n"],"mappings":";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;AACA,SAAgB,MAAM,MAAM;AAE1B,SAAQ,IAAI,UAAU,OAAO,KAAK,CAAC,GAAG;;AAMxC,MAAM,QAAQ"}",
       "src/vite-mpa-index.html": "<!doctype html>
     <html lang="en">
       <head>

--- a/packages/integration-tests-next/setup.mjs
+++ b/packages/integration-tests-next/setup.mjs
@@ -27,7 +27,7 @@ for (const dir of directories) {
     continue;
   }
 
-  execSync("pnpm install", {
+  execSync("pnpm install --force", {
     cwd: dir,
     stdio: "inherit",
   });


### PR DESCRIPTION
When removing the old integration tests (#922) I noticed some changes in the snapshot output. 

This PR changes the tests so bundlers are run with `pnpm <bundler>` so that the correct bundler version is resolved.

This results in some whitespace, wrapping and closure changes to the Vite 4/8 snapshots.