### PR TITLE
chore: normalize package repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@sentry/sentry-javascript-bundler-plugins",
   "version": "0.0.0",
   "description": "Sentry Bundler Plugins Monorepo.",
-  "repository": "git://github.com/getsentry/sentry-javascript-bundler-plugins.git",
+  "repository": "git+https://github.com/getsentry/sentry-javascript-bundler-plugins.git",
   "homepage": "https://github.com/getsentry/sentry-javascript-bundler-plugins",
   "private": true,
   "workspaces": [

--- a/packages/babel-plugin-component-annotate/package.json
+++ b/packages/babel-plugin-component-annotate/package.json
@@ -2,7 +2,7 @@
   "name": "@sentry/babel-plugin-component-annotate",
   "version": "5.3.0",
   "description": "A Babel plugin that annotates frontend components with additional data to enrich the experience in Sentry",
-  "repository": "git://github.com/getsentry/sentry-javascript-bundler-plugins.git",
+  "repository": "git+https://github.com/getsentry/sentry-javascript-bundler-plugins.git",
   "homepage": "https://github.com/getsentry/sentry-javascript-bundler-plugins/tree/main/packages/babel-plugin-component-annotate",
   "author": "Sentry",
   "license": "MIT",

--- a/packages/bundler-plugin-core/package.json
+++ b/packages/bundler-plugin-core/package.json
@@ -2,7 +2,7 @@
   "name": "@sentry/bundler-plugin-core",
   "version": "5.3.0",
   "description": "Sentry Bundler Plugin Core",
-  "repository": "git://github.com/getsentry/sentry-javascript-bundler-plugins.git",
+  "repository": "git+https://github.com/getsentry/sentry-javascript-bundler-plugins.git",
   "homepage": "https://github.com/getsentry/sentry-javascript-bundler-plugins/tree/main/packages/bundler-plugin-core",
   "author": "Sentry",
   "license": "MIT",

--- a/packages/bundler-plugins/package.json
+++ b/packages/bundler-plugins/package.json
@@ -2,7 +2,7 @@
   "name": "@sentry/bundler-plugins",
   "version": "5.3.0",
   "description": "Sentry Bundler Plugins",
-  "repository": "git://github.com/getsentry/sentry-javascript-bundler-plugins.git",
+  "repository": "git+https://github.com/getsentry/sentry-javascript-bundler-plugins.git",
   "homepage": "https://github.com/getsentry/sentry-javascript-bundler-plugins/tree/main/packages/bundler-plugins",
   "author": "Sentry",
   "license": "MIT",

--- a/packages/esbuild-plugin/package.json
+++ b/packages/esbuild-plugin/package.json
@@ -2,7 +2,7 @@
   "name": "@sentry/esbuild-plugin",
   "version": "5.3.0",
   "description": "Official Sentry esbuild plugin",
-  "repository": "git@github.com:getsentry/sentry-javascript-bundler-plugins.git",
+  "repository": "git+https://github.com/getsentry/sentry-javascript-bundler-plugins.git",
   "homepage": "https://github.com/getsentry/sentry-javascript-bundler-plugins/tree/main/packages/esbuild-plugin",
   "author": "Sentry",
   "license": "MIT",

--- a/packages/rollup-plugin/package.json
+++ b/packages/rollup-plugin/package.json
@@ -2,7 +2,7 @@
   "name": "@sentry/rollup-plugin",
   "version": "5.3.0",
   "description": "Official Sentry Rollup plugin",
-  "repository": "git://github.com/getsentry/sentry-javascript-bundler-plugins.git",
+  "repository": "git+https://github.com/getsentry/sentry-javascript-bundler-plugins.git",
   "homepage": "https://github.com/getsentry/sentry-javascript-bundler-plugins/tree/main/packages/rollup-plugin",
   "author": "Sentry",
   "license": "MIT",

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -2,7 +2,7 @@
   "name": "@sentry/vite-plugin",
   "version": "5.3.0",
   "description": "Official Sentry Vite plugin",
-  "repository": "git://github.com/getsentry/sentry-javascript-bundler-plugins.git",
+  "repository": "git+https://github.com/getsentry/sentry-javascript-bundler-plugins.git",
   "homepage": "https://github.com/getsentry/sentry-javascript-bundler-plugins/tree/main/packages/vite-plugin",
   "author": "Sentry",
   "license": "MIT",

--- a/packages/webpack-plugin/package.json
+++ b/packages/webpack-plugin/package.json
@@ -2,7 +2,7 @@
   "name": "@sentry/webpack-plugin",
   "version": "5.3.0",
   "description": "Official Sentry Webpack plugin",
-  "repository": "git://github.com/getsentry/sentry-javascript-bundler-plugins.git",
+  "repository": "git+https://github.com/getsentry/sentry-javascript-bundler-plugins.git",
   "homepage": "https://github.com/getsentry/sentry-javascript-bundler-plugins/tree/main/packages/webpack-plugin",
   "author": "Sentry",
   "license": "MIT",


### PR DESCRIPTION
## Summary

- updates package repository metadata from unauthenticated/SSH-style GitHub URLs to git+https://github.com/getsentry/sentry-javascript-bundler-plugins.git
- keeps the change limited to package manifests
- does not change runtime code, dependencies, entry points, versions, or package contents

## Validation

- node metadata assertion across all changed package manifests
- git diff --check
- npm pack --dry-run --ignore-scripts --json in:
  - packages/rollup-plugin
  - packages/vite-plugin
  - packages/webpack-plugin
  - packages/esbuild-plugin
  - packages/bundler-plugin-core
  - packages/bundler-plugins
  - packages/babel-plugin-component-annotate
