### PR TITLE
fix: hide console window when running 'git rev-parse HEAD' on Windows

### DIFF
--- a/packages/bundler-plugins/src/core/utils.ts
+++ b/packages/bundler-plugins/src/core/utils.ts
@@ -192,7 +192,7 @@ function gitRevision(): string | undefined {
   let gitRevision: string | undefined;
   try {
     gitRevision = childProcess
-      .execSync("git rev-parse HEAD", { stdio: ["ignore", "pipe", "ignore"] })
+      .execSync("git rev-parse HEAD", { stdio: ["ignore", "pipe", "ignore"], windowsHide: true })
       .toString()
       .trim();
   } catch {

--- a/packages/bundler-plugins/test/core/utils.test.ts
+++ b/packages/bundler-plugins/test/core/utils.test.ts
@@ -1,4 +1,5 @@
 import {
+  determineReleaseName,
   generateReleaseInjectorCode,
   generateModuleMetadataInjectorCode,
   getDependencies,
@@ -9,6 +10,7 @@ import {
   stringToUUID,
 } from "../../src/core/utils";
 
+import childProcess from "child_process";
 import fs from "fs";
 import { describe, it, expect, test, vi } from "vitest";
 import path from "node:path";
@@ -291,5 +293,28 @@ describe("serializeIgnoreOptions", () => {
   it("handles empty array", () => {
     const result = serializeIgnoreOptions([]);
     expect(result).toEqual([]);
+  });
+});
+
+describe("determineReleaseName", () => {
+  it("runs `git rev-parse HEAD` with windowsHide so no console window flashes on Windows", () => {
+    // Clear env so the function falls through the CI/git-provider checks to the
+    // git fallback (CI runs with GITHUB_SHA set, which would otherwise short-circuit).
+    const originalEnv = process.env;
+    process.env = {};
+    const execSyncSpy = vi
+      .spyOn(childProcess, "execSync")
+      .mockReturnValue(Buffer.from("0".repeat(40)));
+
+    try {
+      determineReleaseName();
+      expect(execSyncSpy).toHaveBeenCalledWith(
+        "git rev-parse HEAD",
+        expect.objectContaining({ windowsHide: true })
+      );
+    } finally {
+      process.env = originalEnv;
+      execSyncSpy.mockRestore();
+    }
   });
 });


### PR DESCRIPTION
`gitRevision()` in `packages/bundler-plugins/src/core/utils.ts` runs `execSync("git rev-parse HEAD", { stdio: [...] })` to auto-detect the release name. It passes no `windowsHide`, and Node's `child_process` defaults it to `false`. This is the fallback `determineReleaseName()` uses in local dev (when no CI/`SENTRY_RELEASE` env var is set). 

When the bundler config is loaded by a **console-less** parent process, Windows allocates a new console for the git child and the default-terminal handoff renders it as a **visible terminal window that flashes up and steals focus**. 

### Real-world impact
This is probably quite limited in real world impact as this command should not be run on local dev machines. However, where it does, it  fires constantly when running a Vite project inside (for example) an **Nx** workspace (`nx serve`): Nx's project-graph daemon reloads the Vite config — and thus the Sentry plugin's release detection — in a console-less plugin worker on **every file save**, so a terminal window flashes *every single time you save a file*. Surfaced via https://github.com/nrwl/nx-console/issues/2906#issuecomment-4322011244 (there's a companion fix in Vite for its own `net use` call). 

### Fix
Add `windowsHide: true` to the `execSync` options. No behavioural change to release detection; `windowsHide` does nothing on macOS/Linux.

### Tests
Added a unit test asserting `execSync` is invoked with `windowsHide: true`.