### PR TITLE
feat(babel): Auto-inject sentry-label from static text children

### DIFF
--- a/packages/babel-plugin-component-annotate/src/index.ts
+++ b/packages/babel-plugin-component-annotate/src/index.ts
@@ -790,6 +790,7 @@ function extractTextFromTextComponent(
         if (innerTexts === null) {
           return null;
         }
+        texts.push(...innerTexts);
       }
     } else if (t.isJSXFragment(child)) {
       const innerTexts = extractTextFromTextComponent(t, child, textComponentNames);

--- a/packages/babel-plugin-component-annotate/src/index.ts
+++ b/packages/babel-plugin-component-annotate/src/index.ts
@@ -45,10 +45,17 @@ const nativeComponentName = "dataSentryComponent";
 const nativeElementName = "dataSentryElement";
 const nativeSourceFileName = "dataSentrySourceFile";
 
+const SENTRY_LABEL_ATTRIBUTE = "sentry-label";
+const MAX_LABEL_LENGTH = 64;
+const DEFAULT_TEXT_COMPONENT_NAMES = ["Text", "text"];
+const MAX_TEXT_SEARCH_DEPTH = 3;
+
 interface AnnotationOpts {
   native?: boolean;
   "annotate-fragments"?: boolean;
   ignoredComponents?: string[];
+  autoInjectSentryLabel?: boolean;
+  textComponentNames?: string[];
 }
 
 interface FragmentContext {
@@ -79,6 +86,10 @@ interface JSXProcessingContext {
   ignoredComponents: string[];
   /** Fragment context for identifying React fragments */
   fragmentContext?: FragmentContext;
+  /** Whether to auto-inject sentry-label from static text children */
+  autoInjectSentryLabel: boolean;
+  /** Component names whose JSXText children are considered text content */
+  textComponentNames: string[];
 }
 
 export { experimentalComponentNameAnnotatePlugin } from "./experimental";
@@ -170,6 +181,8 @@ function createJSXProcessingContext(
     attributeNames: attributeNamesFromState(state),
     ignoredComponents: state.opts.ignoredComponents ?? [],
     fragmentContext: state.sentryFragmentContext,
+    autoInjectSentryLabel: state.opts.autoInjectSentryLabel === true,
+    textComponentNames: state.opts.textComponentNames ?? DEFAULT_TEXT_COMPONENT_NAMES,
   };
 }
 
@@ -261,6 +274,7 @@ function processJSX(
 
   // Use provided componentName or fall back to context componentName
   const currentComponentName = componentName ?? context.componentName;
+  const isRootElement = componentName === undefined;
 
   // NOTE: I don't know of a case where `openingElement` would have more than one item,
   // but it's safer to always iterate
@@ -305,6 +319,10 @@ function processJSX(
       processJSX(context, child, "");
     }
   });
+
+  if (isRootElement && context.autoInjectSentryLabel) {
+    maybeInjectSentryLabel(context, jsxNode);
+  }
 }
 
 /**
@@ -656,6 +674,211 @@ function getJSXMemberExpressionObjectName(
   }
 
   return UNKNOWN_ELEMENT_NAME;
+}
+
+/**
+ * Extracts static text content from JSX children, searching up to a depth limit.
+ * Collects text from JSXText nodes of the root element and from recognized
+ * text components (e.g. <Text>). Non-text custom components are traversed
+ * but their own JSXText is not collected.
+ *
+ * Returns null when dynamic content is found anywhere in the subtree,
+ * signaling that the entire label should be skipped.
+ */
+function extractStaticTextFromChildren(
+  t: typeof Babel.types,
+  node: Babel.types.JSXElement | Babel.types.JSXFragment,
+  textComponentNames: string[],
+  depth: number,
+  isRoot: boolean
+): string[] | null {
+  if (depth <= 0) {
+    return [];
+  }
+
+  const texts: string[] = [];
+
+  for (const child of node.children) {
+    if (t.isJSXText(child)) {
+      if (isRoot) {
+        const trimmed = child.value.replace(/\s+/g, " ").trim();
+        if (trimmed) {
+          texts.push(trimmed);
+        }
+      }
+    } else if (t.isJSXElement(child)) {
+      const childName = getElementName(t, child.openingElement);
+
+      if (textComponentNames.includes(childName)) {
+        const innerTexts = extractTextFromTextComponent(t, child, textComponentNames);
+        if (innerTexts === null) {
+          return null;
+        }
+        texts.push(...innerTexts);
+      } else {
+        const result = extractStaticTextFromChildren(
+          t,
+          child,
+          textComponentNames,
+          depth - 1,
+          false
+        );
+        if (result === null) {
+          return null;
+        }
+        texts.push(...result);
+      }
+    } else if (t.isJSXFragment(child)) {
+      const result = extractStaticTextFromChildren(t, child, textComponentNames, depth, isRoot);
+      if (result === null) {
+        return null;
+      }
+      texts.push(...result);
+    } else if (t.isJSXExpressionContainer(child)) {
+      if (!t.isJSXEmptyExpression(child.expression)) {
+        return null;
+      }
+    } else if (t.isJSXSpreadChild(child)) {
+      return null;
+    }
+  }
+
+  return texts;
+}
+
+/**
+ * Recursively extracts static text from within a recognized text component.
+ * Handles nested text components (e.g. <Text>Hello <Text style={bold}>world</Text></Text>)
+ * which is the standard React Native pattern for inline styling.
+ *
+ * Returns null when any dynamic content is found, signaling bail-out.
+ */
+function extractTextFromTextComponent(
+  t: typeof Babel.types,
+  node: Babel.types.JSXElement | Babel.types.JSXFragment,
+  textComponentNames: string[]
+): string[] | null {
+  const texts: string[] = [];
+
+  for (const child of node.children) {
+    if (t.isJSXText(child)) {
+      const trimmed = child.value.replace(/\s+/g, " ").trim();
+      if (trimmed) {
+        texts.push(trimmed);
+      }
+    } else if (t.isJSXExpressionContainer(child)) {
+      if (!t.isJSXEmptyExpression(child.expression)) {
+        return null;
+      }
+    } else if (t.isJSXElement(child)) {
+      const childName = getElementName(t, child.openingElement);
+      if (textComponentNames.includes(childName)) {
+        const innerTexts = extractTextFromTextComponent(t, child, textComponentNames);
+        if (innerTexts === null) {
+          return null;
+        }
+        texts.push(...innerTexts);
+      } else {
+        const innerTexts = extractTextFromTextComponent(t, child, textComponentNames);
+        if (innerTexts === null) {
+          return null;
+        }
+      }
+    } else if (t.isJSXFragment(child)) {
+      const innerTexts = extractTextFromTextComponent(t, child, textComponentNames);
+      if (innerTexts === null) {
+        return null;
+      }
+      texts.push(...innerTexts);
+    } else if (t.isJSXSpreadChild(child)) {
+      return null;
+    }
+  }
+
+  return texts;
+}
+
+function getElementName(
+  t: typeof Babel.types,
+  openingElement: Babel.types.JSXOpeningElement
+): string {
+  const name = openingElement.name;
+  if (t.isJSXIdentifier(name)) {
+    return name.name;
+  }
+  if (t.isJSXMemberExpression(name)) {
+    return `${getJSXMemberExpressionObjectName(t, name.object)}.${name.property.name}`;
+  }
+  return "";
+}
+
+/**
+ * Injects a sentry-label attribute on the root JSX element of a component if
+ * static text content can be extracted from its children.
+ *
+ * When the root is a JSX fragment, the first JSXElement child is used as the
+ * target for both text extraction and attribute injection (since fragments
+ * cannot carry attributes).
+ */
+function maybeInjectSentryLabel(context: JSXProcessingContext, jsxNode: Babel.NodePath): void {
+  const { t, textComponentNames, ignoredComponents, componentName } = context;
+  const node = jsxNode.node;
+
+  let targetElement: Babel.types.JSXElement;
+
+  if (t.isJSXElement(node)) {
+    targetElement = node;
+  } else if (t.isJSXFragment(node)) {
+    const firstChild = node.children.find((c): c is Babel.types.JSXElement => t.isJSXElement(c));
+    if (!firstChild) {
+      return;
+    }
+    targetElement = firstChild;
+  } else {
+    return;
+  }
+
+  const targetElementName = getElementName(t, targetElement.openingElement);
+
+  if (
+    ignoredComponents.some((ignored) => ignored === componentName || ignored === targetElementName)
+  ) {
+    return;
+  }
+
+  if (
+    targetElement.openingElement.attributes.some(
+      (attr) => t.isJSXAttribute(attr) && attr.name.name === SENTRY_LABEL_ATTRIBUTE
+    )
+  ) {
+    return;
+  }
+
+  const texts = extractStaticTextFromChildren(
+    t,
+    targetElement,
+    textComponentNames,
+    MAX_TEXT_SEARCH_DEPTH,
+    true
+  );
+
+  if (texts === null) {
+    return;
+  }
+
+  let label = texts.join(" ").replace(/\s+/g, " ").trim();
+
+  if (!label) {
+    return;
+  }
+
+  if (label.length > MAX_LABEL_LENGTH) {
+    label = label.substring(0, MAX_LABEL_LENGTH - 3) + "...";
+  }
+
+  targetElement.openingElement.attributes.push(
+    t.jSXAttribute(t.jSXIdentifier(SENTRY_LABEL_ATTRIBUTE), t.stringLiteral(label))
+  );
 }
 
 const UNKNOWN_ELEMENT_NAME = "unknown";

--- a/packages/babel-plugin-component-annotate/src/index.ts
+++ b/packages/babel-plugin-component-annotate/src/index.ts
@@ -50,12 +50,16 @@ const MAX_LABEL_LENGTH = 64;
 const DEFAULT_TEXT_COMPONENT_NAMES = ["Text", "text"];
 const MAX_TEXT_SEARCH_DEPTH = 3;
 
+interface AutoInjectSentryLabelOpts {
+  textComponentNames?: string[];
+}
+
 interface AnnotationOpts {
   native?: boolean;
   "annotate-fragments"?: boolean;
   ignoredComponents?: string[];
-  autoInjectSentryLabel?: boolean;
-  textComponentNames?: string[];
+  /** @hidden */
+  autoInjectSentryLabel?: boolean | AutoInjectSentryLabelOpts;
 }
 
 interface FragmentContext {
@@ -181,8 +185,11 @@ function createJSXProcessingContext(
     attributeNames: attributeNamesFromState(state),
     ignoredComponents: state.opts.ignoredComponents ?? [],
     fragmentContext: state.sentryFragmentContext,
-    autoInjectSentryLabel: state.opts.autoInjectSentryLabel === true,
-    textComponentNames: state.opts.textComponentNames ?? DEFAULT_TEXT_COMPONENT_NAMES,
+    autoInjectSentryLabel: !!state.opts.autoInjectSentryLabel,
+    textComponentNames:
+      (typeof state.opts.autoInjectSentryLabel === "object"
+        ? state.opts.autoInjectSentryLabel.textComponentNames
+        : undefined) ?? DEFAULT_TEXT_COMPONENT_NAMES,
   };
 }
 

--- a/packages/babel-plugin-component-annotate/src/index.ts
+++ b/packages/babel-plugin-component-annotate/src/index.ts
@@ -187,7 +187,7 @@ function createJSXProcessingContext(
     fragmentContext: state.sentryFragmentContext,
     autoInjectSentryLabel: !!state.opts.autoInjectSentryLabel,
     textComponentNames:
-      (typeof state.opts.autoInjectSentryLabel === "object"
+      (state.opts.autoInjectSentryLabel && typeof state.opts.autoInjectSentryLabel === "object"
         ? state.opts.autoInjectSentryLabel.textComponentNames
         : undefined) ?? DEFAULT_TEXT_COMPONENT_NAMES,
   };
@@ -790,7 +790,6 @@ function extractTextFromTextComponent(
         if (innerTexts === null) {
           return null;
         }
-        texts.push(...innerTexts);
       }
     } else if (t.isJSXFragment(child)) {
       const innerTexts = extractTextFromTextComponent(t, child, textComponentNames);

--- a/packages/babel-plugin-component-annotate/test/sentry-label.test.ts
+++ b/packages/babel-plugin-component-annotate/test/sentry-label.test.ts
@@ -468,7 +468,7 @@ describe("autoInjectSentryLabel", () => {
           );
         }
       `,
-        { textComponentNames: ["Label", "Text"] }
+        { autoInjectSentryLabel: { textComponentNames: ["Label", "Text"] } }
       );
       expect(result?.code).toContain('"sentry-label": "Custom text"');
     });
@@ -930,7 +930,7 @@ describe("autoInjectSentryLabel", () => {
           );
         }
       `,
-        { textComponentNames: ["Text", "MyLib.Text"] }
+        { autoInjectSentryLabel: { textComponentNames: ["Text", "MyLib.Text"] } }
       );
       expect(result?.code).toContain('"sentry-label": "Matched"');
     });

--- a/packages/babel-plugin-component-annotate/test/sentry-label.test.ts
+++ b/packages/babel-plugin-component-annotate/test/sentry-label.test.ts
@@ -571,7 +571,7 @@ describe("autoInjectSentryLabel", () => {
       expect(result?.code).toContain('"sentry-label": "Hello World more"');
     });
 
-    it("extracts text from non-text wrapper inside Text", () => {
+    it("handles Text wrapping only a non-text element", () => {
       const result = transformWith(`
         import React from 'react';
         import { Text, View } from 'react-native';
@@ -579,12 +579,12 @@ describe("autoInjectSentryLabel", () => {
         export default function MyComponent() {
           return (
             <View>
-              <Text>Hello <Bold>world</Bold></Text>
+              <Text><Bold>hello</Bold></Text>
             </View>
           );
         }
       `);
-      expect(result?.code).toContain('"sentry-label": "Hello world"');
+      expect(result?.code).not.toContain("sentry-label");
     });
   });
 

--- a/packages/babel-plugin-component-annotate/test/sentry-label.test.ts
+++ b/packages/babel-plugin-component-annotate/test/sentry-label.test.ts
@@ -1,0 +1,1008 @@
+import { describe, it, expect } from "vitest";
+import { transform, BabelFileResult } from "@babel/core";
+import plugin from "../src/index";
+
+function transformWith(code: string, opts: Record<string, unknown> = {}): BabelFileResult | null {
+  return transform(code, {
+    filename: "/filename-test.js",
+    configFile: false,
+    presets: ["@babel/preset-react"],
+    plugins: [[plugin, { autoInjectSentryLabel: true, ...opts }]],
+  });
+}
+
+function transformWithout(
+  code: string,
+  opts: Record<string, unknown> = {}
+): BabelFileResult | null {
+  return transform(code, {
+    filename: "/filename-test.js",
+    configFile: false,
+    presets: ["@babel/preset-react"],
+    plugins: [[plugin, opts]],
+  });
+}
+
+describe("autoInjectSentryLabel", () => {
+  describe("opt-in behavior", () => {
+    it("does not inject sentry-label when autoInjectSentryLabel is not set", () => {
+      const result = transformWithout(`
+        import React from 'react';
+        import { Text, View } from 'react-native';
+
+        export default function MyComponent() {
+          return (
+            <View>
+              <Text>Hello</Text>
+            </View>
+          );
+        }
+      `);
+      expect(result?.code).not.toContain("sentry-label");
+    });
+
+    it("does not inject sentry-label when autoInjectSentryLabel is false", () => {
+      const result = transformWithout(
+        `
+        import React from 'react';
+        import { Text, View } from 'react-native';
+
+        export default function MyComponent() {
+          return (
+            <View>
+              <Text>Hello</Text>
+            </View>
+          );
+        }
+      `,
+        { autoInjectSentryLabel: false }
+      );
+      expect(result?.code).not.toContain("sentry-label");
+    });
+
+    it("injects sentry-label when autoInjectSentryLabel is true", () => {
+      const result = transformWith(`
+        import React from 'react';
+        import { Text, View } from 'react-native';
+
+        export default function MyComponent() {
+          return (
+            <View>
+              <Text>Hello</Text>
+            </View>
+          );
+        }
+      `);
+      expect(result?.code).toContain('"sentry-label": "Hello"');
+    });
+  });
+
+  describe("basic static text extraction", () => {
+    it("extracts text from a Text child", () => {
+      const result = transformWith(`
+        import React from 'react';
+        import { Text, TouchableOpacity } from 'react-native';
+
+        export default function SaveButton() {
+          return (
+            <TouchableOpacity onPress={save}>
+              <Text>Save workout</Text>
+            </TouchableOpacity>
+          );
+        }
+      `);
+      expect(result?.code).toContain('"sentry-label": "Save workout"');
+    });
+
+    it("extracts text from a nested Text within a View", () => {
+      const result = transformWith(`
+        import React from 'react';
+        import { Text, View, TouchableOpacity } from 'react-native';
+
+        export default function Card() {
+          return (
+            <TouchableOpacity>
+              <View>
+                <Text>Details</Text>
+              </View>
+            </TouchableOpacity>
+          );
+        }
+      `);
+      expect(result?.code).toContain('"sentry-label": "Details"');
+    });
+
+    it("works with arrow function components", () => {
+      const result = transformWith(`
+        import React from 'react';
+        import { Text, View } from 'react-native';
+
+        const MyButton = () => (
+          <View>
+            <Text>Press me</Text>
+          </View>
+        );
+      `);
+      expect(result?.code).toContain('"sentry-label": "Press me"');
+    });
+
+    it("works with class components", () => {
+      const result = transformWith(`
+        import React, { Component } from 'react';
+        import { Text, View } from 'react-native';
+
+        class MyButton extends Component {
+          render() {
+            return (
+              <View>
+                <Text>Click here</Text>
+              </View>
+            );
+          }
+        }
+      `);
+      expect(result?.code).toContain('"sentry-label": "Click here"');
+    });
+  });
+
+  describe("multiple text children", () => {
+    it("joins text from multiple Text children with space", () => {
+      const result = transformWith(`
+        import React from 'react';
+        import { Text, View } from 'react-native';
+
+        export default function AddToCart() {
+          return (
+            <View>
+              <Text>Add</Text>
+              <Text>to cart</Text>
+            </View>
+          );
+        }
+      `);
+      expect(result?.code).toContain('"sentry-label": "Add to cart"');
+    });
+
+    it("joins text from multiple nested Text children", () => {
+      const result = transformWith(`
+        import React from 'react';
+        import { Text, View, TouchableOpacity } from 'react-native';
+
+        export default function Header() {
+          return (
+            <TouchableOpacity>
+              <View>
+                <Text>Welcome</Text>
+                <Text>back</Text>
+              </View>
+            </TouchableOpacity>
+          );
+        }
+      `);
+      expect(result?.code).toContain('"sentry-label": "Welcome back"');
+    });
+  });
+
+  describe("skip conditions", () => {
+    it("skips when sentry-label already exists", () => {
+      const result = transformWith(`
+        import React from 'react';
+        import { Text, View } from 'react-native';
+
+        export default function MyComponent() {
+          return (
+            <View sentry-label="Custom label">
+              <Text>Auto text</Text>
+            </View>
+          );
+        }
+      `);
+      expect(result?.code).toContain('"sentry-label": "Custom label"');
+      expect(result?.code).not.toContain('"sentry-label": "Auto text"');
+    });
+
+    it("skips dynamic expression children", () => {
+      const result = transformWith(`
+        import React from 'react';
+        import { Text, View } from 'react-native';
+
+        export default function MyComponent() {
+          return (
+            <View>
+              <Text>{variable}</Text>
+            </View>
+          );
+        }
+      `);
+      expect(result?.code).not.toContain("sentry-label");
+    });
+
+    it("skips when Text child has a function call expression", () => {
+      const result = transformWith(`
+        import React from 'react';
+        import { Text, View } from 'react-native';
+
+        export default function MyComponent() {
+          return (
+            <View>
+              <Text>{t('key')}</Text>
+            </View>
+          );
+        }
+      `);
+      expect(result?.code).not.toContain("sentry-label");
+    });
+
+    it("skips when Text child has a template literal", () => {
+      const result = transformWith(`
+        import React from 'react';
+        import { Text, View } from 'react-native';
+
+        export default function MyComponent() {
+          return (
+            <View>
+              <Text>{\`hello \${name}\`}</Text>
+            </View>
+          );
+        }
+      `);
+      expect(result?.code).not.toContain("sentry-label");
+    });
+
+    it("skips when text is empty or whitespace only", () => {
+      const result = transformWith(`
+        import React from 'react';
+        import { Text, View } from 'react-native';
+
+        export default function MyComponent() {
+          return (
+            <View>
+              <Text>   </Text>
+            </View>
+          );
+        }
+      `);
+      expect(result?.code).not.toContain("sentry-label");
+    });
+
+    it("skips when no Text children exist", () => {
+      const result = transformWith(`
+        import React from 'react';
+        import { View, Image } from 'react-native';
+
+        export default function MyComponent() {
+          return (
+            <View>
+              <Image source={pic} />
+            </View>
+          );
+        }
+      `);
+      expect(result?.code).not.toContain("sentry-label");
+    });
+
+    it("skips when expression container is at root level", () => {
+      const result = transformWith(`
+        import React from 'react';
+        import { View } from 'react-native';
+
+        export default function MyComponent() {
+          return (
+            <View>
+              {someContent}
+            </View>
+          );
+        }
+      `);
+      expect(result?.code).not.toContain("sentry-label");
+    });
+  });
+
+  describe("truncation", () => {
+    it("truncates text longer than 64 characters with ...", () => {
+      const result = transformWith(`
+        import React from 'react';
+        import { Text, View } from 'react-native';
+
+        export default function MyComponent() {
+          return (
+            <View>
+              <Text>This is an extremely long text that definitely exceeds the sixty-four character limit</Text>
+            </View>
+          );
+        }
+      `);
+      const match = result?.code?.match(/"sentry-label": "([^"]+)"/);
+      expect(match).toBeTruthy();
+      const label = match?.[1] ?? "";
+      expect(label.length).toBe(64);
+      expect(label.endsWith("...")).toBe(true);
+      expect(label).toBe("This is an extremely long text that definitely exceeds the si...");
+    });
+
+    it("does not truncate text at exactly 64 characters", () => {
+      // 64 chars exactly
+      const text64 = "A".repeat(64);
+      const result = transformWith(`
+        import React from 'react';
+        import { Text, View } from 'react-native';
+
+        export default function MyComponent() {
+          return (
+            <View>
+              <Text>${text64}</Text>
+            </View>
+          );
+        }
+      `);
+      expect(result?.code).toContain(`"sentry-label": "${text64}"`);
+    });
+  });
+
+  describe("depth limit", () => {
+    it("extracts text at depth 1 (direct child)", () => {
+      const result = transformWith(`
+        import React from 'react';
+        import { Text, View } from 'react-native';
+
+        export default function MyComponent() {
+          return (
+            <View>
+              <Text>Direct child</Text>
+            </View>
+          );
+        }
+      `);
+      expect(result?.code).toContain('"sentry-label": "Direct child"');
+    });
+
+    it("extracts text at depth 2 (nested in one wrapper)", () => {
+      const result = transformWith(`
+        import React from 'react';
+        import { Text, View } from 'react-native';
+
+        export default function MyComponent() {
+          return (
+            <View>
+              <View>
+                <Text>Nested once</Text>
+              </View>
+            </View>
+          );
+        }
+      `);
+      expect(result?.code).toContain('"sentry-label": "Nested once"');
+    });
+
+    it("extracts text at depth 3 (nested in two wrappers)", () => {
+      const result = transformWith(`
+        import React from 'react';
+        import { Text, View } from 'react-native';
+
+        export default function MyComponent() {
+          return (
+            <View>
+              <View>
+                <View>
+                  <Text>Nested twice</Text>
+                </View>
+              </View>
+            </View>
+          );
+        }
+      `);
+      expect(result?.code).toContain('"sentry-label": "Nested twice"');
+    });
+
+    it("does not extract text beyond depth limit", () => {
+      const result = transformWith(`
+        import React from 'react';
+        import { Text, View } from 'react-native';
+
+        export default function MyComponent() {
+          return (
+            <View>
+              <View>
+                <View>
+                  <View>
+                    <Text>Too deep</Text>
+                  </View>
+                </View>
+              </View>
+            </View>
+          );
+        }
+      `);
+      expect(result?.code).not.toContain("sentry-label");
+    });
+
+    it("does not count fragments toward depth limit", () => {
+      const result = transformWith(`
+        import React from 'react';
+        import { Text, View } from 'react-native';
+
+        export default function MyComponent() {
+          return (
+            <View>
+              <View>
+                <View>
+                  <>
+                    <Text>Still found</Text>
+                  </>
+                </View>
+              </View>
+            </View>
+          );
+        }
+      `);
+      expect(result?.code).toContain('"sentry-label": "Still found"');
+    });
+  });
+
+  describe("text component names", () => {
+    it("recognizes lowercase text component", () => {
+      const result = transformWith(`
+        import React from 'react';
+
+        export default function MyComponent() {
+          return (
+            <view>
+              <text>Hello</text>
+            </view>
+          );
+        }
+      `);
+      expect(result?.code).toContain('"sentry-label": "Hello"');
+    });
+
+    it("supports custom text component names via option", () => {
+      const result = transformWith(
+        `
+        import React from 'react';
+
+        export default function MyComponent() {
+          return (
+            <View>
+              <Label>Custom text</Label>
+            </View>
+          );
+        }
+      `,
+        { textComponentNames: ["Label", "Text"] }
+      );
+      expect(result?.code).toContain('"sentry-label": "Custom text"');
+    });
+
+    it("does not extract from non-text components by default", () => {
+      const result = transformWith(`
+        import React from 'react';
+        import { View, Button } from 'react-native';
+
+        export default function MyComponent() {
+          return (
+            <View>
+              <Button>Not extracted</Button>
+            </View>
+          );
+        }
+      `);
+      expect(result?.code).not.toContain("sentry-label");
+    });
+  });
+
+  describe("nested text components (RN inline styling)", () => {
+    it("extracts text from nested Text inside Text", () => {
+      const result = transformWith(`
+        import React from 'react';
+        import { Text, View } from 'react-native';
+
+        export default function MyComponent() {
+          return (
+            <View>
+              <Text>Hello <Text style={bold}>world</Text></Text>
+            </View>
+          );
+        }
+      `);
+      expect(result?.code).toContain('"sentry-label": "Hello world"');
+    });
+
+    it("extracts text from deeply nested inline Text", () => {
+      const result = transformWith(`
+        import React from 'react';
+        import { Text, View } from 'react-native';
+
+        export default function MyComponent() {
+          return (
+            <View>
+              <Text>Press <Text style={bold}>Save <Text style={italic}>now</Text></Text> to continue</Text>
+            </View>
+          );
+        }
+      `);
+      expect(result?.code).toContain('"sentry-label": "Press Save now to continue"');
+    });
+
+    it("bails out when nested Text contains dynamic content", () => {
+      const result = transformWith(`
+        import React from 'react';
+        import { Text, View } from 'react-native';
+
+        export default function MyComponent() {
+          return (
+            <View>
+              <Text>Hello <Text>{name}</Text></Text>
+            </View>
+          );
+        }
+      `);
+      expect(result?.code).not.toContain("sentry-label");
+    });
+
+    it("skips non-text elements inside Text without bailing out", () => {
+      const result = transformWith(`
+        import React from 'react';
+        import { Text, View } from 'react-native';
+
+        export default function MyComponent() {
+          return (
+            <View>
+              <Text>Hello <Icon name="star" /> world</Text>
+            </View>
+          );
+        }
+      `);
+      expect(result?.code).toContain('"sentry-label": "Hello world"');
+    });
+
+    it("extracts text from fragment children inside Text", () => {
+      const result = transformWith(`
+        import React from 'react';
+        import { Text, View } from 'react-native';
+
+        export default function MyComponent() {
+          return (
+            <View>
+              <Text>Hello <>World</> more</Text>
+            </View>
+          );
+        }
+      `);
+      expect(result?.code).toContain('"sentry-label": "Hello World more"');
+    });
+
+    it("handles Text wrapping only a non-text element", () => {
+      const result = transformWith(`
+        import React from 'react';
+        import { Text, View } from 'react-native';
+
+        export default function MyComponent() {
+          return (
+            <View>
+              <Text><Bold>hello</Bold></Text>
+            </View>
+          );
+        }
+      `);
+      expect(result?.code).not.toContain("sentry-label");
+    });
+  });
+
+  describe("web compatibility", () => {
+    it("uses hyphenated sentry-label attribute", () => {
+      const result = transformWith(`
+        import React from 'react';
+        import { Text, View } from 'react-native';
+
+        export default function MyComponent() {
+          return (
+            <View>
+              <Text>Hello</Text>
+            </View>
+          );
+        }
+      `);
+      expect(result?.code).toContain('"sentry-label"');
+      expect(result?.code).not.toContain("sentryLabel");
+    });
+
+    it("uses sentry-label in native mode too", () => {
+      const result = transformWith(
+        `
+        import React from 'react';
+        import { Text, View } from 'react-native';
+
+        export default function MyComponent() {
+          return (
+            <View>
+              <Text>Hello</Text>
+            </View>
+          );
+        }
+      `,
+        { native: true }
+      );
+      expect(result?.code).toContain('"sentry-label": "Hello"');
+    });
+  });
+
+  describe("fragment handling", () => {
+    it("injects on first element child when root is a fragment", () => {
+      const result = transformWith(`
+        import React from 'react';
+        import { Text, TouchableOpacity } from 'react-native';
+
+        export default function MyComponent() {
+          return (
+            <>
+              <TouchableOpacity>
+                <Text>Hello</Text>
+              </TouchableOpacity>
+            </>
+          );
+        }
+      `);
+      expect(result?.code).toContain('"sentry-label": "Hello"');
+    });
+
+    it("extracts text only from the target element, not sibling fragment children", () => {
+      const result = transformWith(`
+        import React from 'react';
+        import { Text, View } from 'react-native';
+
+        export default function MyComponent() {
+          return (
+            <>
+              <View><Text>A</Text></View>
+              <View><Text>B</Text></View>
+            </>
+          );
+        }
+      `);
+      expect(result?.code).toContain('"sentry-label": "A"');
+      expect(result?.code).not.toContain('"sentry-label": "A B"');
+    });
+
+    it("skips root fragment when it has no element children", () => {
+      const result = transformWith(`
+        import React from 'react';
+
+        export default function MyComponent() {
+          return (
+            <>
+              Just text
+            </>
+          );
+        }
+      `);
+      expect(result?.code).not.toContain("sentry-label");
+    });
+
+    it("skips root fragment when first child already has sentry-label", () => {
+      const result = transformWith(`
+        import React from 'react';
+        import { Text, View } from 'react-native';
+
+        export default function MyComponent() {
+          return (
+            <>
+              <View sentry-label="Manual">
+                <Text>Auto text</Text>
+              </View>
+            </>
+          );
+        }
+      `);
+      expect(result?.code).toContain('"sentry-label": "Manual"');
+      expect(result?.code).not.toContain('"sentry-label": "Auto text"');
+    });
+
+    it("traverses through fragment children to find text", () => {
+      const result = transformWith(`
+        import React from 'react';
+        import { Text, View } from 'react-native';
+
+        export default function MyComponent() {
+          return (
+            <View>
+              <>
+                <Text>Fragment text</Text>
+              </>
+            </View>
+          );
+        }
+      `);
+      expect(result?.code).toContain('"sentry-label": "Fragment text"');
+    });
+  });
+
+  describe("edge cases", () => {
+    it("trims whitespace from extracted text", () => {
+      const result = transformWith(`
+        import React from 'react';
+        import { Text, View } from 'react-native';
+
+        export default function MyComponent() {
+          return (
+            <View>
+              <Text>  Hello world  </Text>
+            </View>
+          );
+        }
+      `);
+      expect(result?.code).toContain('"sentry-label": "Hello world"');
+    });
+
+    it("normalizes double spaces when joining text from multiple components", () => {
+      const result = transformWith(`
+        import React from 'react';
+        import { Text, View } from 'react-native';
+
+        export default function MyComponent() {
+          return (
+            <View>
+              <Text>Hello </Text>
+              <Text> world</Text>
+            </View>
+          );
+        }
+      `);
+      expect(result?.code).toContain('"sentry-label": "Hello world"');
+      expect(result?.code).not.toContain("Hello  world");
+    });
+
+    it("collapses internal whitespace", () => {
+      const result = transformWith(`
+        import React from 'react';
+        import { Text, View } from 'react-native';
+
+        export default function MyComponent() {
+          return (
+            <View>
+              <Text>Hello    world</Text>
+            </View>
+          );
+        }
+      `);
+      expect(result?.code).toContain('"sentry-label": "Hello world"');
+    });
+
+    it("still adds other sentry attributes alongside sentry-label", () => {
+      const result = transformWith(`
+        import React from 'react';
+        import { Text, View } from 'react-native';
+
+        export default function MyComponent() {
+          return (
+            <View>
+              <Text>Hello</Text>
+            </View>
+          );
+        }
+      `);
+      expect(result?.code).toContain("data-sentry-component");
+      expect(result?.code).toContain("data-sentry-source-file");
+      expect(result?.code).toContain('"sentry-label": "Hello"');
+    });
+
+    it("handles mixed static and dynamic children — skips all when dynamic present", () => {
+      const result = transformWith(`
+        import React from 'react';
+        import { Text, View } from 'react-native';
+
+        export default function MyComponent() {
+          return (
+            <View>
+              <Text>Static</Text>
+              {dynamicContent}
+            </View>
+          );
+        }
+      `);
+      expect(result?.code).not.toContain("sentry-label");
+    });
+
+    it("respects ignoredComponents — does not inject sentry-label", () => {
+      const result = transformWith(
+        `
+        import React from 'react';
+        import { Text, View } from 'react-native';
+
+        export default function IgnoredComp() {
+          return (
+            <View>
+              <Text>Should not label</Text>
+            </View>
+          );
+        }
+      `,
+        { ignoredComponents: ["IgnoredComp"] }
+      );
+      expect(result?.code).not.toContain("sentry-label");
+    });
+
+    it("respects ignoredComponents matching the element name", () => {
+      const result = transformWith(
+        `
+        import React from 'react';
+        import { Text } from 'react-native';
+        import { CustomCard } from './components';
+
+        export default function MyComponent() {
+          return (
+            <CustomCard>
+              <Text>Card text</Text>
+            </CustomCard>
+          );
+        }
+      `,
+        { ignoredComponents: ["CustomCard"] }
+      );
+      expect(result?.code).not.toContain("sentry-label");
+    });
+
+    it("extracts text from JSXText inside a fragment child of root", () => {
+      const result = transformWith(`
+        import React from 'react';
+
+        export default function MyComponent() {
+          return <button><>Click me</></button>;
+        }
+      `);
+      expect(result?.code).toContain('"sentry-label": "Click me"');
+    });
+
+    it("bails out when non-text element inside Text contains dynamic content", () => {
+      const result = transformWith(`
+        import React from 'react';
+        import { Text, View } from 'react-native';
+
+        export default function MyComponent() {
+          return (
+            <View>
+              <Text>Hello <Bold>{name}</Bold> world</Text>
+            </View>
+          );
+        }
+      `);
+      expect(result?.code).not.toContain("sentry-label");
+    });
+
+    it("handles direct JSXText on the root element", () => {
+      const result = transformWith(`
+        import React from 'react';
+
+        export default function MyComponent() {
+          return <button>Click me</button>;
+        }
+      `);
+      expect(result?.code).toContain('"sentry-label": "Click me"');
+    });
+
+    it("bails out entirely when dynamic content is nested inside a non-text wrapper", () => {
+      const result = transformWith(`
+        import React from 'react';
+        import { Text, View } from 'react-native';
+
+        export default function MyComponent() {
+          return (
+            <View>
+              <View>
+                <Text>{dynamic}</Text>
+              </View>
+              <Text>Static</Text>
+            </View>
+          );
+        }
+      `);
+      expect(result?.code).not.toContain("sentry-label");
+    });
+
+    it("does not match member-expression text components against simple name", () => {
+      const result = transformWith(`
+        import React from 'react';
+        import { View } from 'react-native';
+        import MyLib from 'my-lib';
+
+        export default function MyComponent() {
+          return (
+            <View>
+              <MyLib.Text>Not matched</MyLib.Text>
+            </View>
+          );
+        }
+      `);
+      expect(result?.code).not.toContain("sentry-label");
+    });
+
+    it("matches member-expression text components when configured", () => {
+      const result = transformWith(
+        `
+        import React from 'react';
+        import { View } from 'react-native';
+        import MyLib from 'my-lib';
+
+        export default function MyComponent() {
+          return (
+            <View>
+              <MyLib.Text>Matched</MyLib.Text>
+            </View>
+          );
+        }
+      `,
+        { textComponentNames: ["Text", "MyLib.Text"] }
+      );
+      expect(result?.code).toContain('"sentry-label": "Matched"');
+    });
+  });
+
+  describe("multiple components in one file", () => {
+    it("injects independent labels on each component", () => {
+      const result = transformWith(`
+        import React from 'react';
+        import { Text, View } from 'react-native';
+
+        function SaveButton() {
+          return (
+            <View>
+              <Text>Save</Text>
+            </View>
+          );
+        }
+
+        function CancelButton() {
+          return (
+            <View>
+              <Text>Cancel</Text>
+            </View>
+          );
+        }
+      `);
+      expect(result?.code).toContain('"sentry-label": "Save"');
+      expect(result?.code).toContain('"sentry-label": "Cancel"');
+    });
+
+    it("only injects on components that have text, not on others", () => {
+      const result = transformWith(`
+        import React from 'react';
+        import { Text, View, Image } from 'react-native';
+
+        function IconButton() {
+          return (
+            <View>
+              <Image source={icon} />
+            </View>
+          );
+        }
+
+        function TextButton() {
+          return (
+            <View>
+              <Text>Click</Text>
+            </View>
+          );
+        }
+      `);
+      expect(result?.code).toContain('"sentry-label": "Click"');
+      const matches = result?.code?.match(/"sentry-label"/g);
+      expect(matches?.length).toBe(1);
+    });
+  });
+
+  describe("ternary returns", () => {
+    it("injects labels on both branches of a ternary", () => {
+      const result = transformWith(`
+        import React from 'react';
+        import { Text, View } from 'react-native';
+
+        export default function MyComponent() {
+          return condition
+            ? <View><Text>Yes</Text></View>
+            : <View><Text>No</Text></View>;
+        }
+      `);
+      expect(result?.code).toContain('"sentry-label": "Yes"');
+      expect(result?.code).toContain('"sentry-label": "No"');
+    });
+  });
+});

--- a/packages/babel-plugin-component-annotate/test/sentry-label.test.ts
+++ b/packages/babel-plugin-component-annotate/test/sentry-label.test.ts
@@ -571,7 +571,7 @@ describe("autoInjectSentryLabel", () => {
       expect(result?.code).toContain('"sentry-label": "Hello World more"');
     });
 
-    it("handles Text wrapping only a non-text element", () => {
+    it("extracts text from non-text wrapper inside Text", () => {
       const result = transformWith(`
         import React from 'react';
         import { Text, View } from 'react-native';
@@ -579,12 +579,12 @@ describe("autoInjectSentryLabel", () => {
         export default function MyComponent() {
           return (
             <View>
-              <Text><Bold>hello</Bold></Text>
+              <Text>Hello <Bold>world</Bold></Text>
             </View>
           );
         }
       `);
-      expect(result?.code).not.toContain("sentry-label");
+      expect(result?.code).toContain('"sentry-label": "Hello world"');
     });
   });
 


### PR DESCRIPTION
## Summary

Adds an opt-in `autoInjectSentryLabel` option to `@sentry/babel-plugin-component-annotate` that automatically extracts static text from JSX children and injects a `sentry-label` attribute on the root element.

This enables React Native apps to get meaningful touch breadcrumb labels (e.g., "Save workout", "Add to cart") without manual annotation. The feature walks the JSX tree up to 3 levels deep, collecting text from recognized text components (default: `Text`, `text`), and bails out entirely if any dynamic content is found anywhere in the subtree.

Resolves https://github.com/getsentry/sentry-react-native/issues/6098

### Key design decisions

- **Opt-in only** — `autoInjectSentryLabel` defaults to `false`, no behavior change for existing users. When disabled, the only overhead is two property reads during context creation and one boolean check per `processJSX` call — none of the new extraction/injection code is reached.
- **Conservative bail-out** — any dynamic expression (`{variable}`, `{t('key')}`, template literals) anywhere in the subtree causes the entire label to be skipped — including dynamic content nested inside non-text wrapper elements within text components (e.g., `<Text>Hello <Bold>{name}</Bold></Text>`). This is stricter than the runtime extraction in sentry-react-native#6106, which skips dynamic nodes and continues. Build-time can't evaluate dynamic content, so skipping entirely avoids partial/misleading labels.
- **Hyphenated `sentry-label`** — React strips unknown hyphenated props from DOM elements, so this is safe for web even though the feature targets React Native
- **Cross-SDK safe** — `bundler-plugin-core`'s `createComponentNameAnnotateHooks` does not pass this option through, so only React Native (which configures the Babel plugin directly via Metro) can activate it. Web SDKs are unaffected.
- **Nested `<Text>` support** — handles the standard RN inline styling pattern (`<Text>Hello <Text style={bold}>world</Text></Text>`), recursively extracting text from nested text components
- **Fragment handling** — when the root is a fragment, the first `JSXElement` child is used as the injection target. Fragments are treated as transparent wrappers and do not consume depth budget during text search.
- **Truncation** — labels exceeding 64 characters are truncated with `...`
- **`textComponentNames` option** — configurable list of component names whose children are treated as text content

### New plugin options

| Option | Type | Default | Description |
|--------|------|---------|-------------|
| `autoInjectSentryLabel` | `boolean` | `false` | Enable auto-injection of `sentry-label` |
| `textComponentNames` | `string[]` | `["Text", "text"]` | Component names whose JSXText children are considered text content |

## Test plan

- [x] 55 new tests in `sentry-label.test.ts` covering: opt-in behavior, basic extraction, multiple text children, skip conditions, truncation, depth limit, text component names, nested text (RN inline styling), fragment handling (including depth budget), dynamic content bail-out in non-text wrappers, web compatibility, edge cases, multiple components per file, ternary returns
- [x] All 175 tests pass (55 new + 120 existing unchanged)
- [x] Verified no regressions in existing `test-plugin.test.ts` (65 tests) and `experimental.test.ts` (55 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)