### PR TITLE
test: Fix CI caching on Windows

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -148,8 +148,10 @@ jobs:
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         id: dependency-cache
         with:
-          path: "**/node_modules"
-          key: ${{ runner.os }}-${{ hashFiles('**/package.json') }}-${{ hashFiles('**/yarn.lock') }}
+          path: |
+            node_modules
+            packages/*/node_modules
+          key: ${{ runner.os }}-${{ matrix.node-version }}-${{ hashFiles('**/package.json') }}-${{ hashFiles('**/yarn.lock') }}
       - name: Install dependencies
         run: yarn --frozen-lockfile --ignore-engines
         if: steps.dependency-cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
There were intermittent integration test failures in CI on Windows. This was because the `*/fixtures/node_modules/*` directories were getting cached and pnpm on Windows uses copies rather than links. 

We don't want any of the fixtures dependencies to be cached anyway!