### PR TITLE
fix(webpack): Make `webpack` import lazy to support rspack-only projects

### DIFF
--- a/packages/bundler-plugins/src/webpack/index.ts
+++ b/packages/bundler-plugins/src/webpack/index.ts
@@ -1,10 +1,32 @@
 import type { SentryWebpackPluginOptions } from "./webpack4and5";
 import { sentryWebpackPluginFactory } from "./webpack4and5";
-import * as webpack4or5 from "webpack";
+import { createRequire } from "node:module";
 
-const BannerPlugin = webpack4or5?.BannerPlugin || webpack4or5?.default?.BannerPlugin;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type PluginClass = new (options: any) => unknown;
 
-const DefinePlugin = webpack4or5?.DefinePlugin || webpack4or5?.default?.DefinePlugin;
+type WebpackModule = {
+  BannerPlugin?: PluginClass;
+  DefinePlugin?: PluginClass;
+  default?: WebpackModule;
+};
+
+// `webpack` is an optional peer dependency. We require it lazily so the plugin doesn't
+// crash on load in bundlers that don't ship `webpack` (e.g. rspack) — those provide
+// the plugin classes via `compiler.webpack` at runtime instead.
+function loadWebpack(): WebpackModule {
+  try {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore Rollup transpiles import.meta for CJS
+    return createRequire(import.meta.url)("webpack") as WebpackModule;
+  } catch {
+    return {};
+  }
+}
+
+const webpack = loadWebpack();
+const BannerPlugin = webpack.BannerPlugin ?? webpack.default?.BannerPlugin;
+const DefinePlugin = webpack.DefinePlugin ?? webpack.default?.DefinePlugin;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const sentryWebpackPlugin: (options?: SentryWebpackPluginOptions) => any =


### PR DESCRIPTION
The `./webpack` entry has a top-level `import * as webpack from "webpack"` that compiles to an unconditional `require("webpack")`. In rspack-only projects where the `webpack` package isn't installed, this throws `Cannot find module 'webpack'` at module load (before the plugin even runs).

This PR replaces the static import with a guarded `createRequire` call that catches the error and falls back to `undefined`. This is safe because for webpack 5.1+ and rspack, `BannerPlugin`/`DefinePlugin` are already sourced from `compiler.webpack` at runtime ([see here](https://github.com/webpack/webpack/commit/65eca2e529ce1d79b79200d4bdb1ce1b81141459#diff-732395f8fcd972919381425c80194bb0def0a2af50c0940762299605a81c0006R174)). The top-level import only served as a fallback for webpack < 5.1.

The `./webpack5` entry was already unaffected since it calls `sentryWebpackPluginFactory()` with no arguments and relies entirely on `compiler.webpack`.

closes https://github.com/getsentry/sentry-javascript-bundler-plugins/issues/939