### PR TITLE
fix(vite): avoid version-specific plugin return type

### DIFF
--- a/packages/integration-tests-next/fixtures/vite-type-compat.test.ts
+++ b/packages/integration-tests-next/fixtures/vite-type-compat.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import * as ts from "typescript";
-import { isAbsolute, join, relative } from "node:path";
+import { isAbsolute, join, normalize, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 import { createRequire } from "node:module";
 
@@ -33,6 +33,7 @@ function assertFixtureViteVersion(fixtureDir: string, expectedMajor: string): vo
 function getDiagnosticsForFixture(fixtureName: string, expectedMajor: string): string[] {
   const fixtureDir = join(fixturesDir, fixtureName);
   const fileName = join(fixtureDir, "sentry-vite-plugin-type-compat.mts");
+  const isVirtualConfigFile = (path: string) => normalize(path) === normalize(fileName);
 
   assertFixtureViteVersion(fixtureDir, expectedMajor);
   assertFixtureViteVersion(pluginViteTypesFixtureDir, "6");
@@ -52,10 +53,10 @@ function getDiagnosticsForFixture(fixtureName: string, expectedMajor: string): s
   // eslint-disable-next-line @typescript-eslint/unbound-method
   const getSourceFile = host.getSourceFile;
 
-  host.fileExists = (path) => path === fileName || ts.sys.fileExists(path);
-  host.readFile = (path) => (path === fileName ? configSource : ts.sys.readFile(path));
+  host.fileExists = (path) => isVirtualConfigFile(path) || ts.sys.fileExists(path);
+  host.readFile = (path) => (isVirtualConfigFile(path) ? configSource : ts.sys.readFile(path));
   host.getSourceFile = (path, languageVersion, onError, shouldCreateNewSourceFile) =>
-    path === fileName
+    isVirtualConfigFile(path)
       ? ts.createSourceFile(path, configSource, languageVersion, true)
       : getSourceFile(path, languageVersion, onError, shouldCreateNewSourceFile);
   host.resolveModuleNames = (moduleNames, containingFile) =>

--- a/packages/integration-tests-next/fixtures/vite-type-compat.test.ts
+++ b/packages/integration-tests-next/fixtures/vite-type-compat.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import * as ts from "typescript";
-import { join } from "node:path";
+import { isAbsolute, join, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 import { createRequire } from "node:module";
 
@@ -20,8 +20,11 @@ export default defineConfig({
 function assertFixtureViteVersion(fixtureDir: string, expectedMajor: string): void {
   const requireFromFixture = createRequire(join(fixtureDir, "package.json"));
   const vitePackageJsonPath = requireFromFixture.resolve("vite/package.json");
+  const relativeVitePackageJsonPath = relative(fixtureDir, vitePackageJsonPath);
 
-  expect(vitePackageJsonPath).toContain(`${fixtureDir}/node_modules/`);
+  expect(isAbsolute(relativeVitePackageJsonPath)).toBe(false);
+  expect(relativeVitePackageJsonPath.startsWith("..")).toBe(false);
+  expect(relativeVitePackageJsonPath.split(/[\\/]/)[0]).toBe("node_modules");
 
   const vitePackageJson = requireFromFixture("vite/package.json") as { version: string };
   expect(vitePackageJson.version.split(".")[0]).toBe(expectedMajor);

--- a/packages/integration-tests-next/fixtures/vite-type-compat.test.ts
+++ b/packages/integration-tests-next/fixtures/vite-type-compat.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import * as ts from "typescript";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createRequire } from "node:module";
+
+const fixturesDir = fileURLToPath(new URL(".", import.meta.url));
+const pluginSourceFile = fileURLToPath(new URL("../../vite-plugin/src/index.ts", import.meta.url));
+const pluginViteTypesFixtureDir = join(fixturesDir, "vite6");
+
+const configSource = `
+import { defineConfig } from "vite";
+import { sentryVitePlugin } from "@sentry/vite-plugin";
+
+export default defineConfig({
+  plugins: [sentryVitePlugin()],
+});
+`;
+
+function assertFixtureViteVersion(fixtureDir: string, expectedMajor: string): void {
+  const requireFromFixture = createRequire(join(fixtureDir, "package.json"));
+  const vitePackageJsonPath = requireFromFixture.resolve("vite/package.json");
+
+  expect(vitePackageJsonPath).toContain(`${fixtureDir}/node_modules/`);
+
+  const vitePackageJson = requireFromFixture("vite/package.json") as { version: string };
+  expect(vitePackageJson.version.split(".")[0]).toBe(expectedMajor);
+}
+
+function getDiagnosticsForFixture(fixtureName: string, expectedMajor: string): string[] {
+  const fixtureDir = join(fixturesDir, fixtureName);
+  const fileName = join(fixtureDir, "sentry-vite-plugin-type-compat.mts");
+
+  assertFixtureViteVersion(fixtureDir, expectedMajor);
+  assertFixtureViteVersion(pluginViteTypesFixtureDir, "6");
+
+  const compilerOptions: ts.CompilerOptions = {
+    esModuleInterop: true,
+    module: ts.ModuleKind.Node16,
+    moduleResolution: ts.ModuleResolutionKind.Node16,
+    noEmit: true,
+    skipLibCheck: true,
+    strict: true,
+    target: ts.ScriptTarget.ES2020,
+    types: ["node"],
+  };
+
+  const host = ts.createCompilerHost(compilerOptions);
+  // eslint-disable-next-line @typescript-eslint/unbound-method
+  const getSourceFile = host.getSourceFile;
+
+  host.fileExists = (path) => path === fileName || ts.sys.fileExists(path);
+  host.readFile = (path) => (path === fileName ? configSource : ts.sys.readFile(path));
+  host.getSourceFile = (path, languageVersion, onError, shouldCreateNewSourceFile) =>
+    path === fileName
+      ? ts.createSourceFile(path, configSource, languageVersion, true)
+      : getSourceFile(path, languageVersion, onError, shouldCreateNewSourceFile);
+  host.resolveModuleNames = (moduleNames, containingFile) =>
+    moduleNames.map((moduleName) => {
+      if (moduleName === "@sentry/vite-plugin") {
+        return {
+          resolvedFileName: pluginSourceFile,
+          extension: ts.Extension.Ts,
+        };
+      }
+
+      const resolutionContainingFile =
+        moduleName === "vite" && containingFile === pluginSourceFile
+          ? join(pluginViteTypesFixtureDir, "sentry-vite-plugin-type-compat.mts")
+          : containingFile;
+
+      return ts.resolveModuleName(
+        moduleName,
+        resolutionContainingFile,
+        compilerOptions,
+        ts.sys,
+        undefined,
+        undefined,
+        ts.ModuleKind.ESNext
+      ).resolvedModule;
+    });
+
+  const program = ts.createProgram([fileName], compilerOptions, host);
+
+  return ts
+    .getPreEmitDiagnostics(program)
+    .map((diagnostic) => ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n"))
+    .filter((message) => !message.includes("The current file is a CommonJS module"));
+}
+
+describe("sentryVitePlugin type compatibility", () => {
+  it.each([
+    ["vite6", "6"],
+    ["vite7", "7"],
+    ["vite8", "8"],
+  ])("is compatible with %s defineConfig plugins", (fixtureName, expectedMajor) => {
+    expect(getDiagnosticsForFixture(fixtureName, expectedMajor)).toEqual([]);
+  });
+});

--- a/packages/integration-tests-next/fixtures/vite6/package.json
+++ b/packages/integration-tests-next/fixtures/vite6/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "vite6-integration-tests",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "vite": "6.4.1",
+    "@sentry/vite-plugin": "5.2.1"
+  },
+  "pnpm": {
+    "overrides": {
+      "@sentry/bundler-plugin-core": "file:../../../bundler-plugin-core/sentry-bundler-plugin-core-5.2.1.tgz",
+      "@sentry/rollup-plugin": "file:../../../rollup-plugin/sentry-rollup-plugin-5.2.1.tgz",
+      "@sentry/vite-plugin": "file:../../../vite-plugin/sentry-vite-plugin-5.2.1.tgz",
+      "@sentry/babel-plugin-component-annotate": "file:../../../babel-plugin-component-annotate/sentry-babel-plugin-component-annotate-5.2.1.tgz"
+    },
+    "patchedDependencies": {
+      "@sentry/cli": "../patches/@sentry__cli.patch"
+    }
+  }
+}

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -1,7 +1,11 @@
-import { SentryRollupPluginOptions } from "@sentry/rollup-plugin";
+import type { SentryRollupPluginOptions } from "@sentry/rollup-plugin";
 import { _rollupPluginInternal } from "@sentry/rollup-plugin";
 import { createRequire } from "node:module";
-import { Plugin } from "vite";
+
+interface SentryVitePlugin {
+  name: string;
+  enforce: "pre";
+}
 
 function getViteMajorVersion(): string | undefined {
   try {
@@ -17,11 +21,11 @@ function getViteMajorVersion(): string | undefined {
   return undefined;
 }
 
-export const sentryVitePlugin = (options?: SentryRollupPluginOptions): Plugin[] => {
+export const sentryVitePlugin = (options?: SentryRollupPluginOptions): SentryVitePlugin[] => {
   return [
     {
       enforce: "pre",
-      ...(_rollupPluginInternal(options, "vite", getViteMajorVersion()) as Plugin),
+      ..._rollupPluginInternal(options, "vite", getViteMajorVersion()),
     },
   ];
 };


### PR DESCRIPTION
Avoids exposing Vite's version-specific Plugin type from `sentryVitePlugin` by exporting a vite-version-agnostic shape of it.

Also added a Vite 6 fixture and type compatibility coverage for Vite 6, 7, and 8 so we can catch this in the future if it happens again.

Fixes #926
